### PR TITLE
Apply the caption background color preference in the preview

### DIFF
--- a/crates/preview/preview-ui/src/preview_surface.rs
+++ b/crates/preview/preview-ui/src/preview_surface.rs
@@ -92,6 +92,7 @@ struct VideoSurfaceState {
     snap_radius_px: u32,
     caption_bottom_inset: f32,
     caption_font_size: f32,
+    caption_background_color: Color<u8>,
     caption_split_hover: Option<GlamVec2>,
     preview_padding_px: u32,
     preview_shadow_size_px: u32,
@@ -190,6 +191,7 @@ impl PreviewController {
             snap_radius_px: preference.timeline_snap_radius_px,
             caption_bottom_inset: 0.0,
             caption_font_size: preference.caption_font_size,
+            caption_background_color: preference.caption_background_color,
             caption_split_hover: None,
             preview_padding_px: preference.preview_padding_px,
             preview_shadow_size_px: preference.preview_shadow_size_px,
@@ -276,6 +278,7 @@ impl PreviewController {
         preferences_store::connect(&preferences, move |preference| {
             let mut state = preference_state.borrow_mut();
             state.caption_font_size = preference.caption_font_size;
+            state.caption_background_color = preference.caption_background_color;
             state.preview_padding_px = preference.preview_padding_px;
             state.preview_shadow_size_px = preference.preview_shadow_size_px;
             state.preview_upsample_method = preference.preview_upsample_method;
@@ -1017,6 +1020,7 @@ fn attach_render(
             .then_some(project.preview_guides.as_ref());
         let caption_bottom_inset = state.caption_bottom_inset;
         let caption_font_size = state.caption_font_size;
+        let caption_background_color = state.caption_background_color;
         let caption_split_hover = state.caption_split_hover;
         let shadow_size_px = state.preview_shadow_size_px;
         let upsample_method = state.preview_upsample_method;
@@ -1061,6 +1065,7 @@ fn attach_render(
                         position,
                         surface_rect,
                         caption_font_size,
+                        caption_background_color,
                         caption_bottom_inset,
                         focused_caption
                             .as_ref()

--- a/crates/preview/preview-ui/src/preview_surface/captions.rs
+++ b/crates/preview/preview-ui/src/preview_surface/captions.rs
@@ -113,6 +113,7 @@ pub(super) fn draw_captions(
     position: Time,
     preview_rect: Rect,
     caption_font_size: f32,
+    caption_background_color: Color<u8>,
     caption_bottom_inset: f32,
     split: Option<(&ItemAddress, Vec2, Color)>,
 ) {
@@ -120,7 +121,7 @@ pub(super) fn draw_captions(
         return;
     }
 
-    let active = active_captions(project, position);
+    let active = active_captions(project, position, caption_background_color);
     let mut bottom_stack = caption_bottom_inset;
     for item in active {
         let automatic_bottom = item.h_align == HorizontalAlign::Center
@@ -158,6 +159,7 @@ pub(super) fn split_at_position(
     position: Time,
     preview_rect: Rect,
     caption_font_size: f32,
+    caption_background_color: Color<u8>,
     caption_bottom_inset: f32,
     point: Vec2,
 ) -> Option<usize> {
@@ -166,7 +168,7 @@ pub(super) fn split_at_position(
         return None;
     }
     let mut bottom_stack = caption_bottom_inset;
-    for item in active_captions(project, position) {
+    for item in active_captions(project, position, caption_background_color) {
         let automatic_bottom = item.h_align == HorizontalAlign::Center
             && item.v_align == VerticalAlign::Bottom
             && item.position_x == 50
@@ -190,7 +192,11 @@ pub(super) fn split_at_position(
     None
 }
 
-fn active_captions(project: &Project, position: Time) -> Vec<CaptionItem> {
+fn active_captions(
+    project: &Project,
+    position: Time,
+    caption_background_color: Color<u8>,
+) -> Vec<CaptionItem> {
     let mut active = project
         .caption_tracks
         .iter()
@@ -218,7 +224,7 @@ fn active_captions(project: &Project, position: Time) -> Vec<CaptionItem> {
             if let Some(defaults) = defaults {
                 if !item.styling_enabled {
                     item.text_color = defaults.text_color;
-                    item.background_color = defaults.background_color;
+                    item.background_color = caption_background_color;
                     item.edge_color = defaults.edge_color;
                     item.edge_style = defaults.edge_style;
                     item.font = defaults.font;

--- a/crates/preview/preview-ui/src/preview_surface/dispatch.rs
+++ b/crates/preview/preview-ui/src/preview_surface/dispatch.rs
@@ -90,6 +90,7 @@ pub(super) fn caption_split_at_pointer(
         player.position,
         preview_rect,
         state.caption_font_size,
+        state.caption_background_color,
         state.caption_bottom_inset,
         point,
     )?;


### PR DESCRIPTION
## Summary

The Captions preference group stores `caption_font_size` and `caption_background_color`, but only the font size reached the preview. Captions rendered with `styling_enabled == false` (the default for new items) always fell back to the hardcoded `CaptionItem::new()` background, so changing the preference had no visible effect.

This threads the stored color through the preview surface state and the caption layout helpers (the same path `caption_font_size` already takes), so default-styled captions pick up the preference live when it changes. Items with `styling_enabled` turned on keep their per-item colors edited from the inspector.

## Testing

- Set the preference to opaque red in the settings DB, launched the editor with a project containing a default-styled caption item: the caption background renders red in the preview.
- Per-item colors (styling enabled) still render as edited in the inspector.

AI-assisted contribution: developed and verified with a coding agent; I have reviewed the changes.