### PR TITLE
Render the preview at the GLArea framebuffer scale

### DIFF
--- a/crates/preview/preview-ui/src/preview_surface.rs
+++ b/crates/preview/preview-ui/src/preview_surface.rs
@@ -962,7 +962,11 @@ fn attach_render(
             tracing::error!("Video GLArea error: {error}");
             return glib::Propagation::Stop;
         }
-        let surface = IVec2::new(area.width().max(1), area.height().max(1));
+        let surface_scale = area.scale_factor().max(1) as f32;
+        let surface = IVec2::new(
+            (area.width().max(1) as f32 * surface_scale) as i32,
+            (area.height().max(1) as f32 * surface_scale) as i32,
+        );
         let project = project.borrow();
         let player = player_state::snapshot(&player_state);
         let position = player.position;
@@ -1042,6 +1046,7 @@ fn attach_render(
             .expect("preview renderer was initialized")
             .render(
                 surface,
+                surface_scale,
                 frame.as_ref(),
                 Appearance {
                     content_rect,

--- a/crates/preview/preview-ui/src/preview_surface/renderer.rs
+++ b/crates/preview/preview-ui/src/preview_surface/renderer.rs
@@ -79,6 +79,7 @@ impl VideoRenderer {
     pub fn render(
         &mut self,
         surface: IVec2,
+        pixels_per_point: f32,
         frame: Option<&CompositedVideoFrame>,
         appearance: Appearance,
         draw_overlay: impl FnOnce(&TimelinePainter),
@@ -100,10 +101,10 @@ impl VideoRenderer {
             );
             self.gl.uniform_4_f32(
                 self.content_rect_uniform.as_ref(),
-                appearance.content_rect.left(),
-                appearance.content_rect.top(),
-                appearance.content_rect.width(),
-                appearance.content_rect.height(),
+                appearance.content_rect.left() * pixels_per_point,
+                appearance.content_rect.top() * pixels_per_point,
+                appearance.content_rect.width() * pixels_per_point,
+                appearance.content_rect.height() * pixels_per_point,
             );
             self.gl.uniform_4_f32(
                 self.background_color_uniform.as_ref(),
@@ -114,7 +115,7 @@ impl VideoRenderer {
             );
             self.gl.uniform_1_f32(
                 self.shadow_size_uniform.as_ref(),
-                appearance.shadow_size_px as f32,
+                appearance.shadow_size_px as f32 * pixels_per_point,
             );
             self.gl.active_texture(glow::TEXTURE0);
             self.gl
@@ -135,7 +136,10 @@ impl VideoRenderer {
         }
         let painter = self
             .overlay_renderer
-            .begin_overlay_frame(glam::UVec2::new(width as u32, height as u32), 1.0)?;
+            .begin_overlay_frame(
+                glam::UVec2::new(width as u32, height as u32),
+                pixels_per_point,
+            )?;
         draw_overlay(&painter);
         self.overlay_renderer.end_frame()
     }


### PR DESCRIPTION
## Summary

On scaled displays (macOS Retina, Wayland fractional scaling) the preview rendered only into the bottom-left portion of the GL framebuffer: the render path sized its viewport and overlay painter from the GLArea's logical allocation and hardcoded `1.0` pixels-per-point.

This sizes the render surface from the widget's scale factor, scales the content-rect and shadow uniforms to framebuffer pixels, and passes the scale to the overlay painter. Existing logical-coordinate drawing (captions, split hit-testing, `video_content_rect` aspect-fit) is unchanged and keeps mapping onto the video quad.

## Testing

- macOS on a 2x Retina display: the preview canvas now fills the preview area, aspect-fit and centered, and the caption overlay stays aligned with the canvas.