### PR TITLE
Add preview zoom and pan

### DIFF
--- a/crates/preview/preview-ui/src/preview_surface.rs
+++ b/crates/preview/preview-ui/src/preview_surface.rs
@@ -93,6 +93,9 @@ struct VideoSurfaceState {
     caption_bottom_inset: f32,
     caption_font_size: f32,
     caption_split_hover: Option<GlamVec2>,
+    preview_zoom: f32,
+    preview_pan: (f32, f32),
+    preview_drag_base_pan: Option<(f32, f32)>,
     preview_padding_px: u32,
     preview_shadow_size_px: u32,
     preview_upsample_method: preferences_store::PreviewUpsampleMethod,
@@ -191,6 +194,9 @@ impl PreviewController {
             caption_bottom_inset: 0.0,
             caption_font_size: preference.caption_font_size,
             caption_split_hover: None,
+            preview_zoom: 1.0,
+            preview_pan: (0.0, 0.0),
+            preview_drag_base_pan: None,
             preview_padding_px: preference.preview_padding_px,
             preview_shadow_size_px: preference.preview_shadow_size_px,
             preview_upsample_method: preference.preview_upsample_method,
@@ -292,6 +298,68 @@ impl PreviewController {
         style.connect_dark_notify(move |_| dark_area.queue_render());
         let contrast_area = area.clone();
         style.connect_high_contrast_notify(move |_| contrast_area.queue_render());
+
+        let zoom_scroll = gtk::EventControllerScroll::new(
+            gtk::EventControllerScrollFlags::VERTICAL,
+        );
+        let zoom_area = area.clone();
+        let zoom_state = state.clone();
+        zoom_scroll.connect_scroll(move |_, _, delta_y| {
+            let mut state = zoom_state.borrow_mut();
+            let previous_zoom = state.preview_zoom;
+            state.preview_zoom = (previous_zoom * (1.0 - 0.1 * delta_y as f32)).clamp(1.0, 8.0);
+            let ratio = state.preview_zoom / previous_zoom;
+            let cursor_x = zoom_area.width() as f32 * 0.5;
+            let cursor_y = zoom_area.height() as f32 * 0.5;
+            state.preview_pan = (
+                cursor_x - (cursor_x - state.preview_pan.0) * ratio,
+                cursor_y - (cursor_y - state.preview_pan.1) * ratio,
+            );
+            if state.preview_zoom <= 1.0 {
+                state.preview_pan = (0.0, 0.0);
+            }
+            drop(state);
+            zoom_area.queue_render();
+            glib::Propagation::Stop
+        });
+        area.add_controller(zoom_scroll);
+
+        let pan_drag = gtk::GestureDrag::builder()
+            .button(gdk::BUTTON_MIDDLE)
+            .build();
+        let pan_drag_base = state.clone();
+        pan_drag.connect_drag_begin(move |_, _, _| {
+            let mut state = pan_drag_base.borrow_mut();
+            state.preview_drag_base_pan = Some(state.preview_pan);
+        });
+        let pan_drag_update = state.clone();
+        let pan_drag_update_area = area.clone();
+        pan_drag.connect_drag_update(move |_, offset_x, offset_y| {
+            let mut state = pan_drag_update.borrow_mut();
+            let Some((base_x, base_y)) = state.preview_drag_base_pan else {
+                return;
+            };
+            if state.preview_zoom <= 1.0 {
+                return;
+            }
+            state.preview_pan = (base_x + offset_x as f32, base_y + offset_y as f32);
+            drop(state);
+            pan_drag_update_area.queue_render();
+        });
+        let pan_drag_end = state.clone();
+        let pan_drag_end_area = area.clone();
+        pan_drag.connect_drag_end(move |_, offset_x, offset_y| {
+            let mut state = pan_drag_end.borrow_mut();
+            if offset_x.abs() + offset_y.abs() < 3.0 {
+                state.preview_zoom = 1.0;
+                state.preview_pan = (0.0, 0.0);
+                drop(state);
+                pan_drag_end_area.queue_render();
+            } else {
+                state.preview_drag_base_pan = None;
+            }
+        });
+        area.add_controller(pan_drag);
 
         Self {
             surface: VideoSurface { area, state },
@@ -986,12 +1054,14 @@ fn attach_render(
             }
         }
         let padding_px = state.padding_px();
-        let content_rect = video_content_rect(
-            surface.x,
-            surface.y,
+        let content_rect = geometry::display_content_rect(
+            area.width().max(1),
+            area.height().max(1),
             project.canvas_size.width,
             project.canvas_size.height,
             padding_px,
+            state.preview_zoom,
+            state.preview_pan,
         );
         let viewport = PreviewViewport::new(
             GlamVec2::new(
@@ -1058,7 +1128,7 @@ fn attach_render(
                 |timeline_painter| {
                     let surface_rect = Rect::from_min_size(
                         vec2(0.0, 0.0),
-                        vec2(surface.x as f32, surface.y as f32),
+                        vec2(area.width() as f32, area.height() as f32),
                     );
                     draw_captions(
                         timeline_painter,

--- a/crates/preview/preview-ui/src/preview_surface/dispatch.rs
+++ b/crates/preview/preview-ui/src/preview_surface/dispatch.rs
@@ -80,9 +80,14 @@ pub(super) fn caption_split_at_pointer(
     let address = selection_state::focused_item_address(selection_state, &project)?;
     let player = player_state::snapshot(player_state);
     let state = state.borrow();
-    let preview_rect = Rect::from_min_size(
-        vec2(0.0, 0.0),
-        vec2(area.width().max(1) as f32, area.height().max(1) as f32),
+    let preview_rect = geometry::display_content_rect(
+        area.width().max(1),
+        area.height().max(1),
+        project.canvas_size.width,
+        project.canvas_size.height,
+        state.padding_px(),
+        state.preview_zoom,
+        state.preview_pan,
     );
     let text_byte = captions::split_at_position(
         &project,

--- a/crates/preview/preview-ui/src/preview_surface/geometry.rs
+++ b/crates/preview/preview-ui/src/preview_surface/geometry.rs
@@ -29,6 +29,37 @@ pub(super) fn video_content_rect(
     )
 }
 
+pub(super) fn display_content_rect(
+    surface_width: i32,
+    surface_height: i32,
+    canvas_width: u32,
+    canvas_height: u32,
+    padding_px: u32,
+    zoom: f32,
+    pan: (f32, f32),
+) -> Rect {
+    let fit = video_content_rect(
+        surface_width,
+        surface_height,
+        canvas_width,
+        canvas_height,
+        padding_px,
+    );
+    if zoom <= 1.0 {
+        return fit;
+    }
+    let width = fit.width() * zoom;
+    let height = fit.height() * zoom;
+    let center = vec2(
+        surface_width.max(1) as f32 * 0.5 + pan.0,
+        surface_height.max(1) as f32 * 0.5 + pan.1,
+    );
+    Rect::from_min_size(
+        vec2(center.x - width * 0.5, center.y - height * 0.5),
+        vec2(width, height),
+    )
+}
+
 pub(super) fn surface_viewport(
     area: &gtk::GLArea,
     project: &Project,
@@ -39,12 +70,14 @@ pub(super) fn surface_viewport(
             project.canvas_size.width.max(1) as f32,
             project.canvas_size.height.max(1) as f32,
         ),
-        video_content_rect(
+        display_content_rect(
             area.width().max(1),
             area.height().max(1),
             project.canvas_size.width,
             project.canvas_size.height,
             state.padding_px(),
+            state.preview_zoom,
+            state.preview_pan,
         ),
     )
 }


### PR DESCRIPTION
## Summary

Adds zoom and pan to the preview surface:

- **Scroll wheel** zooms the canvas, clamped to 1x-8x and anchored on the cursor position.
- **Middle-button drag** pans while zoomed; a middle click (drag under 3px) returns to fit.
- The zoomed content rect drives the video quad, the caption overlay, the guides viewport, and caption split hit-testing, so everything stays aligned while zoomed. The composited frame itself is unchanged, so exports are unaffected.
- Scrolling over the preview is consumed even when extension handlers decline it; at 1x the behavior matches the current fit-only view.

Stacked on #11 ("Render the preview at the GLArea framebuffer scale") — the zoom math assumes the render surface covers the full framebuffer. Once #11 merges this PR reduces to the zoom commit alone.

## Testing

- Built and ran on macOS (aarch64): default view is aspect-fit and centered at full framebuffer resolution; scrolling zooms in steps up to 8x anchored under the cursor; middle-drag pans; middle click resets to fit.