### PR TITLE
Add lld, clang, and opencv-devel to Fedora dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,13 @@ FEDORA_PACKAGES := \
 	rust \
 	cargo \
 	boost-devel \
+	clang \
+	clang-devel \
 	cmake \
 	gcc-c++ \
+	lld \
 	ninja-build \
+	opencv-devel \
 	openssl-devel \
 	pkgconf-pkg-config \
 	gobject-introspection-devel \


### PR DESCRIPTION
Adds the three packages that `make deps-fedora` currently misses. Refs #14.

- **`lld`** — set unconditionally by this repo's tracked `.cargo/config.toml` (`-C link-arg=-fuse-ld=lld`) and again by `DEV_RUSTFLAGS` (`Makefile:18`), so every link in the workspace needs it.
- **`clang`** / **`clang-devel`** — needed by `bindgen` in `cuda-bindings`, and reached independently through `opencv` → `clang` v2.1.0 → `clang-sys`. A bare `libclang` runtime is not enough; bindgen needs clang's own resource-dir headers, otherwise the failure is a confusing `'stddef.h' file not found`.
- **`opencv-devel`** — `opencv` is an unconditional workspace dependency (`Cargo.toml:137`) used by `crates/stabilization/mesh-flow-stabilization` and `crates/stabilization/affine-l1-stabilization`, so it cannot be opted out of.

Without these, a clean Fedora machine following `docs/source/development.rst` stops three separate times, each after a long build.

`rust` and `cargo` are deliberately left untouched here — that is a separate, cosmetic call and I did not want to mix it into this change.

Verified on Fedora 43 (x86_64, RTX 3060, driver 580.119.02): with these packages added, `make deps-fedora` produces a machine that builds all three binaries. The listed package set is what I actually installed and tested; a narrower one (e.g. `clang-libs` instead of `clang-devel`) may suffice but I have not verified it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
