### PR TITLE
Follow the system light/dark theme in the timeline

### DIFF
--- a/crates/timeline/timeline-ui/src/audio_meter.rs
+++ b/crates/timeline/timeline-ui/src/audio_meter.rs
@@ -82,7 +82,7 @@ pub(super) fn new(levels: SharedAudioLevels) -> gtk::GLArea {
         let painter = match runtime.renderer.begin_frame(
             screen_size_px,
             pixels_per_point,
-            Color::VIEW_BG_DARK,
+            crate::scheme::view_bg(),
         ) {
             Ok(painter) => painter,
             Err(error) => {

--- a/crates/timeline/timeline-ui/src/drawing.rs
+++ b/crates/timeline/timeline-ui/src/drawing.rs
@@ -105,11 +105,11 @@ pub(super) fn draw_timeline(input: TimelineInput<'_, '_>) {
         visible_track_height,
     );
 
-    painter.rect_filled(rect(0.0, 0.0, width, height), 0, Color::VIEW_BG_DARK);
+    painter.rect_filled(rect(0.0, 0.0, width, height), 0, crate::scheme::view_bg());
     painter.rect_filled(
         rect(0.0, RULER_HEIGHT, width, 1.0),
         0,
-        Color::SIDEBAR_BORDER_DARK,
+        crate::scheme::sidebar_border(),
     );
 
     let timeline_empty = project
@@ -137,7 +137,7 @@ pub(super) fn draw_timeline(input: TimelineInput<'_, '_>) {
             style: ruler::RulerStyle {
                 height: RULER_HEIGHT,
                 frame_tick_min_width: FRAME_TICK_MIN_WIDTH,
-                grid_color: Color::SIDEBAR_SHADE_DARK,
+                grid_color: crate::scheme::sidebar_shade(),
                 label_color: Color::LIGHT5,
             },
         },

--- a/crates/timeline/timeline-ui/src/drawing/folded.rs
+++ b/crates/timeline/timeline-ui/src/drawing/folded.rs
@@ -479,7 +479,7 @@ fn draw_expanded_row_background(
     painter.rect_filled(
         rect(0.0, y, timeline_x + timeline_width, TRACK_HEIGHT),
         0,
-        Color::SIDEBAR_SHADE_DARK.alpha_multiply(0.22),
+        crate::scheme::sidebar_shade().alpha_multiply(0.22),
     );
     let branch_x = timeline_x - 18.0;
     painter.line_segment(
@@ -487,13 +487,13 @@ fn draw_expanded_row_background(
             vec2(branch_x as f32, y as f32),
             vec2(branch_x as f32, (y + TRACK_HEIGHT * 0.5) as f32),
         ],
-        Stroke::new(1.0, Color::SIDEBAR_BORDER_DARK),
+        Stroke::new(1.0, crate::scheme::sidebar_border()),
     );
     painter.line_segment(
         [
             vec2(branch_x as f32, (y + TRACK_HEIGHT * 0.5) as f32),
             vec2((timeline_x - 6.0) as f32, (y + TRACK_HEIGHT * 0.5) as f32),
         ],
-        Stroke::new(1.0, Color::SIDEBAR_BORDER_DARK),
+        Stroke::new(1.0, crate::scheme::sidebar_border()),
     );
 }

--- a/crates/timeline/timeline-ui/src/drawing/item_decoration.rs
+++ b/crates/timeline/timeline-ui/src/drawing/item_decoration.rs
@@ -150,7 +150,7 @@ pub(in crate::drawing) fn draw_track_divider(
     painter.rect_filled(
         rect(x, y + TRACK_HEIGHT - 1.0, width, 1.0),
         0,
-        Color::SIDEBAR_SHADE_DARK,
+        crate::scheme::sidebar_shade(),
     );
 }
 
@@ -378,7 +378,7 @@ pub(in crate::drawing) fn draw_item_border(
     let border_color = if selected {
         selected_border_color
     } else {
-        Color::SIDEBAR_BORDER_DARK
+        crate::scheme::sidebar_border()
     };
 
     let border = f64::from(ITEM_BORDER_STROKE_WIDTH)

--- a/crates/timeline/timeline-ui/src/drawing/track_controls.rs
+++ b/crates/timeline/timeline-ui/src/drawing/track_controls.rs
@@ -13,19 +13,19 @@ pub(super) fn draw_track_label_pane(
         return;
     }
 
-    painter.rect_filled(rect(0.0, 0.0, LABEL_WIDTH, height), 0, Color::VIEW_BG_DARK);
+    painter.rect_filled(rect(0.0, 0.0, LABEL_WIDTH, height), 0, crate::scheme::view_bg());
     painter.rect_filled(
         rect(0.0, RULER_HEIGHT, LABEL_WIDTH, 1.0),
         0,
-        Color::SIDEBAR_BORDER_DARK,
+        crate::scheme::sidebar_border(),
     );
     painter.rect_filled(
         rect(LABEL_WIDTH - 1.0, 0.0, 1.0, height),
         0,
-        Color::SIDEBAR_BORDER_DARK,
+        crate::scheme::sidebar_border(),
     );
 
-    let icon_color = Color::VIEW_FG_DARK;
+    let icon_color = crate::scheme::view_fg();
     let row_clip = rect(
         0.0,
         RULER_HEIGHT,
@@ -61,7 +61,7 @@ pub(super) fn draw_track_label_pane(
         row_painter.rect_filled(
             rect(0.0, y + TRACK_HEIGHT - 1.0, LABEL_WIDTH, 1.0),
             0,
-            Color::SIDEBAR_SHADE_DARK,
+            crate::scheme::sidebar_shade(),
         );
 
         let prefix = match key.kind {
@@ -172,22 +172,22 @@ pub(super) fn draw_track_label_pane(
             height,
         ),
         0,
-        Color::VIEW_BG_DARK,
+        crate::scheme::view_bg(),
     );
     painter.rect_filled(
         rect(timeline_x() - 1.0, 0.0, 1.0, height),
         0,
-        Color::SIDEBAR_BORDER_DARK,
+        crate::scheme::sidebar_border(),
     );
     painter.rect_filled(
         rect(0.0, 0.0, LABEL_WIDTH, RULER_HEIGHT),
         0,
-        Color::VIEW_BG_DARK,
+        crate::scheme::view_bg(),
     );
     painter.rect_filled(
         rect(0.0, RULER_HEIGHT, LABEL_WIDTH, 1.0),
         0,
-        Color::SIDEBAR_BORDER_DARK,
+        crate::scheme::sidebar_border(),
     );
 }
 
@@ -199,7 +199,7 @@ fn draw_folded_track_label(painter: &TimelinePainter, y: f64, kind: TrackKind, d
     painter.rect_filled(
         rect(0.0, y, LABEL_WIDTH, TRACK_HEIGHT - 1.0),
         0,
-        Color::SIDEBAR_SHADE_DARK.alpha_multiply(0.22),
+        crate::scheme::sidebar_shade().alpha_multiply(0.22),
     );
     painter.line_segment(
         [vec2(branch_x, y as f32), vec2(branch_x, center_y)],
@@ -215,7 +215,7 @@ fn draw_folded_track_label(painter: &TimelinePainter, y: f64, kind: TrackKind, d
     painter.rect_filled(
         rect(0.0, y + TRACK_HEIGHT - 1.0, LABEL_WIDTH, 1.0),
         0,
-        Color::SIDEBAR_SHADE_DARK,
+        crate::scheme::sidebar_shade(),
     );
 }
 

--- a/crates/timeline/timeline-ui/src/drawing/tracks/audio.rs
+++ b/crates/timeline/timeline-ui/src/drawing/tracks/audio.rs
@@ -213,14 +213,14 @@ pub(super) fn draw(
             timeline_x,
             y,
             ITEM_BORDER_STROKE_WIDTH,
-            Color::SIDEBAR_BORDER_DARK,
+            crate::scheme::sidebar_border(),
         );
         draw_tiny_item_horizontal_edges(
             painter,
             &tiny_item_outline_columns,
             timeline_x,
             y,
-            Color::SIDEBAR_BORDER_DARK,
+            crate::scheme::sidebar_border(),
         );
         draw_tiny_item_edges(
             painter,

--- a/crates/timeline/timeline-ui/src/drawing/tracks/caption.rs
+++ b/crates/timeline/timeline-ui/src/drawing/tracks/caption.rs
@@ -96,14 +96,14 @@ pub(super) fn draw(input: TrackDrawInput<'_>, first_visible_row: usize, last_vis
             timeline_x,
             y,
             ITEM_BORDER_STROKE_WIDTH,
-            Color::SIDEBAR_BORDER_DARK,
+            crate::scheme::sidebar_border(),
         );
         draw_tiny_item_horizontal_edges(
             painter,
             &tiny_item_outline_columns,
             timeline_x,
             y,
-            Color::SIDEBAR_BORDER_DARK,
+            crate::scheme::sidebar_border(),
         );
         draw_tiny_item_edges(
             painter,

--- a/crates/timeline/timeline-ui/src/drawing/tracks/video.rs
+++ b/crates/timeline/timeline-ui/src/drawing/tracks/video.rs
@@ -161,14 +161,14 @@ pub(super) fn draw(
             timeline_x,
             y,
             ITEM_BORDER_STROKE_WIDTH,
-            Color::SIDEBAR_BORDER_DARK,
+            crate::scheme::sidebar_border(),
         );
         draw_tiny_item_horizontal_edges(
             painter,
             &tiny_item_outline_columns,
             timeline_x,
             y,
-            Color::SIDEBAR_BORDER_DARK,
+            crate::scheme::sidebar_border(),
         );
         draw_tiny_item_edges(
             painter,

--- a/crates/timeline/timeline-ui/src/drawing/visual_items.rs
+++ b/crates/timeline/timeline-ui/src/drawing/visual_items.rs
@@ -72,7 +72,7 @@ pub(in crate::drawing) fn draw_caption_item(
     );
     if !item.text.is_empty() {
         let font_id = FontId::proportional(10.0);
-        let color = Color::VIEW_FG_DARK;
+        let color = crate::scheme::view_fg();
         let max_width = (clip_width - ITEM_PADDING_X * 2.0 - 4.0).max(0.0) as f32;
         painter
             .with_clip_rect(rect(

--- a/crates/timeline/timeline-ui/src/lib.rs
+++ b/crates/timeline/timeline-ui/src/lib.rs
@@ -46,6 +46,7 @@ use shrimply_core::timeline_value::{TimelineBool, TimelineValue};
 use shrimply_timeline::{TrackGap, TrackKey};
 
 mod audio_meter;
+mod scheme;
 mod beat_grid;
 mod clipboard;
 mod context_menu;
@@ -364,7 +365,7 @@ pub fn new(
         let painter = match runtime.renderer.begin_frame(
             screen_size_px,
             pixels_per_point,
-            Color::VIEW_BG_DARK,
+            crate::scheme::view_bg(),
         ) {
             Ok(painter) => painter,
             Err(error) => {

--- a/crates/timeline/timeline-ui/src/scheme.rs
+++ b/crates/timeline/timeline-ui/src/scheme.rs
@@ -1,0 +1,40 @@
+//! Theme-aware palette access for the custom-drawn timeline. The drawing code
+//! otherwise hardcodes the dark palette variants.
+
+use shrimply_math_color::Color;
+
+fn dark_scheme() -> bool {
+    adw::StyleManager::default().is_dark()
+}
+
+pub(crate) fn view_bg() -> Color {
+    if dark_scheme() {
+        Color::VIEW_BG_DARK
+    } else {
+        Color::VIEW_BG_LIGHT
+    }
+}
+
+pub(crate) fn view_fg() -> Color {
+    if dark_scheme() {
+        Color::VIEW_FG_DARK
+    } else {
+        Color::VIEW_FG_LIGHT
+    }
+}
+
+pub(crate) fn sidebar_border() -> Color {
+    if dark_scheme() {
+        Color::SIDEBAR_BORDER_DARK
+    } else {
+        Color::SIDEBAR_BORDER_LIGHT
+    }
+}
+
+pub(crate) fn sidebar_shade() -> Color {
+    if dark_scheme() {
+        Color::SIDEBAR_SHADE_DARK
+    } else {
+        Color::SIDEBAR_SHADE_LIGHT
+    }
+}


### PR DESCRIPTION
## Summary

The timeline always drew the dark palette variants (`VIEW_BG_DARK`, `SIDEBAR_BORDER_DARK`, `SIDEBAR_SHADE_DARK`, `VIEW_FG_DARK`) even though `math-color` ships matching light variants. With a light system theme the GTK widgets switch to light while the timeline stays dark, splitting the window into two color schemes.

Add a small `scheme` module that resolves the palette from `StyleManager::default()` (the same pattern already used in `multiline_text_input.rs` and the Rhai editor) and use it at the hardcoded dark-variant call sites. Dark theme rendering is unchanged; with a light theme the timeline now matches the rest of the window.

## Testing

- Light system theme: the timeline background, grid lines, borders, and icons render with the light palette and match the surrounding widgets.
- Dark theme rendering takes the same code path as before (the dark constants).