### PR TITLE
i18n: Add Polish (pl) translations

### DIFF
--- a/crates/ui/i18n-core/locales/app.toml
+++ b/crates/ui/i18n-core/locales/app.toml
@@ -14,6 +14,7 @@ pt = "Um editor de vídeo simples"
 tr = "Basit bir video düzenleyicisi"
 it = "Un semplice video editor"
 id = "Editor video sederhana"
+pl = "Prosty edytor wideo"
 
 ["About Shrimply"]
 en = "About Shrimply"
@@ -29,6 +30,7 @@ pt = "Sobre o Shrimply"
 tr = "Shrimply Hakkında"
 it = "Riguardo Shrimply"
 id = "Tentang Shrimply"
+pl = "O Shrimply"
 
 ["Add Server"]
 en = "Add Server"
@@ -44,6 +46,7 @@ pt = "Adicionar servidor"
 tr = "Sunucu Ekle"
 it = "Aggiungi server"
 id = "Tambah Server"
+pl = "Dodaj serwer"
 
 ["Available"]
 en = "Available"
@@ -59,6 +62,7 @@ pt = "Disponível"
 tr = "Mevcut"
 it = "Disponibile"
 id = "Tersedia"
+pl = "Dostępne"
 
 ["Background Color"]
 en = "Background Color"
@@ -74,6 +78,7 @@ pt = "Cor de fundo"
 tr = "Arka Plan Rengi"
 it = "Colore dello sfondo"
 id = "Warna Latar Belakang"
+pl = "Kolor tła"
 
 ["Black"]
 en = "Black"
@@ -89,6 +94,7 @@ pt = "Preto"
 tr = "Siyah"
 it = "Nero"
 id = "Hitam"
+pl = "Czarny"
 
 ["Blender Binary"]
 en = "Blender Binary"
@@ -104,6 +110,7 @@ pt = "Executável do Blender"
 tr = "Blender Yürütülebilir Dosyası"
 it = "Binario di Blender"
 id = "File Biner Blender"
+pl = "Plik wykonywalny Blender"
 
 ["Blender"]
 en = "Blender"
@@ -119,6 +126,7 @@ pt = "Blender"
 tr = "Blender"
 it = "Blender"
 id = "Blender"
+pl = "Blender"
 
 ["Blue"]
 en = "Blue"
@@ -134,6 +142,7 @@ pt = "Azul"
 tr = "Mavi"
 it = "Blu"
 id = "Biru"
+pl = "Niebieski"
 
 ["Brown"]
 en = "Brown"
@@ -149,6 +158,7 @@ pt = "Marrom"
 tr = "Kahverengi"
 it = "Marrone"
 id = "Cokelat"
+pl = "Brązowy"
 
 ["Built with help from"]
 en = "Built with help from"
@@ -164,6 +174,7 @@ pt = "Desenvolvido com a ajuda de"
 tr = "Katkıda bulunanlar"
 it = "Creato con l’aiuto di"
 id = "Dibuat dengan bantuan dari"
+pl = "Stworzone z pomocą"
 
 ["Caption background color"]
 en = "Caption background color"
@@ -179,6 +190,7 @@ pt = "Cor de fundo da legenda"
 tr = "Altyazı arka plan rengi"
 it = "Colore sfondo sottotitoli"
 id = "Warna latar belakang subtitel"
+pl = "Kolor tła napisów"
 
 ["Captions"]
 en = "Captions"
@@ -194,6 +206,7 @@ pt = "Legendas"
 tr = "Altyazılar"
 it = "Sottotitoli"
 id = "Subtitel"
+pl = "Napisy"
 
 ["CUDA"]
 en = "CUDA"
@@ -209,6 +222,7 @@ pt = "CUDA"
 tr = "CUDA"
 it = "CUDA"
 id = "CUDA"
+pl = "CUDA"
 
 ["Checking server URL"]
 en = "Checking server URL"
@@ -224,6 +238,7 @@ pt = "Verificando URL do servidor"
 tr = "Sunucu URL'si kontrol ediliyor"
 it = "Verificando URL del server"
 id = "Memeriksa URL server"
+pl = "Sprawdzanie URL serwera"
 
 ["Checking…"]
 en = "Checking…"
@@ -239,6 +254,7 @@ pt = "Verificando…"
 tr = "Kontrol ediliyor…"
 it = "Verficando..."
 id = "Memeriksa…"
+pl = "Sprawdzanie…"
 
 ["Choose Blender Binary"]
 en = "Choose Blender Binary"
@@ -254,6 +270,7 @@ pt = "Escolher executável do Blender"
 tr = "Blender Yürütülebilir Dosyası Seçin"
 it = "Scegli il binario di Blender"
 id = "Pilih Biner Blender"
+pl = "Wybierz plik wykonywalny Blender"
 
 ["Clear Blender binary"]
 en = "Clear Blender binary"
@@ -269,6 +286,7 @@ pt = "Limpar executável do Blender"
 tr = "Blender yürütülebilir dosyasını temizle"
 it = "Rimuovi il binario di Blender"
 id = "Hapus biner Blender"
+pl = "Wyczyść plik wykonywalny Blender"
 
 ["Clear History"]
 en = "Clear History"
@@ -284,6 +302,7 @@ pt = "Limpar histórico"
 tr = "Geçmişi Temizle"
 it = "Cancella la cronologia"
 id = "Bersihkan Riwayat"
+pl = "Wyczyść historię"
 
 ["Click to type, drag horizontally to adjust"]
 en = "Click to type, drag horizontally to adjust"
@@ -299,6 +318,7 @@ pt = "Clique para digitar, arraste horizontalmente para ajustar"
 tr = "Yazmak için tıklayın, ayarlamak için yatay olarak sürükleyin"
 it = "Clicca per scrivere, trascina orizzontalmente per aggiustare"
 id = "Klik untuk mengetik, seret horizontal untuk menyesuaikan"
+pl = "Kliknij, aby pisać, przeciągnij poziomo, aby dopasować"
 
 ["Compatibility Notice"]
 en = "Compatibility Notice"
@@ -314,6 +334,7 @@ pt = "Aviso de compatibilidade"
 tr = "Uyumluluk Notu"
 it = "Nota di compatibilità"
 id = "Pemberitahuan Kompatibilitas"
+pl = "Uwaga dotycząca kompatybilności"
 
 ["Abort"]
 en = "Abort"
@@ -329,6 +350,7 @@ pt = "Abortar"
 tr = "Sonlandır"
 it = "Cancella"
 id = "Batalkan"
+pl = "Przerwij"
 
 ["Convert"]
 en = "Convert"
@@ -344,6 +366,7 @@ pt = "Converter"
 tr = "Dönüştür"
 it = "Converti"
 id = "Konversi"
+pl = "Konwertuj"
 
 ["Convert Kdenlive Project?"]
 en = "Convert Kdenlive Project?"
@@ -359,6 +382,7 @@ pt = "Converter projeto do Kdenlive?"
 tr = "Kdenlive Projesi Dönüştürülsün Mü?"
 it = "Convertire progetto Kdenlive?"
 id = "Konversi Proyek Kdenlive?"
+pl = "Przekonwertować projekt Kdenlive?"
 
 ["Fix"]
 en = "Fix"
@@ -374,6 +398,7 @@ pt = "Corrigir"
 tr = "Düzelt"
 it = "Correggi"
 id = "Perbaiki"
+pl = "Napraw"
 
 ["Project Timing Needs Repair"]
 en = "Project Timing Needs Repair"
@@ -389,6 +414,7 @@ pt = "A temporização do projeto precisa de correção"
 tr = "Proje Zamanlamasında Düzeltme Gerekiyor"
 it = "La tempistica del progetto richiede una riparazione"
 id = "Timing Proyek Perlu Diperbaiki"
+pl = "Synchronizacja projektu wymaga naprawy"
 
 ["Save Fixed Project"]
 en = "Save Fixed Project"
@@ -404,6 +430,7 @@ pt = "Salvar projeto corrigido"
 tr = "Düzeltilmiş Projeyi Kaydet"
 it = "Salva progetto corretto"
 id = "Simpan Proyek yang Diperbaiki"
+pl = "Zapisz naprawiony projekt"
 
 ["Some clips are not aligned to the project frame grid. Fixing them will snap and minimally shift clip boundaries, then save a new project without changing the original."]
 en = "Some clips are not aligned to the project frame grid. Fixing them will snap and minimally shift clip boundaries, then save a new project without changing the original."
@@ -419,6 +446,7 @@ pt = "Alguns clipes não estão alinhados à grade de quadros do projeto. A corr
 tr = "Bazı klipler proje kare ızgarasıyla hizalı değil. Düzeltme işlemi klip sınırlarını ızgaraya oturtup mümkün olduğunca az kaydıracak, ardından özgün projeyi değiştirmeden yeni bir proje kaydedecektir."
 it = "Alcune clip non sono allineate alla griglia dei fotogrammi del progetto. La correzione aggancerà e sposterà leggermente i bordi delle clip, salvando un nuovo progetto senza modificare l’originale."
 id = "Beberapa klip tidak sejajar dengan kisi bingkai proyek. Memperbaikinya akan mengunci dan sedikit menggeser batas klip, lalu menyimpan proyek baru tanpa mengubah aslinya."
+pl = "Niektóre klipy nie są wyrównane z siatką klatek projektu. Naprawienie ich skoryguje i lekko przesunie granice klipów, a następnie zapisze nowy projekt bez zmieniania oryginału."
 
 ["Compute"]
 en = "Compute"
@@ -434,6 +462,7 @@ pt = "Computação"
 tr = "Hesapla"
 it = "Calcola"
 id = "Komputasi"
+pl = "Obliczenia"
 
 ["Confirm color"]
 en = "Confirm color"
@@ -449,6 +478,7 @@ pt = "Confirmar cor"
 tr = "Rengi doğrula"
 it = "Conferma colore"
 id = "Konfirmasi warna"
+pl = "Zatwierdź kolor"
 
 ["Create Project"]
 en = "Create Project"
@@ -464,6 +494,7 @@ pt = "Criar projeto"
 tr = "Proje Oluştur"
 it = "Crea progetto"
 id = "Buat Proyek"
+pl = "Stwórz projekt"
 
 ["Cut selection"]
 en = "Cut selection"
@@ -479,6 +510,7 @@ pt = "Cortar seleção"
 tr = "Seçimi kes"
 it = "Taglia la selezione"
 id = "Potong pilihan"
+pl = "Wytnij zaznaczenie"
 
 ["Dark Blue"]
 en = "Dark Blue"
@@ -494,6 +526,7 @@ pt = "Azul-escuro"
 tr = "Koyu Mavi"
 it = "Blu scuro"
 id = "Biru Tua"
+pl = "Ciemny niebieski"
 
 ["Dark Brown"]
 en = "Dark Brown"
@@ -509,6 +542,7 @@ pt = "Marrom-escuro"
 tr = "Koyu Kahverengi"
 it = "Marrone chiaro"
 id = "Cokelat Tua"
+pl = "Ciemny brązowy"
 
 ["Dark Gray 1"]
 en = "Dark Gray 1"
@@ -524,6 +558,7 @@ pt = "Cinza-escuro 1"
 tr = "Koyu Gri 1"
 it = "Grigio scuro 1"
 id = "Abu-abu Tua 1"
+pl = "Ciemny szary 1"
 
 ["Dark Gray 2"]
 en = "Dark Gray 2"
@@ -539,6 +574,7 @@ pt = "Cinza-escuro 2"
 tr = "Koyu Gri 2"
 it = "Grigio scuro 2"
 id = "Abu-abu Tua 2"
+pl = "Ciemny szary 2"
 
 ["Dark Gray 3"]
 en = "Dark Gray 3"
@@ -554,6 +590,7 @@ pt = "Cinza-escuro 3"
 tr = "Koyu Gri 3"
 it = "Grigio scuro 3"
 id = "Abu-abu Tua 3"
+pl = "Ciemny szary 3"
 
 ["Dark Gray 4"]
 en = "Dark Gray 4"
@@ -569,6 +606,7 @@ pt = "Cinza-escuro 4"
 tr = "Koyu Gri 4"
 it = "Grigio scuro 4"
 id = "Abu-abu Tua 4"
+pl = "Ciemny szary 4"
 
 ["Dark Green"]
 en = "Dark Green"
@@ -584,6 +622,7 @@ pt = "Verde-escuro"
 tr = "Koyu Yeşil"
 it = "Verde scuro"
 id = "Hijau Tua"
+pl = "Ciemny zielony"
 
 ["Dark Orange"]
 en = "Dark Orange"
@@ -599,6 +638,7 @@ pt = "Laranja-escuro"
 tr = "Koyu Turuncu"
 it = "Arancione scuro"
 id = "Oranye Tua"
+pl = "Ciemny pomarańczowy"
 
 ["Dark Purple"]
 en = "Dark Purple"
@@ -614,6 +654,7 @@ pt = "Roxo-escuro"
 tr = "Koyu Mor"
 it = "Viola scuro"
 id = "Ungu Tua"
+pl = "Ciemny fioletowy"
 
 ["Dark Red"]
 en = "Dark Red"
@@ -629,6 +670,7 @@ pt = "Vermelho-escuro"
 tr = "Koyu Kırmızı"
 it = "Rosso scuro"
 id = "Merah Tua"
+pl = "Ciemny czerwony"
 
 ["Dark Yellow"]
 en = "Dark Yellow"
@@ -644,6 +686,7 @@ pt = "Amarelo-escuro"
 tr = "Koyu Sarı"
 it = "Giallo scuro"
 id = "Kuning Tua"
+pl = "Ciemny żółty"
 
 ["Default Text Font"]
 en = "Default Text Font"
@@ -659,6 +702,7 @@ pt = "Fonte de texto padrão"
 tr = "Varsayılan Metin Yazı Tipi"
 it = "Font predefinito del testo"
 id = "Font Teks Default"
+pl = "Domyślna czcionka tekstu"
 
 ["Default Visual Duration"]
 en = "Default Visual Duration"
@@ -674,6 +718,7 @@ pt = "Duração visual padrão"
 tr = "Varsayılan Görsel Süresi"
 it = "Durata visuale predefinita"
 id = "Durasi Visual Default"
+pl = "Domyślny czas trwania elementu wizualnego"
 
 ["Delete Server"]
 en = "Delete Server"
@@ -689,6 +734,7 @@ pt = "Excluir servidor"
 tr = "Sunucuyu Sil"
 it = "Elimina server"
 id = "Hapus Server"
+pl = "Usuń serwer"
 
 ["Delete selection"]
 en = "Delete selection"
@@ -704,6 +750,7 @@ pt = "Excluir seleção"
 tr = "Seçimi sil"
 it = "Elimina selezione"
 id = "Hapus pilihan"
+pl = "Usuń zaznaczenie"
 
 ["Device"]
 en = "Device"
@@ -719,6 +766,7 @@ pt = "Dispositivo"
 tr = "Cihaz"
 it = "Dispositivo"
 id = "Perangkat"
+pl = "Urządzenie"
 
 ["Distance in pixels for timeline, beat, and preview snapping"]
 en = "Distance in pixels for timeline, beat, and preview snapping"
@@ -734,6 +782,7 @@ pt = "Distância em pixels para encaixe na linha do tempo, batidas e pré-visual
 tr = "Zaman akışı, vuruş ve önizleme hizalaması için piksel cinsinden mesafe"
 it = "Distanza in pixel per l’aggancio a sequenza, beat e anteprima"
 id = "Jarak dalam piksel untuk snap timeline, ketukan, dan pratinjau"
+pl = "Odległość przyciągania dla osi czasu, rytmu i podglądu (w pikselach)"
 
 ["Drop shadow extent around the video frame in pixels"]
 en = "Drop shadow extent around the video frame in pixels"
@@ -749,6 +798,7 @@ pt = "Extensão da sombra projetada ao redor do quadro de vídeo em pixels"
 tr = "Piksel cinsinden video çerçevesinin etrafındaki gölge genişliği"
 it = "Estensione in pixel dell’ombra esterna attorno al fotogramma video"
 id = "Rentang drop shadow di sekitar frame video dalam piksel"
+pl = "Zasięg cienia wokół klatki wideo (w pikselach)"
 
 ["Edit Server"]
 en = "Edit Server"
@@ -764,6 +814,7 @@ pt = "Editar servidor"
 tr = "Sunucuyu Düzenle"
 it = "Modifica server"
 id = "Edit Server"
+pl = "Edytuj serwer"
 
 ["External"]
 en = "External"
@@ -779,6 +830,7 @@ pt = "Externo"
 tr = "Harici"
 it = "Esterno"
 id = "Eksternal"
+pl = "Zewnętrzne"
 
 ["Features"]
 en = "Features"
@@ -794,6 +846,7 @@ pt = "Recursos"
 tr = "Özellikler"
 it = "Funzioni"
 id = "Fitur"
+pl = "Funkcje"
 
 ["Fix typo: %{correction}"]
 en = "Fix typo: %{correction}"
@@ -809,6 +862,7 @@ pt = "Corrigir erro de digitação: %{correction}"
 tr = "Yazım hatasını düzelt: %{correction}"
 it = "Correggi refuso: %{correction}"
 id = "Perbaiki kesalahan ketik: %{correction}"
+pl = "Napraw literówkę: %{correction}"
 
 ["Font Size"]
 en = "Font Size"
@@ -824,6 +878,7 @@ pt = "Tamanho da fonte"
 tr = "Yazı Tipi Boyutu"
 it = "Grandezza font"
 id = "Ukuran Font"
+pl = "Rozmiar czcionki"
 
 ["General"]
 en = "General"
@@ -839,6 +894,7 @@ pt = "Geral"
 tr = "Genel"
 it = "Generale"
 id = "Umum"
+pl = "Ogólne"
 
 ["Green"]
 en = "Green"
@@ -854,6 +910,7 @@ pt = "Verde"
 tr = "Yeşil"
 it = "Verde"
 id = "Hijau"
+pl = "Zielony"
 
 ["Height"]
 en = "Height"
@@ -869,6 +926,7 @@ pt = "Altura"
 tr = "Yükseklik"
 it = "Altezza"
 id = "Tinggi"
+pl = "Wysokość"
 
 ["Hexadecimal color"]
 en = "Hexadecimal color"
@@ -884,6 +942,7 @@ pt = "Cor hexadecimal"
 tr = "Onaltılık renk"
 it = "Colore esadecimale"
 id = "Warna heksadesimal"
+pl = "Kolor szesnastkowy"
 
 ["History"]
 en = "History"
@@ -899,6 +958,7 @@ pt = "Histórico"
 tr = "Geçmiş"
 it = "Cronologia"
 id = "Riwayat"
+pl = "Historia"
 
 ["GPU Host Memory Budget"]
 en = "GPU Host Memory Budget"
@@ -914,6 +974,7 @@ pt = "Limite de memória do host para GPU"
 tr = "GPU Ana Bellek Bütçesi"
 it = "Limite memoria di sistema per la GPU"
 id = "Anggaran Memori Host GPU"
+pl = "Limit pamięci hosta dla GPU"
 
 ["Import Kdenlive as Shrimply Project"]
 en = "Import Kdenlive as Shrimply Project"
@@ -929,6 +990,7 @@ pt = "Importar Kdenlive como projeto do Shrimply"
 tr = "Kdenlive'ı Shrimply Projesi Olarak İçe Aktar"
 it = "Importa Kdenlive come progetto Shrimply"
 id = "Impor Kdenlive sebagai Proyek Shrimply"
+pl = "Importuj Kdenlive jako projekt Shrimply"
 
 ["Import OTIO as Shrimply Project"]
 en = "Import OTIO as Shrimply Project"
@@ -944,6 +1006,7 @@ pt = "Importar OTIO como projeto do Shrimply"
 tr = "OTIO'yu Shrimply Projesi Olarak İçe Aktar"
 it = "Importa OTIO come progetto Shrimply"
 id = "Impor OTIO sebagai Proyek Shrimply"
+pl = "Importuj OTIO jako projekt Shrimply"
 
 ["Import"]
 en = "Import"
@@ -959,6 +1022,7 @@ pt = "Importar"
 tr = "İçe Aktar"
 it = "Importa"
 id = "Impor"
+pl = "Importuj"
 
 ["Inference Servers"]
 en = "Inference Servers"
@@ -974,6 +1038,7 @@ pt = "Servidores de inferência"
 tr = "Çıkarım Sunucuları"
 it = "Server d’inferenza"
 id = "Server Inferensi"
+pl = "Serwery inferencji"
 
 ["Jobs"]
 en = "Jobs"
@@ -989,6 +1054,7 @@ pt = "Tarefas"
 tr = "İşler"
 it = "Processi"
 id = "Tugas"
+pl = "Prace"
 
 ["Keyboard Shortcuts"]
 en = "Keyboard Shortcuts"
@@ -1004,6 +1070,7 @@ pt = "Atalhos de teclado"
 tr = "Klavye Kısayolları"
 it = "Scorciatoie da tastiera"
 id = "Pintasan Papan Tombol"
+pl = "Skróty klawiszowe"
 
 ["Last edited %{date}"]
 en = "Last edited %{date}"
@@ -1019,6 +1086,7 @@ pt = "Última edição em %{date}"
 tr = "En son %{date} tarihinde düzenlendi"
 it = "Ultima modifica il %{date}"
 id = "Terakhir diedit %{date}"
+pl = "Ostatnio edytowano: %{date}"
 
 ["Last Edited"]
 en = "Last Edited"
@@ -1034,6 +1102,7 @@ pt = "Última edição"
 tr = "En Son Düzenlenen"
 it = "Ultima modifica"
 id = "Terakhir Diedit"
+pl = "Ostatnia modyfikacja"
 
 ["Last edited time unavailable"]
 en = "Last edited time unavailable"
@@ -1049,6 +1118,7 @@ pt = "Data da última edição indisponível"
 tr = "En son düzenleme zamanı mevcut değil"
 it = "Data dell’ultima modifica non disponibile"
 id = "Waktu edit terakhir tidak tersedia"
+pl = "Data ostatniej modyfikacji niedostępna"
 
 ["Learn more"]
 en = "Learn more"
@@ -1064,6 +1134,7 @@ pt = "Saiba mais"
 tr = "Daha Fazla Bilgi"
 it = "Scopri di più"
 id = "Pelajari lebih lanjut"
+pl = "Dowiedz się więcej"
 
 ["Light Blue"]
 en = "Light Blue"
@@ -1079,6 +1150,7 @@ pt = "Azul-claro"
 tr = "Açık Mavi"
 it = "Blu chiaro"
 id = "Biru Muda"
+pl = "Jasny niebieski"
 
 ["Light Brown"]
 en = "Light Brown"
@@ -1094,6 +1166,7 @@ pt = "Marrom-claro"
 tr = "Açık Kahverengi"
 it = "Marrone chiaro"
 id = "Cokelat Muda"
+pl = "Jasny brązowy"
 
 ["Light Gray 1"]
 en = "Light Gray 1"
@@ -1109,6 +1182,7 @@ pt = "Cinza-claro 1"
 tr = "Açık Gri 1"
 it = "Grigio chiaro 1"
 id = "Abu-abu Muda 1"
+pl = "Jasny szary 1"
 
 ["Light Gray 2"]
 en = "Light Gray 2"
@@ -1124,6 +1198,7 @@ pt = "Cinza-claro 2"
 tr = "Açık Gri 2"
 it = "Grigio chiaro 2"
 id = "Abu-abu Muda 2"
+pl = "Jasny szary 2"
 
 ["Light Gray 3"]
 en = "Light Gray 3"
@@ -1139,6 +1214,7 @@ pt = "Cinza-claro 3"
 tr = "Açık Gri 3"
 it = "Grigio chiaro 3"
 id = "Abu-abu Muda 3"
+pl = "Jasny szary 3"
 
 ["Light Gray 4"]
 en = "Light Gray 4"
@@ -1154,6 +1230,7 @@ pt = "Cinza-claro 4"
 tr = "Açık Gri 4"
 it = "Grigio chiaro 4"
 id = "Abu-abu Muda 4"
+pl = "Jasny szary 4"
 
 ["Light Green"]
 en = "Light Green"
@@ -1169,6 +1246,7 @@ pt = "Verde-claro"
 tr = "Açık Yeşil"
 it = "Verde chiaro"
 id = "Hijau Muda"
+pl = "Jasny zielony"
 
 ["Light Orange"]
 en = "Light Orange"
@@ -1184,6 +1262,7 @@ pt = "Laranja-claro"
 tr = "Açık Turuncu"
 it = "Arancione chiaro"
 id = "Oranye Muda"
+pl = "Jasny pomarańczowy"
 
 ["Light Purple"]
 en = "Light Purple"
@@ -1199,6 +1278,7 @@ pt = "Roxo-claro"
 tr = "Açık Mor"
 it = "Viola chiaro"
 id = "Ungu Muda"
+pl = "Jasny fioletowy"
 
 ["Light Red"]
 en = "Light Red"
@@ -1214,6 +1294,7 @@ pt = "Vermelho-claro"
 tr = "Açık Kırmızı"
 it = "Rosso chiaro"
 id = "Merah Muda"
+pl = "Jasny czerwony"
 
 ["Light Yellow"]
 en = "Light Yellow"
@@ -1229,6 +1310,7 @@ pt = "Amarelo-claro"
 tr = "Açık Sarı"
 it = "Giallo chiaro"
 id = "Kuning Muda"
+pl = "Jasny żółty"
 
 ["Loading project…"]
 en = "Loading project…"
@@ -1244,6 +1326,7 @@ pt = "Carregando projeto…"
 tr = "Proje yükleniyor…"
 it = "Caricamento del progetto..."
 id = "Memuat proyek…"
+pl = "Ładowanie projektu…"
 
 ["Lock ratio"]
 en = "Lock ratio"
@@ -1259,6 +1342,7 @@ pt = "Bloquear proporção"
 tr = "Oranı kilitle"
 it = "Blocca proporzioni"
 id = "Kunci rasio"
+pl = "Zablokuj proporcje"
 
 ["Maximum number of active video decoder sessions"]
 en = "Maximum number of active video decoder sessions"
@@ -1274,6 +1358,7 @@ pt = "Número máximo de sessões ativas do decodificador de vídeo"
 tr = "Etkin video kod çözücü oturumlarının azami sayısı"
 it = "Numero massimo di sessioni di decodifica video attive"
 id = "Jumlah maksimum sesi dekoder video aktif"
+pl = "Maksymalna liczba aktywnych sesji dekodera wideo"
 
 ["New Project"]
 en = "New Project"
@@ -1289,6 +1374,7 @@ pt = "Novo projeto"
 tr = "Yeni Proje"
 it = "Nuovo progetto"
 id = "Proyek Baru"
+pl = "Nowy projekt"
 
 ["No Matching Projects"]
 en = "No Matching Projects"
@@ -1304,6 +1390,7 @@ pt = "Nenhum projeto correspondente"
 tr = "Eşleşen Proje Yok"
 it = "Nessun progetto corrispondente"
 id = "Tidak Ada Proyek yang Cocok"
+pl = "Brak pasujących projektów"
 
 ["No Recent Projects"]
 en = "No Recent Projects"
@@ -1319,6 +1406,7 @@ pt = "Nenhum projeto recente"
 tr = "Son Kullanılan Proje Yok"
 it = "Nessun progetto recente"
 id = "Tidak Ada Proyek Terkini"
+pl = "Brak ostatnich projektów"
 
 ["Not configured"]
 en = "Not configured"
@@ -1334,6 +1422,7 @@ pt = "Não configurado"
 tr = "Yapılandırılmadı"
 it = "Non configurato"
 id = "Belum dikonfigurasi"
+pl = "Nie skonfigurowano"
 
 ["OTIO Project Settings"]
 en = "OTIO Project Settings"
@@ -1349,6 +1438,7 @@ pt = "Configurações de projeto OTIO"
 tr = "OTIO Proje Ayarları"
 it = "Configurazione del progetto OTIO"
 id = "Pengaturan Proyek OTIO"
+pl = "Ustawienia projektu OTIO"
 
 ["OTIO does not include the Kdenlive project profile."]
 en = "OTIO does not include the Kdenlive project profile."
@@ -1364,6 +1454,7 @@ pt = "O OTIO não inclui o perfil do projeto do Kdenlive."
 tr = "OTIO, Kdenlive proje profilini içermez."
 it = "OTIO non include il profilo del progetto Kdenlive"
 id = "OTIO tidak menyertakan profil proyek Kdenlive."
+pl = "OTIO nie zawiera profilu projektu Kdenlive."
 
 ["OTIO imported with limitations"]
 en = "OTIO imported with limitations"
@@ -1379,6 +1470,7 @@ pt = "OTIO importado com limitações"
 tr = "OTIO kısıtlamalarla içe aktarıldı"
 it = "OTIO importato con limitazioni"
 id = "OTIO diimpor dengan batasan"
+pl = "OTIO zimportowane z ograniczeniami"
 
 ["Open Project"]
 en = "Open Project"
@@ -1394,6 +1486,7 @@ pt = "Abrir projeto"
 tr = "Proje Aç"
 it = "Apri progetto"
 id = "Buka Proyek"
+pl = "Otwórz projekt"
 
 ["Open Project…"]
 en = "Open Project…"
@@ -1409,6 +1502,7 @@ pt = "Abrir projeto…"
 tr = "Proje Aç…"
 it = "Apri progetto..."
 id = "Buka Proyek…"
+pl = "Otwórz projekt…"
 
 ["Open the GTK color picker"]
 en = "Open the GTK color picker"
@@ -1424,6 +1518,7 @@ pt = "Abrir o seletor de cores do GTK"
 tr = "GTK renk seçiciyi aç"
 it = "Apri il selettore colore GTK"
 id = "Buka pemilih warna GTK"
+pl = "Otwórz okno wyboru koloru GTK"
 
 ["Orange"]
 en = "Orange"
@@ -1439,6 +1534,7 @@ pt = "Laranja"
 tr = "Turuncu"
 it = "Arancione"
 id = "Oranye"
+pl = "Pomarańczowy"
 
 ["Pick a color from the screen"]
 en = "Pick a color from the screen"
@@ -1454,6 +1550,7 @@ pt = "Selecionar uma cor da tela"
 tr = "Ekrandan bir renk seç"
 it = "Seleziona un colore dallo schermo"
 id = "Pilih warna dari layar"
+pl = "Wybierz kolor z ekranu"
 
 ["Play / Pause"]
 en = "Play / Pause"
@@ -1469,6 +1566,7 @@ pt = "Reproduzir / Pausar"
 tr = "Oynat / Duraklat"
 it = "Riproduci / Pausa"
 id = "Putar / Jeda"
+pl = "Odtwórz / Wstrzymaj"
 
 ["Preferences"]
 en = "Preferences"
@@ -1484,6 +1582,7 @@ pt = "Preferências"
 tr = "Tercihler"
 it = "Preferenze"
 id = "Preferensi"
+pl = "Preferencje"
 
 ["Preview"]
 en = "Preview"
@@ -1499,6 +1598,7 @@ pt = "Pré-visualização"
 tr = "Önizleme"
 it = "Anteprima"
 id = "Pratinjau"
+pl = "Podgląd"
 
 ["Project Name"]
 en = "Project Name"
@@ -1514,6 +1614,7 @@ pt = "Nome do projeto"
 tr = "Proje Adı"
 it = "Nome del progetto"
 id = "Nama Proyek"
+pl = "Nazwa projektu"
 
 ["Project Settings"]
 en = "Project Settings"
@@ -1529,6 +1630,7 @@ pt = "Configurações do projeto"
 tr = "Proje Ayarları"
 it = "Impostazioni del progetto"
 id = "Pengaturan Proyek"
+pl = "Ustawienia projektu"
 
 ["Project options"]
 en = "Project options"
@@ -1544,6 +1646,7 @@ pt = "Opções do projeto"
 tr = "Proje seçenekleri"
 it = "Opzioni del progetto"
 id = "Opsi proyek"
+pl = "Opcje projektu"
 
 ["Project saved to the new location"]
 en = "Project saved to the new location"
@@ -1559,6 +1662,7 @@ pt = "Projeto salvo no novo local"
 tr = "Proje yeni konuma kaydedildi"
 it = "Progetto salvato nella nuova destinazione"
 id = "Proyek disimpan ke lokasi baru"
+pl = "Zapisano projekt w nowym miejscu"
 
 ["Protocol"]
 en = "Protocol"
@@ -1574,6 +1678,7 @@ pt = "Protocolo"
 tr = "Protokol"
 it = "Protocollo"
 id = "Protokol"
+pl = "Protokół"
 
 ["Purple"]
 en = "Purple"
@@ -1589,6 +1694,7 @@ pt = "Roxo"
 tr = "Mor"
 it = "Viola"
 id = "Ungu"
+pl = "Fioletowy"
 
 ["Reading and converting Kdenlive timeline…"]
 en = "Reading and converting Kdenlive timeline…"
@@ -1604,6 +1710,7 @@ pt = "Lendo e convertendo linha do tempo do Kdenlive…"
 tr = "Kdenlive zaman çizelgesi okunup dönüştürülüyor…"
 it = "Leggendo e convertendo la sequenza di Kdenlive"
 id = "Membaca dan mengonversi timeline Kdenlive…"
+pl = "Odczytywanie i konwertowanie osi czasu Kdenlive…"
 
 ["Recent"]
 en = "Recent"
@@ -1619,6 +1726,7 @@ pt = "Recentes"
 tr = "Son Kullanılanlar"
 it = "Recenti"
 id = "Terkini"
+pl = "Ostatnie"
 
 ["Red"]
 en = "Red"
@@ -1634,6 +1742,7 @@ pt = "Vermelho"
 tr = "Kırmızı"
 it = "Rosso"
 id = "Merah"
+pl = "Czerwony"
 
 ["Redo"]
 en = "Redo"
@@ -1649,6 +1758,7 @@ pt = "Refazer"
 tr = "İleri Al"
 it = "Ripeti"
 id = "Ulangi"
+pl = "Ponów"
 
 ["Replace selected item properties"]
 en = "Replace selected item properties"
@@ -1664,6 +1774,7 @@ pt = "Substituir propriedades do item selecionado"
 tr = "Seçilen ögenin özelliklerini değiştir"
 it = "Sostituisci le propietà degli oggetti selezionati"
 id = "Ganti properti item yang dipilih"
+pl = "Zastąp właściwości zaznaczonego elementu"
 
 ["Reserved memory"]
 en = "Reserved memory"
@@ -1679,6 +1790,7 @@ pt = "Memória reservada"
 tr = "Ayrılmış bellek"
 it = "Memoria riservata"
 id = "Memori yang dicadangkan"
+pl = "Pamięć zarezerwowana"
 
 ["Retry"]
 en = "Retry"
@@ -1694,6 +1806,7 @@ pt = "Repetir"
 tr = "Tekrar dene"
 it = "Riprova"
 id = "Coba lagi"
+pl = "Spróbuj ponownie"
 
 ["Ripple cut"]
 en = "Ripple cut"
@@ -1709,6 +1822,7 @@ pt = "Corte com ondulação"
 tr = "Ardışık kesim"
 it = "Taglia e scorri"
 id = "Potong ripple"
+pl = "Cięcie z przesunięciem"
 
 ["Ripple trim selected clip to playhead"]
 en = "Ripple trim selected clip to playhead"
@@ -1724,6 +1838,7 @@ pt = "Aparar com ondulação o clipe selecionado até o indicador de reproduçã
 tr = "Seçilen klibi oynatma imlecine kadar ardışık kırp"
 it = "Taglia e scorri la clip selezionata fino alla testina di riproduzione"
 id = "Pangkas ripple klip yang dipilih ke playhead"
+pl = "Przytnij wybrany klip z przesunięciem do głowicy odtwarzania"
 
 ["Saturation and value"]
 en = "Saturation and value"
@@ -1739,6 +1854,7 @@ pt = "Saturação e valor"
 tr = "Doygunluk ve parlaklık"
 it = "Saturazione e valore"
 id = "Saturasi dan nilai"
+pl = "Nasycenie i wartość"
 
 ["Save As"]
 en = "Save As"
@@ -1754,6 +1870,7 @@ pt = "Salvar como"
 tr = "Farklı Kaydet"
 it = "Salva come"
 id = "Simpan Sebagai"
+pl = "Zapisz jako"
 
 ["Save As…"]
 en = "Save As…"
@@ -1769,6 +1886,7 @@ pt = "Salvar como…"
 tr = "Farklı Kaydet…"
 it = "Salva come..."
 id = "Simpan Sebagai…"
+pl = "Zapisz jako…"
 
 ["Save Project As"]
 en = "Save Project As"
@@ -1784,6 +1902,7 @@ pt = "Salvar projeto como"
 tr = "Projeyi Farklı Kaydet"
 it = "Salva il progetto come"
 id = "Simpan Proyek Sebagai"
+pl = "Zapisz projekt jako"
 
 ["Save"]
 en = "Save"
@@ -1799,6 +1918,7 @@ pt = "Salvar"
 tr = "Kaydet"
 it = "Salva"
 id = "Simpan"
+pl = "Zapisz"
 
 ["Search history"]
 en = "Search history"
@@ -1814,6 +1934,7 @@ pt = "Pesquisar histórico"
 tr = "Arama geçmişi"
 it = "Cerca cronologia"
 id = "Cari riwayat"
+pl = "Przeszukaj historię"
 
 ["Select color"]
 en = "Select color"
@@ -1829,6 +1950,7 @@ pt = "Selecionar cor"
 tr = "Renk seç"
 it = "Seleziona colore"
 id = "Pilih warna"
+pl = "Wybierz kolor"
 
 ["Selected Server"]
 en = "Selected Server"
@@ -1844,6 +1966,7 @@ pt = "Servidor selecionado"
 tr = "Seçilen Sunucu"
 it = "Server selezionato"
 id = "Server yang Dipilih"
+pl = "Zaznaczony serwer"
 
 ["Server URL"]
 en = "Server URL"
@@ -1859,6 +1982,7 @@ pt = "URL do servidor"
 tr = "Sunucu URL'si"
 it = "URL del server"
 id = "URL Server"
+pl = "URL serwera"
 
 ["Server does not support device selection"]
 en = "Server does not support device selection"
@@ -1874,6 +1998,7 @@ pt = "O servidor não suporta seleção de dispositivo"
 tr = "Sunucu cihaz seçimini desteklemiyor"
 it = "Il server non supporta la selezione del dispositivo"
 id = "Server tidak mendukung pemilihan perangkat"
+pl = "Serwer nie obsługuje wyboru urządzenia"
 
 ["Server menu"]
 en = "Server menu"
@@ -1889,6 +2014,7 @@ pt = "Menu do servidor"
 tr = "Sunucu menüsü"
 it = "Menu del server"
 id = "Menu server"
+pl = "Menu serwera"
 
 ["Shadow Size"]
 en = "Shadow Size"
@@ -1904,6 +2030,7 @@ pt = "Tamanho da sombra"
 tr = "Gölge Boyutu"
 it = "Dimensione dell’ombra"
 id = "Ukuran Bayangan"
+pl = "Rozmiar cienia"
 
 ["Show Keyboard Shortcuts"]
 en = "Show Keyboard Shortcuts"
@@ -1919,6 +2046,7 @@ pt = "Mostrar atalhos de teclado"
 tr = "Klavye Kısayollarını Göster"
 it = "Mostra le scorciatoie da tastiera"
 id = "Tampilkan Pintasan Papan Tombol"
+pl = "Pokaż skróty klawiszowe"
 
 ["Show in Files"]
 en = "Show in Files"
@@ -1934,6 +2062,7 @@ pt = "Mostrar em Arquivos"
 tr = "Dosyalar'da Göster"
 it = "Mostra nei file"
 id = "Tampilkan di Berkas"
+pl = "Pokaż w plikach"
 
 ["Shrimply projects"]
 en = "Shrimply projects"
@@ -1949,6 +2078,7 @@ pt = "Projetos do Shrimply"
 tr = "Shrimply projeleri"
 it = "Progetti Shrimply"
 id = "Proyek Shrimply"
+pl = "Projekty Shrimply"
 
 ["Shrimply supports only some Kdenlive features. Unsupported content may be changed or omitted."]
 en = "Shrimply supports only some Kdenlive features. Unsupported content may be changed or omitted."
@@ -1964,6 +2094,7 @@ pt = "O Shrimply suporta apenas alguns recursos do Kdenlive. O conteúdo não su
 tr = "Shrimply sadece bazı Kdenlive özelliklerini destekler. Desteklenmeyen içerik değiştirilebilir veya çıkarılabilir."
 it = "Shrimply supporta solo alcune funzioni di Kdenlive. Il contenuto non supportato potrebbe cambiare o essere omesso"
 id = "Shrimply hanya mendukung beberapa fitur Kdenlive. Konten yang tidak didukung dapat diubah atau dihilangkan."
+pl = "Shrimply obsługuje tylko niektóre funkcje Kdenlive. Nieobsługiwana zawartość może zostać zmieniona albo pominięta."
 
 ["Snap Attraction Radius"]
 en = "Snap Attraction Radius"
@@ -1979,6 +2110,7 @@ pt = "Raio de atração do encaixe"
 tr = "Yapışma Çekim Yarıçapı"
 it = "Raggio di attrazione del aggancio"
 id = "Radius Tarikan Snap"
+pl = "Promień przyciągania"
 
 ["Space around the video frame in pixels"]
 en = "Space around the video frame in pixels"
@@ -1994,6 +2126,7 @@ pt = "Espaço ao redor do quadro de vídeo em pixels"
 tr = "Piksel cinsinden video karesinin etrafındaki boşluk"
 it = "Spazio in pixels attorno al frame video"
 id = "Ruang di sekitar bingkai video dalam piksel"
+pl = "Przestrzeń dookoła klatki wideo (w pikselach)"
 
 ["Split all clips and select left"]
 en = "Split all clips and select left"
@@ -2009,6 +2142,7 @@ pt = "Dividir todos os clipes e selecionar à esquerda"
 tr = "Tüm klipleri böl ve sol tarafı seç"
 it = "Dividi tutte le clip e seleziona la parte sinistra"
 id = "Bagi semua klip dan pilih sebelah kiri"
+pl = "Podziel wszystkie klipy i zaznacz lewą stronę"
 
 ["Split all clips at playhead"]
 en = "Split all clips at playhead"
@@ -2024,6 +2158,7 @@ pt = "Dividir todos os clipes no indicador de reprodução"
 tr = "Oynatma imlecinde tüm klipleri böl"
 it = "Dividi tutte le clip alla testina di riproduzione"
 id = "Bagi semua klip di playhead"
+pl = "Podziel wszystkie klipy w miejscu głowicy odtwarzania"
 
 ["Maximum system RAM available for CUDA spill and reconstructible GPU resources"]
 en = "Maximum system RAM available for CUDA spill and reconstructible GPU resources"
@@ -2039,6 +2174,7 @@ pt = "RAM máxima do sistema disponível para transbordamento de CUDA e recursos
 tr = "CUDA taşması ve yeniden oluşturulabilir GPU kaynakları için kullanılabilir azami sistem RAM'i"
 it = "RAM di sistema massima disponibile per spillover CUDA e risorse GPU ricostruibili"
 id = "RAM sistem maksimum yang tersedia untuk limpahan CUDA dan sumber daya GPU yang dapat direkonstruksi"
+pl = "Maksymalna ilość pamięci RAM dostępnej na potrzeby CUDA spill i zasobów GPU możliwych do odtworzenia"
 
 ["Step playback"]
 en = "Step playback"
@@ -2054,6 +2190,7 @@ pt = "Reprodução quadro a quadro"
 tr = "Adım adım oynatma"
 it = "Riproduzione a fotogrammi"
 id = "Putar per bingkai"
+pl = "Odtwarzanie klatka po klatce"
 
 ["Stop Other Editor"]
 en = "Stop Other Editor"
@@ -2069,6 +2206,7 @@ pt = "Parar outro editor"
 tr = "Diğer Düzenleyiciyi Durdur"
 it = "Ferma l’altro editor"
 id = "Hentikan Editor Lain"
+pl = "Zatrzymaj inny edytor"
 
 ["Temporal Decoder Pool Size"]
 en = "Temporal Decoder Pool Size"
@@ -2084,6 +2222,7 @@ pt = "Tamanho do pool de decodificadores temporais"
 tr = "Zamansal Çözücü Havuz Boyutu"
 it = "Dimensione pool della decodifica temporale"
 id = "Ukuran Pool Dekoder Temporal"
+pl = "Rozmiar puli dekoderów temporalnych"
 
 ["Timeline"]
 en = "Timeline"
@@ -2099,6 +2238,7 @@ pt = "Linha do tempo"
 tr = "Zaman Çizelgesi"
 it = "Sequenza"
 id = "Timeline"
+pl = "Oś czasu"
 
 ["Toggle Inspector"]
 en = "Toggle Inspector"
@@ -2114,6 +2254,7 @@ pt = "Alternar inspetor"
 tr = "Denetleyiciyi Aç/Kapat"
 it = "Mostra/nascondi inspector"
 id = "Buka/Tutup Inspector"
+pl = "Pokaż/ukryj inspektor"
 
 ["Toggle Timeline"]
 en = "Toggle Timeline"
@@ -2129,6 +2270,7 @@ pt = "Alternar linha do tempo"
 tr = "Zaman Çizelgesini Aç/Kapat"
 it = "Mostra/nascondi sequenza"
 id = "Buka/Tutup Timeline"
+pl = "Pokaż/ukryj oś czasu"
 
 ["Toggle timeline zoom"]
 en = "Toggle timeline zoom"
@@ -2144,6 +2286,7 @@ pt = "Alternar zoom da linha do tempo"
 tr = "Zaman çizelgesi yakınlaştırmasını aç/kapat"
 it = "Mostra/nascondi lo zoom sulla sequenza"
 id = "Alihkan zoom timeline"
+pl = "Przełącz powiększenie osi czasu"
 
 ["Torch"]
 en = "Torch"
@@ -2159,6 +2302,7 @@ pt = "Torch"
 tr = "Torch"
 it = "Torch"
 id = "Torch"
+pl = "Torch"
 
 ["Unavailable"]
 en = "Unavailable"
@@ -2174,6 +2318,7 @@ pt = "Indisponível"
 tr = "Kullanılamıyor"
 it = "Non disponibile"
 id = "Tidak tersedia"
+pl = "Niedostępne"
 
 ["Undo"]
 en = "Undo"
@@ -2189,6 +2334,7 @@ pt = "Desfazer"
 tr = "Geri Al"
 it = "Annulla"
 id = "Urungkan"
+pl = "Cofnij"
 
 ["Untitled Project"]
 en = "Untitled Project"
@@ -2204,6 +2350,7 @@ pt = "Projeto sem título"
 tr = "Başlıksız Proje"
 it = "Progetto senza titolo"
 id = "Proyek Tanpa Judul"
+pl = "Projekt bez tytułu"
 
 ["Use this server"]
 en = "Use this server"
@@ -2219,6 +2366,7 @@ pt = "Usar este servidor"
 tr = "Bu sunucuyu kullan"
 it = "Usa questo server"
 id = "Gunakan server ini"
+pl = "Użyj tego serwera"
 
 ["Validating imported project…"]
 en = "Validating imported project…"
@@ -2234,6 +2382,7 @@ pt = "Validando projeto importado…"
 tr = "İçe aktarılmış proje doğrulanıyor…"
 it = "Validando progetto importato..."
 id = "Memvalidasi proyek yang diimpor…"
+pl = "Weryfikowanie importowanego projektu…"
 
 ["Version %{version}"]
 en = "Version %{version}"
@@ -2249,6 +2398,7 @@ pt = "Versão %{version}"
 tr = "Sürüm %{version}"
 it = "Versione %{version}"
 id = "Versi %{version}"
+pl = "Wersja %{version}"
 
 ["Very Dark Blue"]
 en = "Very Dark Blue"
@@ -2264,6 +2414,7 @@ pt = "Azul muito escuro"
 tr = "Çok Koyu Mavi"
 it = "Blu molto scuro"
 id = "Biru Sangat Tua"
+pl = "Bardzo ciemny niebieski"
 
 ["Very Dark Brown"]
 en = "Very Dark Brown"
@@ -2279,6 +2430,7 @@ pt = "Marrom muito escuro"
 tr = "Çok Koyu Kahverengi"
 it = "Marrone molto scuro"
 id = "Cokelat Sangat Tua"
+pl = "Bardzo ciemny brązowy"
 
 ["Very Dark Green"]
 en = "Very Dark Green"
@@ -2294,6 +2446,7 @@ pt = "Verde muito escuro"
 tr = "Çok Koyu Yeşil"
 it = "Verde molto scuro"
 id = "Hijau Sangat Tua"
+pl = "Bardzo ciemny zielony"
 
 ["Very Dark Orange"]
 en = "Very Dark Orange"
@@ -2309,6 +2462,7 @@ pt = "Laranja muito escuro"
 tr = "Çok Koyu Turuncu"
 it = "Arancione molto scuro"
 id = "Oranye Sangat Tua"
+pl = "Bardzo ciemny pomarańczowy"
 
 ["Very Dark Purple"]
 en = "Very Dark Purple"
@@ -2324,6 +2478,7 @@ pt = "Roxo muito escuro"
 tr = "Çok Koyu Mor"
 it = "Viola molto scuro"
 id = "Ungu Sangat Tua"
+pl = "Bardzo ciemny fioletowy"
 
 ["Very Dark Red"]
 en = "Very Dark Red"
@@ -2339,6 +2494,7 @@ pt = "Vermelho muito escuro"
 tr = "Çok Koyu Kırmızı"
 it = "Rosso molto scuro"
 id = "Merah Sangat Tua"
+pl = "Bardzo ciemny czerwony"
 
 ["Very Dark Yellow"]
 en = "Very Dark Yellow"
@@ -2354,6 +2510,7 @@ pt = "Amarelo muito escuro"
 tr = "Çok Koyu Sarı"
 it = "Giallo molto scuro"
 id = "Kuning Sangat Tua"
+pl = "Bardzo ciemny żółty"
 
 ["Very Light Blue"]
 en = "Very Light Blue"
@@ -2369,6 +2526,7 @@ pt = "Azul muito claro"
 tr = "Çok Açık Mavi"
 it = "Blu molto chiaro"
 id = "Biru Sangat Muda"
+pl = "Bardzo jasny niebieski"
 
 ["Very Light Brown"]
 en = "Very Light Brown"
@@ -2384,6 +2542,7 @@ pt = "Marrom muito claro"
 tr = "Çok Açık Kahverengi"
 it = "Marrone molto chiaro"
 id = "Cokelat Sangat Muda"
+pl = "Bardzo jasny brązowy"
 
 ["Very Light Green"]
 en = "Very Light Green"
@@ -2399,6 +2558,7 @@ pt = "Verde muito claro"
 tr = "Çok Açık Yeşil"
 it = "Verde molto chiaro"
 id = "Hijau Sangat Muda"
+pl = "Bardzo jasny zielony"
 
 ["Very Light Orange"]
 en = "Very Light Orange"
@@ -2414,6 +2574,7 @@ pt = "Laranja muito claro"
 tr = "Çok Açık Turuncu"
 it = "Arancione molto chiaro"
 id = "Oranye Sangat Muda"
+pl = "Bardzo jasny pomarańczowy"
 
 ["Very Light Purple"]
 en = "Very Light Purple"
@@ -2429,6 +2590,7 @@ pt = "Roxo muito claro"
 tr = "Çok Açık Mor"
 it = "Viola molto chiaro"
 id = "Ungu Sangat Muda"
+pl = "Bardzo jasny fioletowy"
 
 ["Very Light Red"]
 en = "Very Light Red"
@@ -2444,6 +2606,7 @@ pt = "Vermelho muito claro"
 tr = "Çok Açık Kırmızı"
 it = "Rosso molto chiaro"
 id = "Merah Sangat Muda"
+pl = "Bardzo jasny czerwony"
 
 ["Very Light Yellow"]
 en = "Very Light Yellow"
@@ -2459,6 +2622,7 @@ pt = "Amarelo muito claro"
 tr = "Çok Açık Sarı"
 it = "Giallo molto chiaro"
 id = "Kuning Sangat Muda"
+pl = "Bardzo jasny żółty"
 
 ["White"]
 en = "White"
@@ -2474,6 +2638,7 @@ pt = "Branco"
 tr = "Beyaz"
 it = "Bianco"
 id = "Putih"
+pl = "Biały"
 
 ["Workers"]
 en = "Workers"
@@ -2489,6 +2654,7 @@ pt = "Processos de trabalho"
 tr = "İş Parçacıkları"
 it = "Processi"
 id = "Worker"
+pl = "Procesy robocze"
 
 ["Writing Shrimply project…"]
 en = "Writing Shrimply project…"
@@ -2504,6 +2670,7 @@ pt = "Gravando projeto do Shrimply…"
 tr = "Shrimply projesi yazılıyor…"
 it = "Scrittura del progetto Shrimply in corso…"
 id = "Menulis proyek Shrimply…"
+pl = "Zapisywanie projektu Shrimply…"
 
 ["Yellow"]
 en = "Yellow"
@@ -2519,6 +2686,7 @@ pt = "Amarelo"
 tr = "Sarı"
 it = "Giallo"
 id = "Kuning"
+pl = "Żółty"
 
 ["%{project} — %{action}"]
 en = "%{project} — %{action}"
@@ -2534,6 +2702,7 @@ pt = "%{project} — %{action}"
 tr = "%{project} — %{action}"
 it = "%{project} — %{action}"
 id = "%{project} — %{action}"
+pl = "%{project} — %{action}"
 
 ["%{project} — Saving"]
 en = "%{project} — Saving"
@@ -2549,6 +2718,7 @@ pt = "%{project} — Salvando"
 tr = "%{project} — Kaydediliyor"
 it = "%{project} — Salvando"
 id = "%{project} — Menyimpan"
+pl = "%{project} — Zapisywanie"
 
 ["%{project} — Unsaved"]
 en = "%{project} — Unsaved"
@@ -2564,6 +2734,7 @@ pt = "%{project} — Não salvo"
 tr = "%{project} — Kaydedilmemiş"
 it = "%{project} — Non salvato"
 id = "%{project} — Belum Disimpan"
+pl = "%{project} — Nie zapisano"
 
 ["%{project} — Unsaved — Save failed"]
 en = "%{project} — Unsaved — Save failed"
@@ -2579,6 +2750,7 @@ pt = "%{project} — Não salvo — Falha ao salvar"
 tr = "%{project} — Kaydedilmemiş — Kayıt başarısız"
 it = "%{project} — Non salvato — Salvataggio fallito"
 id = "%{project} — Belum Disimpan — Gagal menyimpan"
+pl = "%{project} — Nie zapisano — Zapis nieudany"
 
 ["%{runtime} · Available"]
 en = "%{runtime} · Available"
@@ -2594,6 +2766,7 @@ pt = "%{runtime} · Disponível"
 tr = "%{runtime} · Mevcut"
 it = "%{runtime} · Disponibile"
 id = "%{runtime} · Tersedia"
+pl = "%{runtime} · Dostępne"
 
 ["%{queued} queued · %{active} active"]
 en = "%{queued} queued · %{active} active"
@@ -2609,6 +2782,7 @@ pt = "%{queued} na fila · %{active} ativas"
 tr = "%{queued} kuyrukta · %{active} aktif"
 it = "%{queued} accodato · %{active} attivi"
 id = "%{queued} dalam antrean · %{active} aktif"
+pl = "%{queued} w kolejce · %{active} aktywne"
 
 ["Project is in use"]
 en = "Project is in use"
@@ -2624,6 +2798,7 @@ pt = "O projeto está em uso"
 tr = "Proje kullanımda"
 it = "Il progetto è in uso"
 id = "Proyek sedang digunakan"
+pl = "Projekt jest w użyciu"
 
 ["Shrimply"]
 en = "Shrimply"
@@ -2639,6 +2814,7 @@ pt = "Shrimply"
 tr = "Shrimply"
 it = "Shrimply"
 id = "Shrimply"
+pl = "Shrimply"
 
 ["—"]
 en = "—"
@@ -2654,6 +2830,7 @@ pt = "—"
 tr = "—"
 it = "—"
 id = "—"
+pl = "—"
 
 ["Bilinear"]
 en = "Bilinear"
@@ -2669,6 +2846,7 @@ pt = "Bilinear"
 tr = "Bilineer"
 it = "Bilineare"
 id = "Bilinear"
+pl = "Dwuliniowe"
 
 ["Filter used when the preview is larger than the video"]
 en = "Filter used when the preview is larger than the video"
@@ -2684,6 +2862,7 @@ pt = "Filtro usado quando a pré-visualização é maior que o vídeo"
 tr = "Önizleme videodan daha büyük olduğunda kullanılan filtre"
 it = "Filtro utilizzato quando l’anteprima è più grande del video"
 id = "Filter yang digunakan saat pratinjau lebih besar dari video"
+pl = "Filtr używany, gdy podgląd jest większy niż wideo"
 
 ["Filter used when the preview is smaller than the video"]
 en = "Filter used when the preview is smaller than the video"
@@ -2699,6 +2878,7 @@ pt = "Filtro usado quando a pré-visualização é menor que o vídeo"
 tr = "Önizleme videodan daha küçük olduğunda kullanılan filtre"
 it = "Filtro utilizzato quando l’anteprima è più piccola del video"
 id = "Filter yang digunakan saat pratinjau lebih kecil dari video"
+pl = "Filtr używany, gdy podgląd jest mniejszy niż wideo"
 
 ["Nearest"]
 en = "Nearest"
@@ -2714,6 +2894,7 @@ pt = "Mais próximo"
 tr = "En Yakın Komşu"
 it = "Più vicino"
 id = "Terdekat"
+pl = "Najbliższy sąsiad"
 
 ["Preview Downsample Method"]
 en = "Preview Downsample Method"
@@ -2729,6 +2910,7 @@ pt = "Método de redução da pré-visualização"
 tr = "Önizleme Alt Örnekleme Yöntemi"
 it = "Metodo di downsampling dell’anteprima"
 id = "Metode Downsample Pratinjau"
+pl = "Metoda downsamplowania podglądu"
 
 ["Preview Upsample Method"]
 en = "Preview Upsample Method"
@@ -2744,6 +2926,7 @@ pt = "Método de ampliação da pré-visualização"
 tr = "Önizleme Üst Örnekleme Yöntemi"
 it = "Metodo di upsample dell’anteprima"
 id = "Metode Upsample Pratinjau"
+pl = "Metoda upsamplowania podglądu"
 
 ["Trilinear"]
 en = "Trilinear"
@@ -2759,3 +2942,4 @@ pt = "Trilinear"
 tr = "Trilineer"
 it = "Trilineare"
 id = "Trilinear"
+pl = "Trzyliniowe"

--- a/crates/ui/i18n-core/locales/common.toml
+++ b/crates/ui/i18n-core/locales/common.toml
@@ -14,6 +14,7 @@ pt = "%{count} efeitos colados"
 tr = "%{count} efekt yapıştırıldı"
 it = "%{count} effetti incollati"
 id = "%{count} efek ditempel"
+pl = "Wklejono efektów: %{count}"
 
 ["1 effect pasted"]
 en = "1 effect pasted"
@@ -29,6 +30,7 @@ pt = "1 efeito colado"
 tr = "1 efekt yapıştırıldı"
 it = "1 effetto incollato"
 id = "1 efek ditempel"
+pl = "Wklejono 1 efekt"
 
 ["Alpha"]
 en = "Alpha"
@@ -44,6 +46,7 @@ pt = "Alfa"
 tr = "Alfa"
 it = "Alfa"
 id = "Alfa"
+pl = "Alfa"
 
 ["Appearance"]
 en = "Appearance"
@@ -59,6 +62,7 @@ pt = "Aparência"
 tr = "Görünüm"
 it = "Aspetto"
 id = "Tampilan"
+pl = "Wygląd"
 
 ["Apply"]
 en = "Apply"
@@ -74,6 +78,7 @@ pt = "Aplicar"
 tr = "Uygula"
 it = "Applica"
 id = "Terapkan"
+pl = "Zastosuj"
 
 ["Audio"]
 en = "Audio"
@@ -89,6 +94,7 @@ pt = "Áudio"
 tr = "Ses"
 it = "Audio"
 id = "Audio"
+pl = "Dźwięk"
 
 ["Audio Generator"]
 en = "Audio Generator"
@@ -104,6 +110,7 @@ pt = "Gerador de áudio"
 tr = "Ses Üreteci"
 it = "Generatore audio"
 id = "Generator Audio"
+pl = "Generator dźwięku"
 
 ["Audio Track"]
 en = "Audio Track"
@@ -119,6 +126,7 @@ pt = "Faixa de áudio"
 tr = "Ses İzi"
 it = "Traccia audio"
 id = "Track Audio"
+pl = "Ścieżka dźwiękowa"
 
 ["Background"]
 en = "Background"
@@ -134,6 +142,7 @@ pt = "Fundo"
 tr = "Arka Plan"
 it = "Sfondo"
 id = "Latar Belakang"
+pl = "Tło"
 
 ["Cancel"]
 en = "Cancel"
@@ -149,6 +158,7 @@ pt = "Cancelar"
 tr = "İptal"
 it = "Cancella"
 id = "Batal"
+pl = "Anuluj"
 
 ["Cancelled"]
 en = "Cancelled"
@@ -164,6 +174,7 @@ pt = "Cancelado"
 tr = "İptal Edildi"
 it = "Annullato"
 id = "Dibatalkan"
+pl = "Anulowano"
 
 ["Cancelling…"]
 en = "Cancelling…"
@@ -179,6 +190,7 @@ pt = "Cancelando…"
 tr = "İptal Ediliyor"
 it = "Annullando..."
 id = "Membatalkan…"
+pl = "Anulowanie…"
 
 ["Caption"]
 en = "Caption"
@@ -194,6 +206,7 @@ pt = "Legenda"
 tr = "Altyazı"
 it = "Sottotitolo"
 id = "Subtitel"
+pl = "Napisy"
 
 ["Caption Track"]
 en = "Caption Track"
@@ -209,6 +222,7 @@ pt = "Faixa de legendas"
 tr = "Altyazı İzi"
 it = "Traccia dei sottotitoli"
 id = "Track Subtitel"
+pl = "Ścieżka napisów"
 
 ["Choose…"]
 en = "Choose…"
@@ -224,6 +238,7 @@ pt = "Escolher…"
 tr = "Seç…"
 it = "Scegli..."
 id = "Pilih…"
+pl = "Wybierz…"
 
 ["Clear"]
 en = "Clear"
@@ -239,6 +254,7 @@ pt = "Limpar"
 tr = "Temizle"
 it = "Pulisci"
 id = "Bersihkan"
+pl = "Wyczyść"
 
 ["Close"]
 en = "Close"
@@ -254,6 +270,7 @@ pt = "Fechar"
 tr = "Kapat"
 it = "Chiudi"
 id = "Tutup"
+pl = "Zamknij"
 
 ["Copy"]
 en = "Copy"
@@ -269,6 +286,7 @@ pt = "Copiar"
 tr = "Kopyala"
 it = "Copia"
 id = "Salin"
+pl = "Kopiuj"
 
 ["Custom"]
 en = "Custom"
@@ -284,6 +302,7 @@ pt = "Personalizado"
 tr = "Özel"
 it = "Personalizzato"
 id = "Kustom"
+pl = "Niestandardowe"
 
 ["Delete"]
 en = "Delete"
@@ -299,6 +318,7 @@ pt = "Excluir"
 tr = "Sil"
 it = "Elimina"
 id = "Hapus"
+pl = "Usuń"
 
 ["Discard"]
 en = "Discard"
@@ -314,6 +334,7 @@ pt = "Descartar"
 tr = "Vazgeç"
 it = "Scarta"
 id = "Buang"
+pl = "Odrzuć"
 
 ["File"]
 en = "File"
@@ -329,6 +350,7 @@ pt = "Arquivo"
 tr = "Dosya"
 it = "File"
 id = "Berkas"
+pl = "Plik"
 
 ["Format"]
 en = "Format"
@@ -344,6 +366,7 @@ pt = "Formato"
 tr = "Biçim"
 it = "Formato"
 id = "Format"
+pl = "Format"
 
 ["Frame Rate"]
 en = "Frame Rate"
@@ -359,6 +382,7 @@ pt = "Taxa de quadros"
 tr = "Kare Hızı"
 it = "Frequenza fotogrammi"
 id = "Frame Rate"
+pl = "Klatki na sekundę"
 
 ["Frame rate"]
 en = "Frame rate"
@@ -374,6 +398,7 @@ pt = "Taxa de quadros"
 tr = "Kare hızı"
 it = "Frequenza fotogrammi"
 id = "Frame rate"
+pl = "Klatki na sekundę"
 
 ["Hue"]
 en = "Hue"
@@ -389,6 +414,7 @@ pt = "Matiz"
 tr = "Ton"
 it = "Tonalità"
 id = "Hue"
+pl = "Odcień"
 
 ["Info"]
 en = "Info"
@@ -404,6 +430,7 @@ pt = "Informações"
 tr = "Bilgi"
 it = "Informazioni"
 id = "Info"
+pl = "Informacje"
 
 ["Model"]
 en = "Model"
@@ -419,6 +446,7 @@ pt = "Modelo"
 tr = "Model"
 it = "Modello"
 id = "Model"
+pl = "Model"
 
 ["New Track"]
 en = "New Track"
@@ -434,6 +462,7 @@ pt = "Nova faixa"
 tr = "Yeni İz"
 it = "Nuova traccia"
 id = "Track Baru"
+pl = "Nowa ścieżka"
 
 ["None"]
 en = "None"
@@ -449,6 +478,7 @@ pt = "Nenhum"
 tr = "Hiçbiri"
 it = "Nessuno"
 id = "Tidak Ada"
+pl = "Brak"
 
 ["Output"]
 en = "Output"
@@ -464,6 +494,7 @@ pt = "Saída"
 tr = "Çıktı"
 it = "Uscita"
 id = "Output"
+pl = "Wyjście"
 
 ["Padding"]
 en = "Padding"
@@ -479,6 +510,7 @@ pt = "Preenchimento"
 tr = "İç Boşluk"
 it = "Spaziatura"
 id = "Padding"
+pl = "Odstęp"
 
 ["Paint"]
 en = "Paint"
@@ -494,6 +526,7 @@ pt = "Pintura"
 tr = "Çizim"
 it = "Pittura"
 id = "Lukis"
+pl = "Malowanie"
 
 ["Performance"]
 en = "Performance"
@@ -509,6 +542,7 @@ pt = "Desempenho"
 tr = "Performans"
 it = "Prestazioni"
 id = "Performa"
+pl = "Wydajność"
 
 ["Preset"]
 en = "Preset"
@@ -524,6 +558,7 @@ pt = "Predefinição"
 tr = "Önayar"
 it = "Preimpostato"
 id = "Preset"
+pl = "Preset"
 
 ["Sending request…"]
 en = "Sending request…"
@@ -539,6 +574,7 @@ pt = "Enviando solicitação…"
 tr = "İstek gönderiliyor…"
 it = "Inviando richiesta..."
 id = "Mengirim permintaan…"
+pl = "Wysyłanie żądania…"
 
 ["Shape"]
 en = "Shape"
@@ -554,6 +590,7 @@ pt = "Forma"
 tr = "Şekil"
 it = "Forma"
 id = "Bentuk"
+pl = "Kształt"
 
 ["Speed"]
 en = "Speed"
@@ -569,6 +606,7 @@ pt = "Velocidade"
 tr = "Hız"
 it = "Velocità"
 id = "Kecepatan"
+pl = "Prędkość"
 
 ["Text"]
 en = "Text"
@@ -584,6 +622,7 @@ pt = "Texto"
 tr = "Metin"
 it = "Testo"
 id = "Teks"
+pl = "Tekst"
 
 ["Text to Speech"]
 en = "Text to Speech"
@@ -599,6 +638,7 @@ pt = "Texto para fala"
 tr = "Metinden Sese"
 it = "Sintesi vocale"
 id = "Teks ke Suara"
+pl = "Zamiana tekstu na mowę"
 
 ["Version"]
 en = "Version"
@@ -614,6 +654,7 @@ pt = "Versão"
 tr = "Sürüm"
 it = "Versione"
 id = "Versi"
+pl = "Wersja"
 
 ["Video"]
 en = "Video"
@@ -629,6 +670,7 @@ pt = "Vídeo"
 tr = "Video"
 it = "Video"
 id = "Video"
+pl = "Wideo"
 
 ["Video Generation"]
 en = "Video Generation"
@@ -644,6 +686,7 @@ pt = "Geração de vídeo"
 tr = "Video Üreteci"
 it = "Generazione video"
 id = "Pembuatan Video"
+pl = "Generowanie wideo"
 
 ["Video Track"]
 en = "Video Track"
@@ -659,6 +702,7 @@ pt = "Faixa de vídeo"
 tr = "Video İzi"
 it = "Traccia video"
 id = "Track Video"
+pl = "Ścieżka wideo"
 
 ["Width"]
 en = "Width"
@@ -674,3 +718,4 @@ pt = "Largura"
 tr = "Genişlik"
 it = "Larghezza"
 id = "Lebar"
+pl = "Szerokość"

--- a/crates/ui/i18n-core/locales/inspector.toml
+++ b/crates/ui/i18n-core/locales/inspector.toml
@@ -14,6 +14,7 @@ pt = "Absorção"
 tr = "Soğurma"
 it = "Assorbimento"
 id = "Penyerapan"
+pl = "Absorpcja"
 
 ["Accurate Render Method"]
 en = "Accurate Render Method"
@@ -29,6 +30,7 @@ pt = "Método de renderização preciso"
 tr = "Hassas İşleme Yöntemi"
 it = "Metodo di rendering preciso"
 id = "Metode Render Akurat"
+pl = "Metoda dokładnego renderowania"
 
 ["Actions"]
 en = "Actions"
@@ -44,6 +46,7 @@ pt = "Ações"
 tr = "Eylemler"
 it = "Azioni"
 id = "Tindakan"
+pl = "Akcje"
 
 ["Adaptive weights"]
 en = "Adaptive weights"
@@ -59,6 +62,7 @@ pt = "Pesos adaptativos"
 tr = "Uyarlamalı ağırlıklar"
 it = "Pesi adattivi"
 id = "Bobot adaptif"
+pl = "Wagi adaptacyjne"
 
 ["Add"]
 en = "Add"
@@ -74,6 +78,7 @@ pt = "Adicionar"
 tr = "Ekle"
 it = "Aggiungi"
 id = "Tambah"
+pl = "Dodaj"
 
 ["Add color"]
 en = "Add color"
@@ -89,6 +94,7 @@ pt = "Adicionar cor"
 tr = "Renk ekle"
 it = "Aggiungi colore"
 id = "Tambah warna"
+pl = "Dodaj kolor"
 
 ["Add font"]
 en = "Add font"
@@ -104,6 +110,7 @@ pt = "Adicionar fonte"
 tr = "Yazı tipi ekle"
 it = "Aggiungi font"
 id = "Tambah font"
+pl = "Dodaj czcionkę"
 
 ["Add keyframe at playhead"]
 en = "Add keyframe at playhead"
@@ -119,6 +126,7 @@ pt = "Adicionar quadro-chave no indicador de reprodução"
 tr = "Oynatma imlecine anahtar kare ekle"
 it = "Aggiungi keyframe alla testina di riproduzione"
 id = "Tambah keyframe di playhead"
+pl = "Dodaj klatkę kluczową w miejscu głowicy odtwarzania"
 
 ["Add modifier"]
 en = "Add modifier"
@@ -134,6 +142,7 @@ pt = "Adicionar modificador"
 tr = "Değiştirici ekle"
 it = "Aggiungi modificatore"
 id = "Tambah modifier"
+pl = "Dodaj modyfikator"
 
 ["Addressing"]
 en = "Addressing"
@@ -149,6 +158,7 @@ pt = "Endereçamento"
 tr = "Adresleme"
 it = "Indirizzamento"
 id = "Pengalamatan"
+pl = "Adresowanie"
 
 ["Aggressiveness"]
 en = "Aggressiveness"
@@ -164,6 +174,7 @@ pt = "Agressividade"
 tr = "Agresiflik"
 it = "Aggressività"
 id = "Agresivitas"
+pl = "Agresywność"
 
 ["Align"]
 en = "Align"
@@ -179,6 +190,7 @@ pt = "Alinhar"
 tr = "Hizala"
 it = "Allinea"
 id = "Ratakan"
+pl = "Wyrównaj"
 
 ["Alpha Mask Stream"]
 en = "Alpha Mask Stream"
@@ -194,6 +206,7 @@ pt = "Fluxo de máscara alfa"
 tr = "Alfa Maskesi Akışı"
 it = "Stream della maschera alpha"
 id = "Stream Mask Alfa"
+pl = "Strumień maski alfa"
 
 ["Amount"]
 en = "Amount"
@@ -209,6 +222,7 @@ pt = "Quantidade"
 tr = "Miktar"
 it = "Quantità"
 id = "Jumlah"
+pl = "Ilość"
 
 ["Amplitude"]
 en = "Amplitude"
@@ -224,6 +238,7 @@ pt = "Amplitude"
 tr = "Genlik"
 it = "Ampiezza"
 id = "Amplitudo"
+pl = "Amplituda"
 
 ["Analysis FPS"]
 en = "Analysis FPS"
@@ -239,6 +254,7 @@ pt = "FPS de análise"
 tr = "Analiz FPS'si"
 it = "FPS di analisi"
 id = "FPS Analisis"
+pl = "FPS analizy"
 
 ["Analysis status"]
 en = "Analysis status"
@@ -254,6 +270,7 @@ pt = "Status da análise"
 tr = "Analiz durumu"
 it = "Stato dell'analisi"
 id = "Status analisis"
+pl = "Status analizy"
 
 ["Analyze"]
 en = "Analyze"
@@ -269,6 +286,7 @@ pt = "Analisar"
 tr = "Analiz et"
 it = "Analizza"
 id = "Analisis"
+pl = "Analizuj"
 
 ["Analyze Again"]
 en = "Analyze Again"
@@ -284,6 +302,7 @@ pt = "Analisar novamente"
 tr = "Tekrar Analiz Et"
 it = "Analizza di nuovo"
 id = "Analisis Ulang"
+pl = "Analizuj ponownie"
 
 ["Analyze this clip for beat-grid snapping"]
 en = "Analyze this clip for beat-grid snapping"
@@ -299,6 +318,7 @@ pt = "Analisar este clipe para encaixe na grade de batidas"
 tr = "Ritim ızgarasına yapışma için bu klibi analiz et"
 it = "Analizza questo clip per l'aggancio alla griglia dei beat"
 id = "Analisis klip ini untuk perataan kisi ketukan"
+pl = "Przeanalizuj ten klip pod kątem przyciągania z siatką rytmiczną"
 
 ["Analyzing source motion…"]
 en = "Analyzing source motion…"
@@ -314,6 +334,7 @@ pt = "Analisando movimento de origem…"
 tr = "Kaynak hareket analiz ediliyor…"
 it = "Analisi del movimento sorgente…"
 id = "Menganalisis gerakan sumber…"
+pl = "Analizowanie ruchu źródła…"
 
 ["Analyzing…"]
 en = "Analyzing…"
@@ -329,6 +350,7 @@ pt = "Analisando…"
 tr = "Analiz ediliyor…"
 it = "Analisi…"
 id = "Menganalisis…"
+pl = "Analizowanie…"
 
 ["Anchor"]
 en = "Anchor"
@@ -344,6 +366,7 @@ pt = "Âncora"
 tr = "Çapa"
 it = "Ancora"
 id = "Jangkar"
+pl = "Kotwica"
 
 ["Angle"]
 en = "Angle"
@@ -359,6 +382,7 @@ pt = "Ângulo"
 tr = "Açı"
 it = "Angolo"
 id = "Sudut"
+pl = "Kąt"
 
 ["Angular radius"]
 en = "Angular radius"
@@ -374,6 +398,7 @@ pt = "Raio angular"
 tr = "Açısal yarıçap"
 it = "Raggio angolare"
 id = "Radius sudut"
+pl = "Promień kąta"
 
 ["Angular randomness"]
 en = "Angular randomness"
@@ -389,6 +414,7 @@ pt = "Aleatoriedade angular"
 tr = "Açısal rastgelelik"
 it = "Casualità angolare"
 id = "Keacakan sudut"
+pl = "Losowość kąta"
 
 ["Animated"]
 en = "Animated"
@@ -404,6 +430,7 @@ pt = "Animado"
 tr = "Hareketli"
 it = "Animato"
 id = "Dianimasikan"
+pl = "Animowane"
 
 ["Anti-aliasing"]
 en = "Anti-aliasing"
@@ -419,6 +446,7 @@ pt = "Anti-aliasing"
 tr = "Kenar Yumuşatma"
 it = "Anti-aliasing"
 id = "Anti-aliasing"
+pl = "Anty-aliasing"
 
 ["Aperture"]
 en = "Aperture"
@@ -434,6 +462,7 @@ pt = "Abertura"
 tr = "Diyafram"
 it = "Apertura"
 id = "Bukaan"
+pl = "Apertura"
 
 ["Arm thickness"]
 en = "Arm thickness"
@@ -449,6 +478,7 @@ pt = "Espessura do braço"
 tr = "Kol kalınlığı"
 it = "Spessore del braccio"
 id = "Ketebalan lengan"
+pl = "Grubość ramienia"
 
 ["Attack"]
 en = "Attack"
@@ -464,6 +494,7 @@ pt = "Ataque"
 tr = "Atak"
 it = "Attacco"
 id = "Attack"
+pl = "Atak"
 
 ["Audio Stream"]
 en = "Audio Stream"
@@ -479,6 +510,7 @@ pt = "Fluxo de áudio"
 tr = "Ses Akışı"
 it = "Stream audio"
 id = "Stream Audio"
+pl = "Strumień audio"
 
 ["Audio stream %{number}"]
 en = "Audio stream %{number}"
@@ -494,6 +526,7 @@ pt = "Fluxo de áudio %{number}"
 tr = "Ses akışı %{number}"
 it = "Stream audio %{number}"
 id = "Stream audio %{number}"
+pl = "Strumień audio %{number}"
 
 ["Auto level"]
 en = "Auto level"
@@ -509,6 +542,7 @@ pt = "Nível automático"
 tr = "Otomatik düzey"
 it = "Livello automatico"
 id = "Level otomatis"
+pl = "Automatyczny poziom"
 
 ["B&W threshold"]
 en = "B&W threshold"
@@ -524,6 +558,7 @@ pt = "Limiar P&B"
 tr = "Siyah-Beyaz eşiği"
 it = "Soglia B/N"
 id = "Ambang B/W"
+pl = "Próg C/B"
 
 ["Background color"]
 en = "Background color"
@@ -539,6 +574,7 @@ pt = "Cor de fundo"
 tr = "Arka plan rengi"
 it = "Colore di sfondo"
 id = "Warna latar belakang"
+pl = "Kolor tła"
 
 ["Background distance"]
 en = "Background distance"
@@ -554,6 +590,7 @@ pt = "Distância do fundo"
 tr = "Arka plan uzaklığı"
 it = "Distanza dello sfondo"
 id = "Jarak latar belakang"
+pl = "Odległość tła"
 
 ["Background fill"]
 en = "Background fill"
@@ -569,6 +606,7 @@ pt = "Preenchimento do fundo"
 tr = "Arka plan dolgusu"
 it = "Riempimento dello sfondo"
 id = "Isian latar belakang"
+pl = "Wypełnienie tła"
 
 ["Background intensity"]
 en = "Background intensity"
@@ -584,6 +622,7 @@ pt = "Intensidade do fundo"
 tr = "Arka plan yoğunluğu"
 it = "Intensità dello sfondo"
 id = "Intensitas latar belakang"
+pl = "Intensywność tła"
 
 ["Background padding"]
 en = "Background padding"
@@ -599,6 +638,7 @@ pt = "Preenchimento do fundo"
 tr = "Arka plan iç boşluğu"
 it = "Margine dello sfondo"
 id = "Padding latar belakang"
+pl = "Odstęp tła"
 
 ["Background plane"]
 en = "Background plane"
@@ -614,6 +654,7 @@ pt = "Plano de fundo"
 tr = "Arka plan düzlemi"
 it = "Piano di sfondo"
 id = "Bidang latar belakang"
+pl = "Płaszczyzna tła"
 
 ["Background roundness"]
 en = "Background roundness"
@@ -629,6 +670,7 @@ pt = "Arredondamento do fundo"
 tr = "Arka plan yuvarlaklığı"
 it = "Arrotondamento dello sfondo"
 id = "Kebulatan latar belakang"
+pl = "Okrągłość tła"
 
 ["Background tiling"]
 en = "Background tiling"
@@ -644,6 +686,7 @@ pt = "Mosaico do fundo"
 tr = "Arka plan döşeme"
 it = "Tassellatura dello sfondo"
 id = "Pengubinan latar belakang"
+pl = "Powtarzanie tła"
 
 ["Bake"]
 en = "Bake"
@@ -659,6 +702,7 @@ pt = "Pré-computar"
 tr = "Pişir"
 it = "Pre-calcola"
 id = "Bake"
+pl = "Wypal"
 
 ["Baking…"]
 en = "Baking…"
@@ -674,6 +718,7 @@ pt = "Pré-computando…"
 tr = "Pişiriliyor…"
 it = "Pre-calcolo…"
 id = "Melakukan baking…"
+pl = "Wypalanie…"
 
 ["Balanced"]
 en = "Balanced"
@@ -689,6 +734,7 @@ pt = "Equilibrado"
 tr = "Dengeli"
 it = "Equilibrato"
 id = "Seimbang"
+pl = "Zbalansowane"
 
 ["Band count"]
 en = "Band count"
@@ -704,6 +750,7 @@ pt = "Número de bandas"
 tr = "Bant sayısı"
 it = "Numero di bande"
 id = "Jumlah band"
+pl = "Liczba pasm"
 
 ["Band width"]
 en = "Band width"
@@ -719,6 +766,7 @@ pt = "Largura da banda"
 tr = "Bant genişliği"
 it = "Larghezza di banda"
 id = "Lebar band"
+pl = "Szerokość pasm"
 
 ["Bands"]
 en = "Bands"
@@ -734,6 +782,7 @@ pt = "Bandas"
 tr = "Bantlar"
 it = "Bande"
 id = "Band"
+pl = "Pasma"
 
 ["Base angle"]
 en = "Base angle"
@@ -749,6 +798,7 @@ pt = "Ângulo base"
 tr = "Temel açı"
 it = "Angolo base"
 id = "Sudut dasar"
+pl = "Kąt bazowy"
 
 ["Base color"]
 en = "Base color"
@@ -764,6 +814,7 @@ pt = "Cor base"
 tr = "Temel renk"
 it = "Colore base"
 id = "Warna dasar"
+pl = "Kolor bazowy"
 
 ["Beat Detection"]
 en = "Beat Detection"
@@ -779,6 +830,7 @@ pt = "Detecção de batidas"
 tr = "Ritim Tespiti"
 it = "Rilevamento beat"
 id = "Deteksi Ketukan"
+pl = "Detekcja rytmu"
 
 ["Bevel"]
 en = "Bevel"
@@ -794,6 +846,7 @@ pt = "Bisel"
 tr = "Pah"
 it = "Smussatura"
 id = "Bevel"
+pl = "Faza"
 
 ["Blend curve"]
 en = "Blend curve"
@@ -809,6 +862,7 @@ pt = "Curva de mesclagem"
 tr = "Karıştırma eğrisi"
 it = "Curva di mescolamento"
 id = "Kurva perpaduan"
+pl = "Krzywa mieszania"
 
 ["Blend mode"]
 en = "Blend mode"
@@ -824,6 +878,7 @@ pt = "Modo de mesclagem"
 tr = "Karıştırma modu"
 it = "Modalità di mescolamento"
 id = "Mode perpaduan"
+pl = "Tryb mieszania"
 
 ["Block height"]
 en = "Block height"
@@ -839,6 +894,7 @@ pt = "Altura do bloco"
 tr = "Blok yüksekliği"
 it = "Altezza del blocco"
 id = "Tinggi blok"
+pl = "Wysokość bloku"
 
 ["Block width"]
 en = "Block width"
@@ -854,6 +910,7 @@ pt = "Largura do bloco"
 tr = "Blok genişliği"
 it = "Larghezza del blocco"
 id = "Lebar blok"
+pl = "Szerokość bloku"
 
 ["Blur"]
 en = "Blur"
@@ -869,6 +926,7 @@ pt = "Desfoque"
 tr = "Bulanıklaştırma"
 it = "Sfocatura"
 id = "Buram"
+pl = "Rozmazanie"
 
 ["Bottom"]
 en = "Bottom"
@@ -884,6 +942,7 @@ pt = "Inferior"
 tr = "Alt"
 it = "In basso"
 id = "Bawah"
+pl = "Dół"
 
 ["Bottom left"]
 en = "Bottom left"
@@ -899,6 +958,7 @@ pt = "Inferior esquerdo"
 tr = "Sol alt"
 it = "In basso a sinistra"
 id = "Kiri bawah"
+pl = "Lewy dół"
 
 ["Bottom right"]
 en = "Bottom right"
@@ -914,6 +974,7 @@ pt = "Inferior direito"
 tr = "Sağ alt"
 it = "In basso a destra"
 id = "Kanan bawah"
+pl = "Prawy dół"
 
 ["Box"]
 en = "Box"
@@ -929,6 +990,7 @@ pt = "Caixa"
 tr = "Kutu"
 it = "Riquadro"
 id = "Kotak"
+pl = "Pudło"
 
 ["Brightness"]
 en = "Brightness"
@@ -944,6 +1006,7 @@ pt = "Brilho"
 tr = "Parlaklık"
 it = "Luminosità"
 id = "Kecerahan"
+pl = "Jasność"
 
 ["Camera"]
 en = "Camera"
@@ -959,6 +1022,7 @@ pt = "Câmera"
 tr = "Kamera"
 it = "Videocamera"
 id = "Kamera"
+pl = "Kamera"
 
 ["Camera model"]
 en = "Camera model"
@@ -974,6 +1038,7 @@ pt = "Modelo da câmera"
 tr = "Kamera modeli"
 it = "Modello videocamera"
 id = "Model kamera"
+pl = "Model kamery"
 
 ["Camera source"]
 en = "Camera source"
@@ -989,6 +1054,7 @@ pt = "Origem da câmera"
 tr = "Kamera kaynağı"
 it = "Fonte Videocamera"
 id = "Sumber kamera"
+pl = "Źródło kamery"
 
 ["Cancelling"]
 en = "Cancelling"
@@ -1004,6 +1070,7 @@ pt = "Cancelando"
 tr = "İptal ediliyor"
 it = "Annullamento"
 id = "Membatalkan"
+pl = "Anulowanie"
 
 ["Caption text color"]
 en = "Caption text color"
@@ -1019,6 +1086,7 @@ pt = "Cor do texto da legenda"
 tr = "Altyazı metin rengi"
 it = "Colore del testo dei sottotitoli"
 id = "Warna teks subtitel"
+pl = "Kolor tekstu napisów"
 
 ["Ceiling"]
 en = "Ceiling"
@@ -1034,6 +1102,7 @@ pt = "Teto"
 tr = "Tavan"
 it = "Limite superiore"
 id = "Batas atas"
+pl = "Górny limit"
 
 ["Cell size"]
 en = "Cell size"
@@ -1049,6 +1118,7 @@ pt = "Tamanho da célula"
 tr = "Hücre boyutu"
 it = "Dimensione cella"
 id = "Ukuran sel"
+pl = "Rozmiar komórki"
 
 ["Center"]
 en = "Center"
@@ -1064,6 +1134,7 @@ pt = "Centro"
 tr = "Merkez"
 it = "Centro"
 id = "Tengah"
+pl = "Środek"
 
 ["Center X"]
 en = "Center X"
@@ -1079,6 +1150,7 @@ pt = "Centro X"
 tr = "Merkez X"
 it = "Centro X"
 id = "Tengah X"
+pl = "Środek X"
 
 ["Center Y"]
 en = "Center Y"
@@ -1094,6 +1166,7 @@ pt = "Centro Y"
 tr = "Merkez Y"
 it = "Centro Y"
 id = "Tengah Y"
+pl = "Środek Y"
 
 ["Chamfer"]
 en = "Chamfer"
@@ -1109,6 +1182,7 @@ pt = "Chanfro"
 tr = "Pah Kırma"
 it = "Smusso"
 id = "Chamfer"
+pl = "Fazowanie"
 
 ["Change all at once"]
 en = "Change all at once"
@@ -1124,6 +1198,7 @@ pt = "Alterar tudo de uma vez"
 tr = "Tümünü tek seferde değiştir"
 it = "Modifica tutto in una volta"
 id = "Ubah semua sekaligus"
+pl = "Zmień wszystko na raz"
 
 ["Change Project Settings?"]
 en = "Change Project Settings?"
@@ -1139,6 +1214,7 @@ pt = "Alterar configurações do projeto?"
 tr = "Proje ayarları değiştirilsin mi?"
 it = "Modificare le impostazioni del progetto?"
 id = "Ubah Pengaturan Proyek?"
+pl = "Zmienić ustawienia projektu?"
 
 ["Changing the frame rate or resolution can affect timing, visual layout, and rendered output. Existing media and effects may no longer match the project."]
 en = "Changing the frame rate or resolution can affect timing, visual layout, and rendered output. Existing media and effects may no longer match the project."
@@ -1154,6 +1230,7 @@ pt = "Alterar a taxa de quadros ou a resolução pode afetar a sincronização, 
 tr = "Kare hızını veya çözünürlüğü değiştirmek zamanlamayı, görsel düzeni ve işlenmiş çıktıyı etkileyebilir. Mevcut medya ve efektler artık bu projeyle eşleşmeyebilir."
 it = "Modificare la frequenza dei fotogrammi o la risoluzione può influire su temporizzazione, layout visivo e l'output renderizzato. I media e gli effetti esistenti potrebbero non corrispondere più al progetto."
 id = "Mengubah frame rate atau resolusi dapat memengaruhi pewaktuan, tata letak visual, dan hasil render. Media dan efek yang ada mungkin tidak lagi cocok dengan proyek."
+pl = "Zmiana liczby klatek na sekundę lub rozdzielczości może wpłynąć na synchronizację, układ wizualny i wynik renderowania. Istniejące materiały i efekty mogą nie być już zgodne z projektem."
 
 ["Channel angle offset"]
 en = "Channel angle offset"
@@ -1169,6 +1246,7 @@ pt = "Deslocamento angular de canais"
 tr = "Kanal açı ofseti"
 it = "Offset angolo canali"
 id = "Ofset sudut saluran"
+pl = "Przesunięcie kąta kanału"
 
 ["Channel offset"]
 en = "Channel offset"
@@ -1184,6 +1262,7 @@ pt = "Deslocamento de canais"
 tr = "Kanal ofseti"
 it = "Offset dei canali"
 id = "Ofset saluran"
+pl = "Przesunięcie kanału"
 
 ["Choose font"]
 en = "Choose font"
@@ -1199,6 +1278,7 @@ pt = "Escolher fonte"
 tr = "Yazı tipi seç"
 it = "Scegli font"
 id = "Pilih font"
+pl = "Wybierz czcionkę"
 
 ["Choose item…"]
 en = "Choose item…"
@@ -1214,6 +1294,7 @@ pt = "Escolher item…"
 tr = "Öge seç…"
 it = "Scegli elemento…"
 id = "Pilih item…"
+pl = "Wybierz element…"
 
 ["Circular"]
 en = "Circular"
@@ -1229,6 +1310,7 @@ pt = "Circular"
 tr = "Dairesel"
 it = "Circolare"
 id = "Melingkar"
+pl = "Okrągłe"
 
 ["Classic"]
 en = "Classic"
@@ -1244,6 +1326,7 @@ pt = "Clássico"
 tr = "Klasik"
 it = "Classico"
 id = "Klasik"
+pl = "Klasyczne"
 
 ["Clear and rewrite the whole text"]
 en = "Clear and rewrite the whole text"
@@ -1259,6 +1342,7 @@ pt = "Limpar e reescrever todo o texto"
 tr = "Tüm metni sil ve yeniden yaz"
 it = "Cancella e riscrivi tutto il testo"
 id = "Hapus dan tulis ulang seluruh teks"
+pl = "Wyczyść i napisz ponownie cały tekst"
 
 ["Clear image"]
 en = "Clear image"
@@ -1274,6 +1358,7 @@ pt = "Remover imagem"
 tr = "Resmi temizle"
 it = "Cancella immagine"
 id = "Hapus gambar"
+pl = "Wyczyść obraz"
 
 ["Clear mask source"]
 en = "Clear mask source"
@@ -1289,6 +1374,7 @@ pt = "Remover origem da máscara"
 tr = "Maske kaynağını temizle"
 it = "Cancella origine della maschera"
 id = "Hapus sumber masker"
+pl = "Usuń źródło maski"
 
 ["Clear model"]
 en = "Clear model"
@@ -1304,6 +1390,7 @@ pt = "Remover modelo"
 tr = "Modeli temizle"
 it = "Cancella modello"
 id = "Hapus model"
+pl = "Usuń model"
 
 ["Clear texture"]
 en = "Clear texture"
@@ -1319,6 +1406,7 @@ pt = "Remover textura"
 tr = "Dokuyu temizle"
 it = "Cancella texture"
 id = "Hapus tekstur"
+pl = "Usuń teksturę"
 
 ["Clearcoat"]
 en = "Clearcoat"
@@ -1334,6 +1422,7 @@ pt = "Verniz"
 tr = "Şeffaf Kaplama"
 it = "Vernice trasparente"
 id = "Clearcoat"
+pl = "Lakier bezbarwny"
 
 ["Clockwise"]
 en = "Clockwise"
@@ -1349,6 +1438,7 @@ pt = "Sentido horário"
 tr = "Saat Yönünde"
 it = "Senso orario"
 id = "Searah jarum jam"
+pl = "Według ruchu zegara"
 
 ["Coalesce"]
 en = "Coalesce"
@@ -1364,6 +1454,7 @@ pt = "Unificar"
 tr = "Kaynaştır"
 it = "Unifica"
 id = "Satukan"
+pl = "Połącz"
 
 ["Collapse"]
 en = "Collapse"
@@ -1379,6 +1470,7 @@ pt = "Recolher"
 tr = "Daralt"
 it = "Comprimi"
 id = "Ciutkan"
+pl = "Zwiń"
 
 ["Color"]
 en = "Color"
@@ -1394,6 +1486,7 @@ pt = "Cor"
 tr = "Renk"
 it = "Colore"
 id = "Warna"
+pl = "Kolor"
 
 ["Color A"]
 en = "Color A"
@@ -1409,6 +1502,7 @@ pt = "Cor A"
 tr = "Renk A"
 it = "Colore A"
 id = "Warna A"
+pl = "Kolor A"
 
 ["Color B"]
 en = "Color B"
@@ -1424,6 +1518,7 @@ pt = "Cor B"
 tr = "Renk B"
 it = "Colore B"
 id = "Warna B"
+pl = "Kolor B"
 
 ["Color mode"]
 en = "Color mode"
@@ -1439,6 +1534,7 @@ pt = "Modo de cor"
 tr = "Renk modu"
 it = "Modalità colore"
 id = "Mode warna"
+pl = "Tryb koloru"
 
 ["Color position"]
 en = "Color position"
@@ -1454,6 +1550,7 @@ pt = "Posição da cor"
 tr = "Renk konumu"
 it = "Posizione colore"
 id = "Posisi warna"
+pl = "Pozycja koloru"
 
 ["Color precision"]
 en = "Color precision"
@@ -1469,6 +1566,7 @@ pt = "Precisão da cor"
 tr = "Renk hassaslığı"
 it = "Precisione colore"
 id = "Presisi warna"
+pl = "Precyzja koloru"
 
 ["Color %{number}"]
 en = "Color %{number}"
@@ -1484,6 +1582,7 @@ pt = "Cor %{number}"
 tr = "Renk %{number}"
 it = "Colore %{number}"
 id = "Warna %{number}"
+pl = "Kolor %{number}"
 
 ["Coloring"]
 en = "Coloring"
@@ -1499,6 +1598,7 @@ pt = "Coloração"
 tr = "Renklendirme"
 it = "Colorazione"
 id = "Pewarnaan"
+pl = "Kolorowanie"
 
 ["Completion"]
 en = "Completion"
@@ -1514,6 +1614,7 @@ pt = "Conclusão"
 tr = "Tamamlama"
 it = "Avanzamento"
 id = "Penyelesaian"
+pl = "Postęp"
 
 ["Complexity"]
 en = "Complexity"
@@ -1529,6 +1630,7 @@ pt = "Complexidade"
 tr = "Karmaşıklık"
 it = "Complessità"
 id = "Kompleksitas"
+pl = "Złożność"
 
 ["Composite"]
 en = "Composite"
@@ -1544,6 +1646,7 @@ pt = "Composição"
 tr = "Kompozit"
 it = "Composito"
 id = "Komposit"
+pl = "Kompozycja"
 
 ["Composite background"]
 en = "Composite background"
@@ -1559,6 +1662,7 @@ pt = "Compor fundo"
 tr = "Kompozit arka plan"
 it = "Componi sfondo"
 id = "Latar belakang komposit"
+pl = "Tło kompozycji"
 
 ["Compositing"]
 en = "Compositing"
@@ -1574,6 +1678,7 @@ pt = "Composição"
 tr = "Kompozisyon"
 it = "Compositing"
 id = "Pengomposisian"
+pl = "Kompozytowanie"
 
 ["Constant high"]
 en = "Constant high"
@@ -1589,6 +1694,7 @@ pt = "Constante alto"
 tr = "Sabit yüksek"
 it = "Costante alto"
 id = "Tinggi konstan"
+pl = "Wysokość stałej"
 
 ["Constant low"]
 en = "Constant low"
@@ -1604,6 +1710,7 @@ pt = "Constante baixo"
 tr = "Sabit düşük"
 it = "Costante basso"
 id = "Rendah konstan"
+pl = "Niskość stałej"
 
 ["Constant-acceleration weight"]
 en = "Constant-acceleration weight"
@@ -1619,6 +1726,7 @@ pt = "Peso de aceleração constante"
 tr = "Sabit ivme ağırlığı"
 it = "Peso di accelerazione costante"
 id = "Bobot percepatan konstan"
+pl = "Waga stałego przyśpieszenia"
 
 ["Constant-motion weight"]
 en = "Constant-motion weight"
@@ -1634,6 +1742,7 @@ pt = "Peso de movimento constante"
 tr = "Sabit hareket ağırlığı"
 it = "Peso di movimento costante"
 id = "Bobot gerakan konstan"
+pl = "Waga stałego ruchu"
 
 ["Continuous"]
 en = "Continuous"
@@ -1649,6 +1758,7 @@ pt = "Contínuo"
 tr = "Sürekli"
 it = "Continuo"
 id = "Kontinu"
+pl = "Ciągłe"
 
 ["Contrast"]
 en = "Contrast"
@@ -1664,6 +1774,7 @@ pt = "Contraste"
 tr = "Kontrast"
 it = "Contrasto"
 id = "Kontras"
+pl = "Kontrast"
 
 ["Copies X"]
 en = "Copies X"
@@ -1679,6 +1790,7 @@ pt = "Cópias X"
 tr = "X Kopya Sayısı"
 it = "Copie X"
 id = "Salinan X"
+pl = "Kopiuje X"
 
 ["Copies Y"]
 en = "Copies Y"
@@ -1694,6 +1806,7 @@ pt = "Cópias Y"
 tr = "Y Kopya Sayısı"
 it = "Copie Y"
 id = "Salinan Y"
+pl = "Kopiuje Y"
 
 ["Copy JSON"]
 en = "Copy JSON"
@@ -1709,6 +1822,7 @@ pt = "Copiar JSON"
 tr = "JSON'u kopyala"
 it = "Copia JSON"
 id = "Salin JSON"
+pl = "Kopiuj JSON"
 
 ["Corner radius"]
 en = "Corner radius"
@@ -1724,6 +1838,7 @@ pt = "Raio do canto"
 tr = "Köşe yuvarlaklığı"
 it = "Raggio angoli"
 id = "Radius sudut"
+pl = "Promień krawędzi"
 
 ["Corner rounding"]
 en = "Corner rounding"
@@ -1739,6 +1854,7 @@ pt = "Arredondamento dos cantos"
 tr = "Köşe yuvarlatma"
 it = "Arrotondamento angoli"
 id = "Pembulatan sudut"
+pl = "Zaokrąglanie krawędzi"
 
 ["Corner threshold"]
 en = "Corner threshold"
@@ -1754,6 +1870,7 @@ pt = "Limiar de canto"
 tr = "Köşe eşiği"
 it = "Soglia angoli"
 id = "Ambang batas sudut"
+pl = "Próg krawędzi"
 
 ["Counterclockwise"]
 en = "Counterclockwise"
@@ -1769,6 +1886,7 @@ pt = "Sentido anti-horário"
 tr = "Saat Yönünün Tersi"
 it = "Senso antiorario"
 id = "Berlawanan arah jarum jam"
+pl = "Odwrotnie od ruchu zegara"
 
 ["Create"]
 en = "Create"
@@ -1784,6 +1902,7 @@ pt = "Criar"
 tr = "Oluştur"
 it = "Crea"
 id = "Buat"
+pl = "Stwórz"
 
 ["Crop ratio"]
 en = "Crop ratio"
@@ -1799,6 +1918,7 @@ pt = "Proporção de corte"
 tr = "Kırpma oranı"
 it = "Proporzione di ritaglio"
 id = "Rasio pemangkasan"
+pl = "Współczynnik przycięcia"
 
 ["Cross"]
 en = "Cross"
@@ -1814,6 +1934,7 @@ pt = "Cruz"
 tr = "Artı"
 it = "Croce"
 id = "Silang"
+pl = "Krzyż"
 
 ["Crosshatch"]
 en = "Crosshatch"
@@ -1829,6 +1950,7 @@ pt = "Hachura cruzada"
 tr = "Çapraz tarama"
 it = "Tratteggio incrociato"
 id = "Arsir silang"
+pl = "Kreskowanie"
 
 ["Curvature"]
 en = "Curvature"
@@ -1844,6 +1966,7 @@ pt = "Curvatura"
 tr = "Eğrilik"
 it = "Curvatura"
 id = "Kelengkungan"
+pl = "Wykrzywienie"
 
 ["Curve"]
 en = "Curve"
@@ -1859,6 +1982,7 @@ pt = "Curva"
 tr = "Eğri"
 it = "Curva"
 id = "Kurva"
+pl = "Krzywa"
 
 ["Cutoff"]
 en = "Cutoff"
@@ -1874,6 +1998,7 @@ pt = "Corte"
 tr = "Kesim"
 it = "Cutoff"
 id = "Cutoff"
+pl = "Odcięcie"
 
 ["Damping"]
 en = "Damping"
@@ -1889,6 +2014,7 @@ pt = "Amortecimento"
 tr = "Sönümleme"
 it = "Smorzamento"
 id = "Peredaman"
+pl = "Tłumienie"
 
 ["Darkest tone"]
 en = "Darkest tone"
@@ -1904,6 +2030,7 @@ pt = "Tom mais escuro"
 tr = "En karanlık ton"
 it = "Tono più scuro"
 id = "Warna tergelap"
+pl = "Najciemniejszy ton"
 
 ["Dash gap"]
 en = "Dash gap"
@@ -1919,6 +2046,7 @@ pt = "Espaço do tracejado"
 tr = "Çizgi aralığı"
 it = "Spazio tratteggio"
 id = "Celah garis putus-putus"
+pl = "Odstęp kreski"
 
 ["Dash length"]
 en = "Dash length"
@@ -1934,6 +2062,7 @@ pt = "Comprimento do traço"
 tr = "Çizgi uzunluğu"
 it = "Lunghezza tratteggio"
 id = "Panjang garis putus-putus"
+pl = "Długość kreski"
 
 ["Dash position"]
 en = "Dash position"
@@ -1949,6 +2078,7 @@ pt = "Posição do tracejado"
 tr = "Çizgi konumu"
 it = "Posizione tratteggio"
 id = "Posisi garis putus-putus"
+pl = "Pozycja kresek"
 
 ["Decay"]
 en = "Decay"
@@ -1964,6 +2094,7 @@ pt = "Decaimento"
 tr = "Zayıflama"
 it = "Decadimento"
 id = "Decay"
+pl = "Spadek"
 
 ["Default outline color"]
 en = "Default outline color"
@@ -1979,6 +2110,7 @@ pt = "Cor de contorno padrão"
 tr = "Varsayılan kontür rengi"
 it = "Colore contorno predefinito"
 id = "Warna garis luar bawaan"
+pl = "Domyślny kolor konturu"
 
 ["Delay"]
 en = "Delay"
@@ -1994,6 +2126,7 @@ pt = "Atraso"
 tr = "Gecikme"
 it = "Ritardo"
 id = "Delay"
+pl = "Opóźnienie"
 
 ["Delete selected keyframe"]
 en = "Delete selected keyframe"
@@ -2009,6 +2142,7 @@ pt = "Excluir quadro-chave selecionado"
 tr = "Seçilen anahtar karesini sil"
 it = "Elimina keyframe selezionato"
 id = "Hapus keyframe yang dipilih"
+pl = "Usuń zaznaczoną klatkę kluczową"
 
 ["Depth"]
 en = "Depth"
@@ -2024,6 +2158,7 @@ pt = "Profundidade"
 tr = "Derinlik"
 it = "Profondità"
 id = "Kedalaman"
+pl = "Głębia"
 
 ["Depth edge roundness"]
 en = "Depth edge roundness"
@@ -2039,6 +2174,7 @@ pt = "Arredondamento de borda de profundidade"
 tr = "Derinlik kenarı yuvarlaklığı"
 it = "Arrotondamento bordo profondità"
 id = "Kebulatan tepi kedalaman"
+pl = "Zaokrąglenie głębi krawędzi"
 
 ["Depth threshold"]
 en = "Depth threshold"
@@ -2054,6 +2190,7 @@ pt = "Limiar de profundidade"
 tr = "Derinlik eşiği"
 it = "Soglia profondità"
 id = "Ambang batas kedalaman"
+pl = "Próg głębi"
 
 ["Detail"]
 en = "Detail"
@@ -2069,6 +2206,7 @@ pt = "Detalhe"
 tr = "Detay"
 it = "Dettaglio"
 id = "Detail"
+pl = "Detal"
 
 ["Diamond"]
 en = "Diamond"
@@ -2084,6 +2222,7 @@ pt = "Losango"
 tr = "Eşkenar dörtgen"
 it = "Rombo"
 id = "Belah ketupat"
+pl = "Diament"
 
 ["Diffusion"]
 en = "Diffusion"
@@ -2099,6 +2238,7 @@ pt = "Difusão"
 tr = "Difüzyon"
 it = "Diffusione"
 id = "Difusi"
+pl = "Dyfuzja"
 
 ["Dimensions"]
 en = "Dimensions"
@@ -2114,6 +2254,7 @@ pt = "Dimensões"
 tr = "Boyutlar"
 it = "Dimensioni"
 id = "Dimensi"
+pl = "Wymiary"
 
 ["Direction"]
 en = "Direction"
@@ -2129,6 +2270,7 @@ pt = "Direção"
 tr = "Yön"
 it = "Direzione"
 id = "Arah"
+pl = "Kierunek"
 
 ["Disable modifier"]
 en = "Disable modifier"
@@ -2144,6 +2286,7 @@ pt = "Desabilitar modificador"
 tr = "Değiştiriciyi devre dışı bırak"
 it = "Disattiva modificatore"
 id = "Nonaktifkan modifier"
+pl = "Wyłącz modyfikator"
 
 ["Discard and reanalyze the current source-time chunk"]
 en = "Discard and reanalyze the current source-time chunk"
@@ -2159,6 +2302,7 @@ pt = "Descartar e reanalisar o trecho temporal de origem atual"
 tr = "Mevcut kaynak-zaman dilimini sil ve yeniden analiz et"
 it = "Scarta e rianalizza il frammento temporale sorgente attuale"
 id = "Buang dan analisis ulang potongan waktu sumber saat ini"
+pl = "Odrzuć i przeanalizuj ponownie obecny przedział czasowy"
 
 ["Distance"]
 en = "Distance"
@@ -2174,6 +2318,7 @@ pt = "Distância"
 tr = "Uzaklık"
 it = "Distanza"
 id = "Jarak"
+pl = "Dystans"
 
 ["Distortion"]
 en = "Distortion"
@@ -2189,6 +2334,7 @@ pt = "Distorção"
 tr = "Bozulma"
 it = "Distorsione"
 id = "Distorsi"
+pl = "Zniekształcenie"
 
 ["Distribution"]
 en = "Distribution"
@@ -2204,6 +2350,7 @@ pt = "Distribuição"
 tr = "Dağılım"
 it = "Distribuzione"
 id = "Distribusi"
+pl = "Rozkład"
 
 ["Distribution randomness"]
 en = "Distribution randomness"
@@ -2219,6 +2366,7 @@ pt = "Aleatoriedade da distribuição"
 tr = "Dağıtım rastgeleliği"
 it = "Casualità distribuzione"
 id = "Keacakan distribusi"
+pl = "Losowość rozkładu"
 
 ["Dot density"]
 en = "Dot density"
@@ -2234,6 +2382,7 @@ pt = "Densidade de pontos"
 tr = "Nokta yoğunluğu"
 it = "Densità punti"
 id = "Kepadatan titik"
+pl = "Gęstość kropek"
 
 ["Dot size"]
 en = "Dot size"
@@ -2249,6 +2398,7 @@ pt = "Tamanho do ponto"
 tr = "Nokta büyüklüğü"
 it = "Dimensione punto"
 id = "Ukuran titik"
+pl = "Rozmiar kropek"
 
 ["Dots"]
 en = "Dots"
@@ -2264,6 +2414,7 @@ pt = "Pontos"
 tr = "Noktalar"
 it = "Punti"
 id = "Titik-titik"
+pl = "Kropki"
 
 ["Downloading font family…"]
 en = "Downloading font family…"
@@ -2279,6 +2430,7 @@ pt = "Baixando família de fontes…"
 tr = "Yazı tipi ailesi indiriliyor…"
 it = "Download della famiglia di font…"
 id = "Mengunduh famili font…"
+pl = "Pobieranie rodziny czcionki.."
 
 ["Drag onto a visual clip in the timeline"]
 en = "Drag onto a visual clip in the timeline"
@@ -2294,6 +2446,7 @@ pt = "Arraste sobre um clipe visual na linha do tempo"
 tr = "Zaman çizelgesinde bir görsel klibin üzerine sürükle"
 it = "Trascina su un clip visivo nella timeline"
 id = "Tarik ke klip visual di lini masa"
+pl = "Upuść na klip wizualny w osi czasu"
 
 ["Drag onto a visual clip…"]
 en = "Drag onto a visual clip…"
@@ -2309,6 +2462,7 @@ pt = "Arraste sobre um clipe visual…"
 tr = "Bir görsel klibin üzerine sürükle…"
 it = "Trascina su un clip visivo…"
 id = "Tarik ke klip visual…"
+pl = "Upuść na klip wizualny…"
 
 ["Drawing"]
 en = "Drawing"
@@ -2324,6 +2478,7 @@ pt = "Desenho"
 tr = "Çizim"
 it = "Disegno"
 id = "Gambar"
+pl = "Rysowanie"
 
 ["Drive"]
 en = "Drive"
@@ -2339,6 +2494,7 @@ pt = "Drive"
 tr = "Sürme"
 it = "Drive"
 id = "Drive"
+pl = "Napęd"
 
 ["Duration"]
 en = "Duration"
@@ -2354,6 +2510,7 @@ pt = "Duração"
 tr = "Süre"
 it = "Durata"
 id = "Durasi"
+pl = "Czas trwania"
 
 ["Edge"]
 en = "Edge"
@@ -2369,6 +2526,7 @@ pt = "Borda"
 tr = "Kenar"
 it = "Bordo"
 id = "Tepi"
+pl = "Krawędź"
 
 ["Edge color"]
 en = "Edge color"
@@ -2384,6 +2542,7 @@ pt = "Cor da borda"
 tr = "Kenar rengi"
 it = "Colore bordo"
 id = "Warna tepi"
+pl = "Kolor krawędzi"
 
 ["Edge softness"]
 en = "Edge softness"
@@ -2399,6 +2558,7 @@ pt = "Suavidade da borda"
 tr = "Kenar yumuşaklığı"
 it = "Morbidezza bordo"
 id = "Kelembutan tepi"
+pl = "Miękkość krawędzi"
 
 ["Edge width"]
 en = "Edge width"
@@ -2414,6 +2574,7 @@ pt = "Largura da borda"
 tr = "Kenar genişliği"
 it = "Larghezza bordo"
 id = "Lebar tepi"
+pl = "Szerokość krawędzi"
 
 ["Edit after the shared beginning"]
 en = "Edit after the shared beginning"
@@ -2429,6 +2590,7 @@ pt = "Editar após o início compartilhado"
 tr = "Ortak giriş kısmından sonra düzenle"
 it = "Modifica dopo l'inizio condiviso"
 id = "Edit setelah awal bersama"
+pl = "Edytuj po wspólnym początku"
 
 ["Edit between the shared ends"]
 en = "Edit between the shared ends"
@@ -2444,6 +2606,7 @@ pt = "Editar entre as extremidades compartilhadas"
 tr = "Ortak bitişlerin arasında düzenle"
 it = "Modifica tra le estremità condivise"
 id = "Edit di antara akhir bersama"
+pl = "Edytuj między wspólnymi końcami"
 
 ["Edit only the changed characters"]
 en = "Edit only the changed characters"
@@ -2459,6 +2622,7 @@ pt = "Editar apenas os caracteres alterados"
 tr = "Sadece değişmiş karakterleri düzenle"
 it = "Modifica solo i caratteri cambiati"
 id = "Edit hanya karakter yang berubah"
+pl = "Edytuj tylko znaki, które się zmieniły"
 
 ["Effect strength"]
 en = "Effect strength"
@@ -2474,6 +2638,7 @@ pt = "Intensidade do efeito"
 tr = "Efekt gücü"
 it = "Intensità effetto"
 id = "Kekuatan efek"
+pl = "Siła efektu"
 
 ["Ellipse"]
 en = "Ellipse"
@@ -2489,6 +2654,7 @@ pt = "Elipse"
 tr = "Elips"
 it = "Ellisse"
 id = "Elips"
+pl = "Elipsa"
 
 ["Enable layout"]
 en = "Enable layout"
@@ -2504,6 +2670,7 @@ pt = "Habilitar layout"
 tr = "Düzeni etkinleştir"
 it = "Attiva layout"
 id = "Aktifkan tata letak"
+pl = "Włącz układ"
 
 ["Enable modifier"]
 en = "Enable modifier"
@@ -2519,6 +2686,7 @@ pt = "Habilitar modificador"
 tr = "Değiştiriciyi etkinleştir"
 it = "Attiva modificatore"
 id = "Aktifkan modifier"
+pl = "Włącz modyfikator"
 
 ["Enable styling"]
 en = "Enable styling"
@@ -2534,6 +2702,7 @@ pt = "Habilitar estilização"
 tr = "Stilleri etkinleştir"
 it = "Attiva stile"
 id = "Aktifkan gaya"
+pl = "Włącz stylizowanie"
 
 ["Enabled"]
 en = "Enabled"
@@ -2549,6 +2718,7 @@ pt = "Habilitado"
 tr = "Etkin"
 it = "Attivo"
 id = "Diaktifkan"
+pl = "Włączone"
 
 ["End cap"]
 en = "End cap"
@@ -2564,6 +2734,7 @@ pt = "Extremidade final"
 tr = "Bitiş ucu"
 it = "Estremità finale"
 id = "Ujung akhir"
+pl = "Zakończenie"
 
 ["End taper"]
 en = "End taper"
@@ -2579,6 +2750,7 @@ pt = "Afilamento final"
 tr = "Sona doğru sivriltme"
 it = "Cono finale"
 id = "Pengecilan akhir"
+pl = "Zwężenie końca"
 
 ["End taper distance"]
 en = "End taper distance"
@@ -2594,6 +2766,7 @@ pt = "Distância do afilamento final"
 tr = "Sona doğru sivriltme uzaklığı"
 it = "Distanza cono finale"
 id = "Jarak pengecilan akhir"
+pl = "Odległość zwężenia końca"
 
 ["Engine"]
 en = "Engine"
@@ -2609,6 +2782,7 @@ pt = "Motor"
 tr = "Motor"
 it = "Engine"
 id = "Mesin"
+pl = "Silnik"
 
 ["Enter a Google font family name"]
 en = "Enter a Google font family name"
@@ -2624,6 +2798,7 @@ pt = "Digite o nome de uma família do Google Fonts"
 tr = "Google Fonts yazı tipi ailesi ismi gir"
 it = "Inserisci il nome di una famiglia Google Fonts"
 id = "Masukkan nama famili Google Fonts"
+pl = "Wpisz nazwę rodziny czcionki Google"
 
 ["Environment"]
 en = "Environment"
@@ -2639,6 +2814,7 @@ pt = "Ambiente"
 tr = "Ortam"
 it = "Ambiente"
 id = "Lingkungan"
+pl = "Środowisko"
 
 ["Environment images"]
 en = "Environment images"
@@ -2654,6 +2830,7 @@ pt = "Imagens de ambiente"
 tr = "Ortam görselleri"
 it = "Immagini di ambiente"
 id = "Gambar lingkungan"
+pl = "Obrazy środowiska"
 
 ["Evolution"]
 en = "Evolution"
@@ -2669,6 +2846,7 @@ pt = "Evolução"
 tr = "Evrim"
 it = "Evoluzione"
 id = "Evolusi"
+pl = "Ewolucja"
 
 ["Evolve seed"]
 en = "Evolve seed"
@@ -2684,6 +2862,7 @@ pt = "Evoluir semente"
 tr = "Tohumu değiştir"
 it = "Evolvi seed"
 id = "Evolusikan seed"
+pl = "Ziarno ewolucji"
 
 ["Expand"]
 en = "Expand"
@@ -2699,6 +2878,7 @@ pt = "Expandir"
 tr = "Genişlet"
 it = "Espandi"
 id = "Perluas"
+pl = "Rozwiń"
 
 ["Exposure"]
 en = "Exposure"
@@ -2714,6 +2894,7 @@ pt = "Exposição"
 tr = "Pozlama"
 it = "Esposizione"
 id = "Eksposur"
+pl = "Ekspozycja"
 
 ["Expression"]
 en = "Expression"
@@ -2729,6 +2910,7 @@ pt = "Expressão"
 tr = "İfade"
 it = "Espressione"
 id = "Ekspresi"
+pl = "Wyrażenie"
 
 ["Extend edge"]
 en = "Extend edge"
@@ -2744,6 +2926,7 @@ pt = "Estender borda"
 tr = "Kenarı uzat"
 it = "Estendi bordo"
 id = "Perpanjang tepi"
+pl = "Rozszerz krawędź"
 
 ["FOV"]
 en = "FOV"
@@ -2759,6 +2942,7 @@ pt = "Campo de visão"
 tr = "Görüş Alanı"
 it = "FOV"
 id = "FOV"
+pl = "Pole widzenia (FOV)"
 
 ["FPS"]
 en = "FPS"
@@ -2774,6 +2958,7 @@ pt = "FPS"
 tr = "FPS"
 it = "FPS"
 id = "FPS"
+pl = "FPS"
 
 ["Fade"]
 en = "Fade"
@@ -2789,6 +2974,7 @@ pt = "Esmaecimento"
 tr = "Soldurma"
 it = "Fade"
 id = "Fade"
+pl = "Zanikanie"
 
 ["Fade length"]
 en = "Fade length"
@@ -2804,6 +2990,7 @@ pt = "Duração do esmaecimento"
 tr = "Soldurma uzunluğu"
 it = "Lunghezza fade"
 id = "Panjang fade"
+pl = "Długość zanikania"
 
 ["Fade one by one"]
 en = "Fade one by one"
@@ -2819,6 +3006,7 @@ pt = "Esmaecer um por um"
 tr = "Tek tek soldur"
 it = "Fade uno per uno"
 id = "Fade satu per satu"
+pl = "Zanikaj jeden po jednym"
 
 ["Fade opacity"]
 en = "Fade opacity"
@@ -2834,6 +3022,7 @@ pt = "Opacidade do esmaecimento"
 tr = "Soldurma opaklığı"
 it = "Opacità fade"
 id = "Opasitas fade"
+pl = "Nieprzezroczystość zanikania"
 
 ["Fade together"]
 en = "Fade together"
@@ -2849,6 +3038,7 @@ pt = "Esmaecer juntos"
 tr = "Beraber soldur"
 it = "Fondi insieme"
 id = "Fade bersama"
+pl = "Zanikaj razem"
 
 ["Fade-through color"]
 en = "Fade-through color"
@@ -2864,6 +3054,7 @@ pt = "Cor do esmaecimento"
 tr = "Geçiş rengi"
 it = "Colore di dissolvenza"
 id = "Warna fade-through"
+pl = "Kolor przejścia"
 
 ["Feather"]
 en = "Feather"
@@ -2879,6 +3070,7 @@ pt = "Difusão"
 tr = "Yumuşatma"
 it = "Sfumatura"
 id = "Feather"
+pl = "Pióro"
 
 ["Feedback"]
 en = "Feedback"
@@ -2894,6 +3086,7 @@ pt = "Realimentação"
 tr = "Geri besleme"
 it = "Feedback"
 id = "Umpan balik"
+pl = "Informacja zwrotna"
 
 ["File Location"]
 en = "File Location"
@@ -2909,6 +3102,7 @@ pt = "Local do arquivo"
 tr = "Dosya Konumu"
 it = "Posizione file"
 id = "Lokasi Berkas"
+pl = "Lokalizacja pliku"
 
 ["Fill"]
 en = "Fill"
@@ -2924,6 +3118,7 @@ pt = "Preenchimento"
 tr = "Doldur"
 it = "Riempi"
 id = "Isian"
+pl = "Wypełnienie"
 
 ["Fill color %{number}"]
 en = "Fill color %{number}"
@@ -2939,6 +3134,7 @@ pt = "Cor de preenchimento %{number}"
 tr = "Dolgu rengi %{number}"
 it = "Colore riempimento %{number}"
 id = "Warna isian %{number}"
+pl = "Kolor wypełnienia %{number}"
 
 ["Flipped"]
 en = "Flipped"
@@ -2954,6 +3150,7 @@ pt = "Invertido"
 tr = "Tersine Çevrilmiş"
 it = "Capovolto"
 id = "Dibalik"
+pl = "Odwrócone"
 
 ["Focal length"]
 en = "Focal length"
@@ -2969,6 +3166,7 @@ pt = "Distância focal"
 tr = "Odak uzaklığı"
 it = "Lunghezza focale"
 id = "Panjang fokus"
+pl = "Ogniskowa"
 
 ["Focus distance (0 = off)"]
 en = "Focus distance (0 = off)"
@@ -2984,6 +3182,7 @@ pt = "Distância de foco (0 = desativado)"
 tr = "Odak mesafesi (0 = kapalı)"
 it = "Distanza messa a fuoco (0 = disattivato)"
 id = "Jarak fokus (0 = mati)"
+pl = "Odległość fokusu (0 = wyłączone)"
 
 ["Fold depth"]
 en = "Fold depth"
@@ -2999,6 +3198,7 @@ pt = "Profundidade da dobra"
 tr = "Katlama derinliği"
 it = "Profondità piegatura"
 id = "Kedalaman lipatan"
+pl = "Głębokość złożenia"
 
 ["Fold size"]
 en = "Fold size"
@@ -3014,6 +3214,7 @@ pt = "Tamanho da dobra"
 tr = "Katlama boyutu"
 it = "Dimensione piegatura"
 id = "Ukuran lipatan"
+pl = "Rozmiar złożenia"
 
 ["Folded Sequence"]
 en = "Folded Sequence"
@@ -3029,6 +3230,7 @@ pt = "Sequência recolhida"
 tr = "Katlanmış sekans"
 it = "Sequenza piegata"
 id = "Urutan Terlipat"
+pl = "Sekwencja zwinięta"
 
 ["Font"]
 en = "Font"
@@ -3044,6 +3246,7 @@ pt = "Fonte"
 tr = "Yazı Tipi"
 it = "Font"
 id = "Font"
+pl = "Czcionka"
 
 ["Font size"]
 en = "Font size"
@@ -3059,6 +3262,7 @@ pt = "Tamanho da fonte"
 tr = "Yazı tipi boyutu"
 it = "Dimensione font"
 id = "Ukuran font"
+pl = "Rozmiar czcionki"
 
 ["Font weight"]
 en = "Font weight"
@@ -3074,6 +3278,7 @@ pt = "Peso da fonte"
 tr = "Yazı tipi kalınlığı"
 it = "Peso font"
 id = "Ketebalan font"
+pl = "Waga czcionki"
 
 ["Fonts"]
 en = "Fonts"
@@ -3089,6 +3294,7 @@ pt = "Fontes"
 tr = "Yazı Tipleri"
 it = "Fonts"
 id = "Font"
+pl = "Czcionki"
 
 ["Formant shift"]
 en = "Formant shift"
@@ -3104,6 +3310,7 @@ pt = "Deslocamento de formantes"
 tr = "Formant kaydırma"
 it = "Spostamento formanti"
 id = "Pergeseran forman"
+pl = "Przesunięcie formantu"
 
 ["Frequency"]
 en = "Frequency"
@@ -3119,6 +3326,7 @@ pt = "Frequência"
 tr = "Frekans"
 it = "Frequenza"
 id = "Frekuensi"
+pl = "Częstotliwość"
 
 ["Fresnel contour"]
 en = "Fresnel contour"
@@ -3133,6 +3341,7 @@ ja = "フレネル輪郭"
 pt = "Contorno de Fresnel"
 it = "Contorno Fresnel"
 id = "Kontur Fresnel"
+pl = "Kontur Fresnela"
 
 ["From inside"]
 en = "From inside"
@@ -3147,6 +3356,7 @@ ja = "内側から"
 pt = "De dentro"
 it = "Da dentro"
 id = "Dari dalam"
+pl = "Ze środka"
 
 ["From outside"]
 en = "From outside"
@@ -3161,6 +3371,7 @@ ja = "外側から"
 pt = "De fora"
 it = "Da fuori"
 id = "Dari luar"
+pl = "Z zewnątrz"
 
 ["Gamma"]
 en = "Gamma"
@@ -3175,6 +3386,7 @@ ja = "ガンマ"
 pt = "Gama"
 it = "Gamma"
 id = "Gamma"
+pl = "Gamma"
 
 ["Generator"]
 en = "Generator"
@@ -3189,6 +3401,7 @@ ja = "ジェネレーター"
 pt = "Gerador"
 it = "Generatore"
 id = "Generator"
+pl = "Generator"
 
 ["Glow / outline"]
 en = "Glow / outline"
@@ -3203,6 +3416,7 @@ ja = "グロー / アウトライン"
 pt = "Brilho / contorno"
 it = "Bagliore / contorno"
 id = "Pijar / garis luar"
+pl = "Poświata / kontur"
 
 ["Gradient step"]
 en = "Gradient step"
@@ -3217,6 +3431,7 @@ ja = "グラデーション段階"
 pt = "Passo do gradiente"
 it = "Passo gradiente"
 id = "Langkah gradien"
+pl = "Rozmiar kroku gradientu"
 
 ["Grain size"]
 en = "Grain size"
@@ -3231,6 +3446,7 @@ ja = "粒子サイズ"
 pt = "Tamanho do grão"
 it = "Dimensione grana"
 id = "Ukuran butiran"
+pl = "Rozmiar ziarna"
 
 ["Ground intensity"]
 en = "Ground intensity"
@@ -3245,6 +3461,7 @@ ja = "地面の強度"
 pt = "Intensidade do chão"
 it = "Intensità terreno"
 id = "Intensitas dasar"
+pl = "Intensywność przyziemna"
 
 ["H align"]
 en = "H align"
@@ -3259,6 +3476,7 @@ ja = "水平揃え"
 pt = "Alinhamento H"
 it = "Allinea H"
 id = "Perataan H"
+pl = "Wyrównanie poziome"
 
 ["Hard shadow"]
 en = "Hard shadow"
@@ -3273,6 +3491,7 @@ ja = "ハードシャドウ"
 pt = "Sombra dura"
 it = "Ombra dura"
 id = "Bayangan tajam"
+pl = "Ostry cień"
 
 ["Head length"]
 en = "Head length"
@@ -3287,6 +3506,7 @@ ja = "先端の長さ"
 pt = "Comprimento da ponta"
 it = "Lunghezza punta"
 id = "Panjang kepala"
+pl = "Długość końcówki"
 
 ["Heart"]
 en = "Heart"
@@ -3301,6 +3521,7 @@ ja = "ハート"
 pt = "Coração"
 it = "Cuore"
 id = "Hati"
+pl = "Serce"
 
 ["Hexagon"]
 en = "Hexagon"
@@ -3315,6 +3536,7 @@ ja = "六角形"
 pt = "Hexágono"
 it = "Esagono"
 id = "Heksagon"
+pl = "Sześciokąt"
 
 ["Hierarchy"]
 en = "Hierarchy"
@@ -3329,6 +3551,7 @@ ja = "階層"
 pt = "Hierarquia"
 it = "Gerarchia"
 id = "Hierarki"
+pl = "Hierarchia"
 
 ["High"]
 en = "High"
@@ -3343,6 +3566,7 @@ ja = "高"
 pt = "Alto"
 it = "Alto"
 id = "Tinggi"
+pl = "Wysokie"
 
 ["High color"]
 en = "High color"
@@ -3357,6 +3581,7 @@ ja = "高域色"
 pt = "Cor alta"
 it = "Colore alto"
 id = "Warna tinggi"
+pl = "Wysoki kolor"
 
 ["High-pass"]
 en = "High-pass"
@@ -3371,6 +3596,7 @@ ja = "ハイパス"
 pt = "Passa-altas"
 it = "Passa-alti"
 id = "High-pass"
+pl = "Górno Przepustowość"
 
 ["Highlight color"]
 en = "Highlight color"
@@ -3385,6 +3611,7 @@ ja = "ハイライト色"
 pt = "Cor de destaque"
 it = "Colore evidenziazione"
 id = "Warna sorotan"
+pl = "Kolor podświetlenia"
 
 ["Horizontal"]
 en = "Horizontal"
@@ -3399,6 +3626,7 @@ ja = "水平"
 pt = "Horizontal"
 it = "Orizzontale"
 id = "Horizontal"
+pl = "Poziome"
 
 ["Horizontal alignment"]
 en = "Horizontal alignment"
@@ -3413,6 +3641,7 @@ ja = "水平揃え"
 pt = "Alinhamento horizontal"
 it = "Allineamento orizzontale"
 id = "Perataan horizontal"
+pl = "Wyrównanie poziome"
 
 ["Hue position"]
 en = "Hue position"
@@ -3427,6 +3656,7 @@ ja = "色相位置"
 pt = "Posição do matiz"
 it = "Posizione tono"
 id = "Posisi rona"
+pl = "Pozycja odcienia"
 
 ["Image"]
 en = "Image"
@@ -3441,6 +3671,7 @@ ja = "画像"
 pt = "Imagem"
 it = "Immagine"
 id = "Gambar"
+pl = "Obraz"
 
 ["Images"]
 en = "Images"
@@ -3455,6 +3686,7 @@ ja = "画像"
 pt = "Imagens"
 it = "Immagini"
 id = "Gambar"
+pl = "Obrazy"
 
 ["Immediate"]
 en = "Immediate"
@@ -3469,6 +3701,7 @@ ja = "即時"
 pt = "Imediato"
 it = "Immediato"
 id = "Langsung"
+pl = "Natychmiastowe"
 
 ["Include this track in playback and export"]
 en = "Include this track in playback and export"
@@ -3483,6 +3716,7 @@ ja = "再生と書き出しにこのトラックを含める"
 pt = "Incluir esta faixa na reprodução e exportação"
 it = "Includi questa traccia in riproduzione ed esportazione"
 id = "Sertakan trek ini dalam pemutaran dan ekspor"
+pl = "Dodaj tą ścieżkę do odtwarzania i eksportu"
 
 ["Index of refraction"]
 en = "Index of refraction"
@@ -3497,6 +3731,7 @@ ja = "屈折率"
 pt = "Índice de refração"
 it = "Indice di rifrazione"
 id = "Indeks bias"
+pl = "Indeks refrakcji"
 
 ["Infinite"]
 en = "Infinite"
@@ -3511,6 +3746,7 @@ ja = "無限"
 pt = "Infinito"
 it = "Infinito"
 id = "Tak terhingga"
+pl = "Nieskończone"
 
 ["Inner radius"]
 en = "Inner radius"
@@ -3525,6 +3761,7 @@ ja = "内半径"
 pt = "Raio interno"
 it = "Raggio interno"
 id = "Radius dalam"
+pl = "Promień wewnętrzny"
 
 ["Intensity"]
 en = "Intensity"
@@ -3539,6 +3776,7 @@ ja = "強度"
 pt = "Intensidade"
 it = "Intensità"
 id = "Intensitas"
+pl = "Intensywność"
 
 ["Intro"]
 en = "Intro"
@@ -3553,6 +3791,7 @@ ja = "イントロ"
 pt = "Introdução"
 it = "Intro"
 id = "Intro"
+pl = "Wstęp"
 
 ["Invert"]
 en = "Invert"
@@ -3567,6 +3806,7 @@ ja = "反転"
 pt = "Inverter"
 it = "Inverti"
 id = "Balikkan"
+pl = "Inwertuj"
 
 ["Iris"]
 en = "Iris"
@@ -3581,6 +3821,7 @@ ja = "アイリス"
 pt = "Íris"
 it = "Iride"
 id = "Iris"
+pl = "Irys"
 
 ["Italic"]
 en = "Italic"
@@ -3595,6 +3836,7 @@ ja = "斜体"
 pt = "Itálico"
 it = "Corsivo"
 id = "Miring"
+pl = "Italika"
 
 ["Items"]
 en = "Items"
@@ -3609,6 +3851,7 @@ ja = "項目"
 pt = "Itens"
 it = "Elementi"
 id = "Item"
+pl = "Elementy"
 
 ["Jitter"]
 en = "Jitter"
@@ -3623,6 +3866,7 @@ ja = "ジッター"
 pt = "Instabilidade"
 it = "Jitter"
 id = "Jitter"
+pl = "Drganie"
 
 ["Key color"]
 en = "Key color"
@@ -3637,6 +3881,7 @@ ja = "キーカラー"
 pt = "Cor-chave"
 it = "Colore chiave"
 id = "Warna kunci"
+pl = "Kolor kluczowy"
 
 ["Keyframes"]
 en = "Keyframes"
@@ -3651,6 +3896,7 @@ ja = "キーフレーム"
 pt = "Quadros-chave"
 it = "Keyframes"
 id = "Keyframe"
+pl = "Klatki kluczowe"
 
 ["Kind"]
 en = "Kind"
@@ -3665,6 +3911,7 @@ ja = "種類"
 pt = "Tipo"
 it = "Tipo"
 id = "Jenis"
+pl = "Typ"
 
 ["Kuwahara radius"]
 en = "Kuwahara radius"
@@ -3679,6 +3926,7 @@ ja = "Kuwahara半径"
 pt = "Raio Kuwahara"
 it = "Raggio Kuwahara"
 id = "Radius Kuwahara"
+pl = "Promień Kuwahara"
 
 ["Kuwahara strength"]
 en = "Kuwahara strength"
@@ -3693,6 +3941,7 @@ ja = "Kuwahara強度"
 pt = "Intensidade Kuwahara"
 it = "Intensità Kuwahara"
 id = "Kekuatan Kuwahara"
+pl = "Siła Kuwahara"
 
 ["Lacunarity"]
 en = "Lacunarity"
@@ -3707,6 +3956,7 @@ ja = "ラキュナリティ"
 pt = "Lacunaridade"
 it = "Lacunarità"
 id = "Lakunaritas"
+pl = "Lakunarność"
 
 ["Layered Image"]
 en = "Layered Image"
@@ -3721,6 +3971,7 @@ ja = "レイヤー画像"
 pt = "Imagem em camadas"
 it = "Immagine su livelli"
 id = "Gambar Berlapis"
+pl = "Obraz z warstwami"
 
 ["Layers"]
 en = "Layers"
@@ -3735,6 +3986,7 @@ ja = "レイヤー"
 pt = "Camadas"
 it = "Livelli"
 id = "Lapisan"
+pl = "Warstwy"
 
 ["Layout"]
 en = "Layout"
@@ -3749,6 +4001,7 @@ ja = "レイアウト"
 pt = "Layout"
 it = "Layout"
 id = "Tata letak"
+pl = "Układ"
 
 ["Language"]
 en = "Language"
@@ -3763,6 +4016,7 @@ ko = "언어"
 pt = "Idioma"
 it = "Lingua"
 id = "Bahasa"
+pl = "Język"
 
 ["Left"]
 en = "Left"
@@ -3777,6 +4031,7 @@ ja = "左"
 pt = "Esquerda"
 it = "Sinistra"
 id = "Kiri"
+pl = "Lewo"
 
 ["Length randomness"]
 en = "Length randomness"
@@ -3791,6 +4046,7 @@ ja = "長さのランダム性"
 pt = "Aleatoriedade do comprimento"
 it = "Casualità lunghezza"
 id = "Keacakan panjang"
+pl = "Losowość długości"
 
 ["Length timing"]
 en = "Length timing"
@@ -3805,6 +4061,7 @@ ja = "長さのタイミング"
 pt = "Temporização do comprimento"
 it = "Timing lunghezza"
 id = "Pewaktuan panjang"
+pl = "Wpływ długości na czas"
 
 ["Letter"]
 en = "Letter"
@@ -3819,6 +4076,7 @@ ja = "文字"
 pt = "Letra"
 it = "Lettera"
 id = "Huruf"
+pl = "Litera"
 
 ["Level"]
 en = "Level"
@@ -3833,6 +4091,7 @@ ja = "レベル"
 pt = "Nível"
 it = "Livello"
 id = "Level"
+pl = "Poziom"
 
 ["Levels"]
 en = "Levels"
@@ -3847,6 +4106,7 @@ ja = "レベル"
 pt = "Níveis"
 it = "Livelli"
 id = "Level"
+pl = "Poziomy"
 
 ["Light bands"]
 en = "Light bands"
@@ -3861,6 +4121,7 @@ ja = "明部バンド"
 pt = "Faixas claras"
 it = "Bande luce"
 id = "Pita cahaya"
+pl = "Jasne pasma"
 
 ["Line count"]
 en = "Line count"
@@ -3875,6 +4136,7 @@ ja = "ライン数"
 pt = "Número de linhas"
 it = "Numero linee"
 id = "Jumlah garis"
+pl = "Liczba wiersza"
 
 ["Line density"]
 en = "Line density"
@@ -3889,6 +4151,7 @@ ja = "ライン密度"
 pt = "Densidade de linhas"
 it = "Densità linee"
 id = "Kepadatan garis"
+pl = "Zwartość wiersza"
 
 ["Line direction"]
 en = "Line direction"
@@ -3903,6 +4166,7 @@ ja = "ライン方向"
 pt = "Direção das linhas"
 it = "Direzione linee"
 id = "Arah garis"
+pl = "Kierunek wiersza"
 
 ["Line height"]
 en = "Line height"
@@ -3917,6 +4181,7 @@ ja = "行の高さ"
 pt = "Altura da linha"
 it = "Altezza linea"
 id = "Tinggi baris"
+pl = "Wysokość wiersza"
 
 ["Line length"]
 en = "Line length"
@@ -3931,6 +4196,7 @@ ja = "ライン長"
 pt = "Comprimento da linha"
 it = "Lunghezza linea"
 id = "Panjang garis"
+pl = "Długość wiersza"
 
 ["Line offset"]
 en = "Line offset"
@@ -3945,6 +4211,7 @@ ja = "ラインオフセット"
 pt = "Deslocamento de linha"
 it = "Offset linea"
 id = "Ofset garis"
+pl = "Przesunięcie wiersza"
 
 ["Line style"]
 en = "Line style"
@@ -3959,6 +4226,7 @@ ja = "ラインスタイル"
 pt = "Estilo de linha"
 it = "Stile linea"
 id = "Gaya garis"
+pl = "Styl wiersza"
 
 ["Line width"]
 en = "Line width"
@@ -3973,6 +4241,7 @@ ja = "線幅"
 pt = "Largura da linha"
 it = "Larghezza linea"
 id = "Lebar garis"
+pl = ""
 
 ["Linear"]
 en = "Linear"
@@ -3987,6 +4256,7 @@ ja = "線形"
 pt = "Linear"
 it = "Lineare"
 id = "Linier"
+pl = "Liniowe"
 
 ["Lines"]
 en = "Lines"
@@ -4001,6 +4271,7 @@ ja = "ライン"
 pt = "Linhas"
 it = "Linee"
 id = "Garis"
+pl = "Wiersze"
 
 ["Link stereo channels"]
 en = "Link stereo channels"
@@ -4015,6 +4286,7 @@ ja = "ステレオチャンネルをリンク"
 pt = "Vincular canais estéreo"
 it = "Collega canali stereo"
 id = "Tautkan saluran stereo"
+pl = "Połącz kanały stereo"
 
 ["Loading cached font…"]
 en = "Loading cached font…"
@@ -4029,6 +4301,7 @@ ja = "キャッシュ済みフォントを読み込み中…"
 pt = "Carregando fonte em cache…"
 it = "Caricamento font in cache…"
 id = "Memuat font cache…"
+pl = "Ładowanie czcionki z pamięci cache…"
 
 ["Loading cameras…"]
 en = "Loading cameras…"
@@ -4043,6 +4316,7 @@ ja = "カメラを読み込み中…"
 pt = "Carregando câmeras…"
 it = "Caricamento telecamere…"
 id = "Memuat kamera…"
+pl = "Ładowanie kamer…"
 
 ["Loading installed fonts…"]
 en = "Loading installed fonts…"
@@ -4057,6 +4331,7 @@ ja = "インストール済みフォントを読み込み中…"
 pt = "Carregando fontes instaladas…"
 it = "Caricamento font installati…"
 id = "Memuat font terpasang…"
+pl = "Ładowanie zainstalowanych czcionek…"
 
 ["Loading scenes..."]
 en = "Loading scenes..."
@@ -4071,6 +4346,7 @@ ja = "シーンを読み込み中..."
 pt = "Carregando cenas..."
 it = "Caricamento scene..."
 id = "Memuat adegan..."
+pl = "Ładowanie scen..."
 
 ["Loading scenes…"]
 en = "Loading scenes…"
@@ -4085,6 +4361,7 @@ ja = "シーンを読み込み中…"
 pt = "Carregando cenas…"
 it = "Caricamento scene…"
 id = "Memuat adegan…"
+pl = "Ładowanie scen…"
 
 ["Loading tracking model"]
 en = "Loading tracking model"
@@ -4099,6 +4376,7 @@ ja = "トラッキングモデルを読み込み中"
 pt = "Carregando modelo de rastreamento"
 it = "Caricamento modello tracking"
 id = "Memuat model pelacakan"
+pl = "Ładowanie modelu śledzącego ruch"
 
 ["Loading view layers…"]
 en = "Loading view layers…"
@@ -4113,6 +4391,7 @@ ja = "ビューレイヤーを読み込み中…"
 pt = "Carregando camadas de visualização…"
 it = "Caricamento livelli vista…"
 id = "Memuat lapisan tampilan…"
+pl = "Ładowanie warstw widoku…"
 
 ["Low"]
 en = "Low"
@@ -4127,6 +4406,7 @@ ja = "低"
 pt = "Baixo"
 it = "Basso"
 id = "Rendah"
+pl = "Niskie"
 
 ["Low color"]
 en = "Low color"
@@ -4141,6 +4421,7 @@ ja = "低域色"
 pt = "Cor baixa"
 it = "Colore basso"
 id = "Warna rendah"
+pl = "Niski kolor"
 
 ["Low latency"]
 en = "Low latency"
@@ -4155,6 +4436,7 @@ ja = "低レイテンシ"
 pt = "Baixa latência"
 it = "Bassa latenza"
 id = "Latensi rendah"
+pl = "Niskie opóźnienie"
 
 ["Low-pass"]
 en = "Low-pass"
@@ -4169,6 +4451,7 @@ ja = "ローパス"
 pt = "Passa-baixas"
 it = "Passa-bassi"
 id = "Low-pass"
+pl = "Filtr Dolnoprzepustowy"
 
 ["Maintain pitch while changing speed"]
 en = "Maintain pitch while changing speed"
@@ -4183,6 +4466,7 @@ ja = "速度変更時にピッチを維持"
 pt = "Manter o tom ao alterar a velocidade"
 it = "Mantieni l'altezza mentre cambi la velocità"
 id = "Pertahankan titinada saat mengubah kecepatan"
+pl = "Zachowaj wysokość dźwięku podczas zmieniania prędkości"
 
 ["Makeup"]
 en = "Makeup"
@@ -4197,6 +4481,7 @@ ja = "メイクアップ"
 pt = "Compensação"
 it = "Compensazione"
 id = "Makeup"
+pl = "Makijaż"
 
 ["Mask"]
 en = "Mask"
@@ -4211,6 +4496,7 @@ ja = "マスク"
 pt = "Máscara"
 it = "Maschera"
 id = "Mask"
+pl = "Maska"
 
 ["Mask strength"]
 en = "Mask strength"
@@ -4225,6 +4511,7 @@ ja = "マスク強度"
 pt = "Intensidade da máscara"
 it = "Intensità maschera"
 id = "Kekuatan masker"
+pl = "Siła maski"
 
 ["Material Preview"]
 en = "Material Preview"
@@ -4239,6 +4526,7 @@ ja = "マテリアルプレビュー"
 pt = "Pré-visualização de material"
 it = "Anteprima materiale"
 id = "Pratinjau Material"
+pl = "Podgląd materiału"
 
 ["Max iterations"]
 en = "Max iterations"
@@ -4253,6 +4541,7 @@ ja = "最大反復回数"
 pt = "Iterações máximas"
 it = "Iterazioni massime"
 id = "Iterasi maks"
+pl = "Maksymalna ilość iteracji"
 
 ["Maximum block size"]
 en = "Maximum block size"
@@ -4267,6 +4556,7 @@ ja = "最大ブロックサイズ"
 pt = "Tamanho máximo de bloco"
 it = "Dimensione massima blocco"
 id = "Ukuran blok maksimum"
+pl = "Maksymalny rozmiar bloku"
 
 ["Maximum directions"]
 en = "Maximum directions"
@@ -4281,6 +4571,7 @@ ja = "最大方向数"
 pt = "Direções máximas"
 it = "Direzioni massime"
 id = "Arah maksimum"
+pl = "Maksymalne kierunki"
 
 ["Maximum gap"]
 en = "Maximum gap"
@@ -4295,6 +4586,7 @@ ja = "最大間隔"
 pt = "Espaço máximo"
 it = "Spazio massimo"
 id = "Celah maksimum"
+pl = "Maksymalny odstęp"
 
 ["Maximum radius"]
 en = "Maximum radius"
@@ -4309,6 +4601,7 @@ ja = "最大半径"
 pt = "Raio máximo"
 it = "Raggio massimo"
 id = "Radius maksimum"
+pl = "Maksymalny promień"
 
 ["Mesh columns"]
 en = "Mesh columns"
@@ -4323,6 +4616,7 @@ ja = "メッシュ列"
 pt = "Colunas da malha"
 it = "Colonne mesh"
 id = "Kolom mesh"
+pl = "Kolumny siatki"
 
 ["Mesh rows"]
 en = "Mesh rows"
@@ -4337,6 +4631,7 @@ ja = "メッシュ行"
 pt = "Linhas da malha"
 it = "Righe mesh"
 id = "Baris mesh"
+pl = "Wiersze siatki"
 
 ["Metallic"]
 en = "Metallic"
@@ -4351,6 +4646,7 @@ ja = "メタリック"
 pt = "Metálico"
 it = "Metallico"
 id = "Metalik"
+pl = "Metaliczne"
 
 ["Method"]
 en = "Method"
@@ -4365,6 +4661,7 @@ ja = "方式"
 pt = "Método"
 it = "Metodo"
 id = "Metode"
+pl = "Metoda"
 
 ["Metric"]
 en = "Metric"
@@ -4379,6 +4676,7 @@ ja = "メトリック"
 pt = "Métrica"
 it = "Metrica"
 id = "Metrik"
+pl = "Metryczne"
 
 ["Mid"]
 en = "Mid"
@@ -4393,6 +4691,7 @@ ja = "中域"
 pt = "Médios"
 it = "Medie"
 id = "Tengah"
+pl = "Średnie"
 
 ["Middle"]
 en = "Middle"
@@ -4407,6 +4706,7 @@ ja = "中央"
 pt = "Meio"
 it = "Centro"
 id = "Tengah"
+pl = "Środek"
 
 ["Middle padding"]
 en = "Middle padding"
@@ -4421,6 +4721,7 @@ ja = "中央余白"
 pt = "Preenchimento central"
 it = "Margine centrale"
 id = "Padding tengah"
+pl = "Odstęp środka"
 
 ["Midpoint"]
 en = "Midpoint"
@@ -4435,6 +4736,7 @@ ja = "中間点"
 pt = "Ponto médio"
 it = "Punto medio"
 id = "Titik tengah"
+pl = "Punkt środkowy"
 
 ["Mirror"]
 en = "Mirror"
@@ -4449,6 +4751,7 @@ ja = "ミラー"
 pt = "Espelhar"
 it = "Specchia"
 id = "Cermin"
+pl = "Lustro"
 
 ["Mix"]
 en = "Mix"
@@ -4463,6 +4766,7 @@ ja = "ミックス"
 pt = "Mistura"
 it = "Miscola"
 id = "Mix"
+pl = "Miks"
 
 ["Mode"]
 en = "Mode"
@@ -4477,6 +4781,7 @@ ja = "モード"
 pt = "Modo"
 it = "Modalità"
 id = "Mode"
+pl = "Tryb"
 
 ["Morph"]
 en = "Morph"
@@ -4491,6 +4796,7 @@ ja = "モーフ"
 pt = "Morph"
 it = "Morph"
 id = "Morph"
+pl = "Przekształć"
 
 ["Morph by"]
 en = "Morph by"
@@ -4505,6 +4811,7 @@ ja = "モーフ単位"
 pt = "Transformar por"
 it = "Morph per"
 id = "Morph berdasarkan"
+pl = "Przekształć o"
 
 ["Motion amount"]
 en = "Motion amount"
@@ -4519,6 +4826,7 @@ ja = "モーション量"
 pt = "Quantidade de movimento"
 it = "Quantità movimento"
 id = "Jumlah gerakan"
+pl = "Ilość ruchu"
 
 ["Motion blur"]
 en = "Motion blur"
@@ -4533,6 +4841,7 @@ ja = "モーションブラー"
 pt = "Desfoque de movimento"
 it = "Motion blur"
 id = "Motion blur"
+pl = "Rozmycie ruchu"
 
 ["Motion position"]
 en = "Motion position"
@@ -4547,6 +4856,7 @@ ja = "モーション位置"
 pt = "Posição do movimento"
 it = "Posizione movimento"
 id = "Posisi gerakan"
+pl = "Pozycja ruchu"
 
 ["Motion-dependent temporal smoothing model"]
 en = "Motion-dependent temporal smoothing model"
@@ -4561,6 +4871,7 @@ ja = "動きに応じた時間平滑化モデル"
 pt = "Modelo de suavização temporal dependente de movimento"
 it = "Modello di smoothing temporale dipendente dal movimento"
 id = "Model penghalusan temporal bergantung gerakan"
+pl = "Model wygładzania temporalnego zależy od ruchu"
 
 ["Move down"]
 en = "Move down"
@@ -4575,6 +4886,7 @@ ja = "下へ移動"
 pt = "Mover para baixo"
 it = "Sposta in basso"
 id = "Pindahkan ke bawah"
+pl = "Przenieś do dołu"
 
 ["Move up"]
 en = "Move up"
@@ -4589,6 +4901,7 @@ ja = "上へ移動"
 pt = "Mover para cima"
 it = "Sposta in alto"
 id = "Pindahkan ke atas"
+pl = "Przenieś do góry"
 
 ["Name"]
 en = "Name"
@@ -4603,6 +4916,7 @@ ja = "名前"
 pt = "Nome"
 it = "Nome"
 id = "Nama"
+pl = "Imię"
 
 ["Natural Duration"]
 en = "Natural Duration"
@@ -4617,6 +4931,7 @@ ja = "元の長さ"
 pt = "Duração natural"
 it = "Durata naturale"
 id = "Durasi Alami"
+pl = "Czas trwania naturalny"
 
 ["Neighboring frames considered on each side"]
 en = "Neighboring frames considered on each side"
@@ -4631,6 +4946,7 @@ ja = "両側で考慮する隣接フレーム"
 pt = "Quadros vizinhos considerados em cada lado"
 it = "Fotogrammi adiacenti considerati su ciascun lato"
 id = "Bingkai tetangga yang dipertimbangkan di setiap sisi"
+pl = "Sąsiadujące klatki brane pod uwagę z obu stron"
 
 ["Next keyframe"]
 en = "Next keyframe"
@@ -4645,6 +4961,7 @@ ja = "次のキーフレーム"
 pt = "Próximo quadro-chave"
 it = "Keyframe successivo"
 id = "Keyframe berikutnya"
+pl = "Następna klatka kluczowa"
 
 ["Noise evolution"]
 en = "Noise evolution"
@@ -4659,6 +4976,7 @@ ja = "ノイズ変化"
 pt = "Evolução do ruído"
 it = "Evoluzione rumore"
 id = "Evolusi derau"
+pl = "Ewolucja szumu"
 
 ["Noise seed"]
 en = "Noise seed"
@@ -4673,6 +4991,7 @@ ja = "ノイズシード"
 pt = "Semente do ruído"
 it = "Seed rumore"
 id = "Seed derau"
+pl = "Ziarno szumu"
 
 ["Normal"]
 en = "Normal"
@@ -4687,6 +5006,7 @@ ja = "標準"
 pt = "Normal"
 it = "Normale"
 id = "Normal"
+pl = "Normalne"
 
 ["Normal angle"]
 en = "Normal angle"
@@ -4701,6 +5021,7 @@ ja = "法線角度"
 pt = "Ângulo da normal"
 it = "Angolo normale"
 id = "Sudut normal"
+pl = "Normalny kąt"
 
 ["Normals"]
 en = "Normals"
@@ -4715,6 +5036,7 @@ ja = "法線"
 pt = "Normais"
 it = "Normali"
 id = "Normal"
+pl = "Normalne"
 
 ["Not analyzed"]
 en = "Not analyzed"
@@ -4729,6 +5051,7 @@ ja = "未解析"
 pt = "Não analisado"
 it = "Non analizzato"
 id = "Belum dianalisis"
+pl = "Nie przeanalizowane"
 
 ["Number of independently moving cell columns"]
 en = "Number of independently moving cell columns"
@@ -4743,6 +5066,7 @@ ja = "独立して動くセル列の数"
 pt = "Número de colunas de células com movimento independente"
 it = "Numero di colonne di celle con movimento indipendente"
 id = "Jumlah kolom sel yang bergerak independen"
+pl = "Ilość niezależnie ruszających się kolumn komórek"
 
 ["Number of independently moving cell rows"]
 en = "Number of independently moving cell rows"
@@ -4757,6 +5081,7 @@ ja = "独立して動くセル行の数"
 pt = "Número de linhas de células com movimento independente"
 it = "Numero di righe di celle con movimento indipendente"
 id = "Jumlah baris sel yang bergerak independen"
+pl = "Ilość niezależnie ruszających się wierszy komórek"
 
 ["Octagon"]
 en = "Octagon"
@@ -4771,6 +5096,7 @@ ja = "八角形"
 pt = "Octógono"
 it = "Ottagono"
 id = "Oktagon"
+pl = "Ośmiokąt"
 
 ["Octaves"]
 en = "Octaves"
@@ -4785,6 +5111,7 @@ ja = "オクターブ"
 pt = "Oitavas"
 it = "Ottave"
 id = "Oktaf"
+pl = "Oktawy"
 
 ["Off"]
 en = "Off"
@@ -4799,6 +5126,7 @@ ja = "オフ"
 pt = "Desativado"
 it = "Spento"
 id = "Mati"
+pl = "Wyłączone"
 
 ["Offset"]
 en = "Offset"
@@ -4813,6 +5141,7 @@ ja = "オフセット"
 pt = "Deslocamento"
 it = "Offset"
 id = "Ofset"
+pl = "Przesunięcie"
 
 ["Offset axis"]
 en = "Offset axis"
@@ -4827,6 +5156,7 @@ ja = "オフセット軸"
 pt = "Eixo de deslocamento"
 it = "Asse offset"
 id = "Sumbu ofset"
+pl = "Przesunięcie osi"
 
 ["Offset frequency"]
 en = "Offset frequency"
@@ -4841,6 +5171,7 @@ ja = "オフセット周波数"
 pt = "Frequência de deslocamento"
 it = "Frequenza offset"
 id = "Frekuensi ofset"
+pl = "Częstotliwość przesunięcia"
 
 ["Offset randomness"]
 en = "Offset randomness"
@@ -4855,6 +5186,7 @@ ja = "オフセットのランダム性"
 pt = "Aleatoriedade de deslocamento"
 it = "Casualità offset"
 id = "Keacakan ofset"
+pl = "Losowość przesunięcia"
 
 ["Offset variation"]
 en = "Offset variation"
@@ -4869,6 +5201,7 @@ ja = "オフセット変化"
 pt = "Variação de deslocamento"
 it = "Variazione offset"
 id = "Variasi ofset"
+pl = "Zmienność przesunięcia"
 
 ["On"]
 en = "On"
@@ -4883,6 +5216,7 @@ ja = "オン"
 pt = "Ativado"
 it = "Acceso"
 id = "Hidup"
+pl = "Włączone"
 
 ["Opacity"]
 en = "Opacity"
@@ -4897,6 +5231,7 @@ ja = "不透明度"
 pt = "Opacidade"
 it = "Opacità"
 id = "Opacity"
+pl = "Nieprzezroczystość"
 
 ["Open larger editor"]
 en = "Open larger editor"
@@ -4911,6 +5246,7 @@ ja = "大きなエディターを開く"
 pt = "Abrir editor ampliado"
 it = "Apri editor più grande"
 id = "Buka editor lebih besar"
+pl = "Otwórz większy edytor"
 
 ["Operation"]
 en = "Operation"
@@ -4925,6 +5261,7 @@ ja = "処理"
 pt = "Operação"
 it = "Operazione"
 id = "Operasi"
+pl = "Operacja"
 
 ["Optimization iterations"]
 en = "Optimization iterations"
@@ -4939,6 +5276,7 @@ ja = "最適化の反復回数"
 pt = "Iterações de otimização"
 it = "Iterazioni di ottimizzazione"
 id = "Iterasi pengoptimalan"
+pl = "Iteracje optymalizacji"
 
 ["Ordering"]
 en = "Ordering"
@@ -4953,6 +5291,7 @@ ja = "順序"
 pt = "Ordenação"
 it = "Ordine"
 id = "Pengurutan"
+pl = "Kolejność"
 
 ["Original"]
 en = "Original"
@@ -4967,6 +5306,7 @@ ja = "オリジナル"
 pt = "Original"
 it = "Originale"
 id = "Asli"
+pl = "Oryginalne"
 
 ["Orthographic height"]
 en = "Orthographic height"
@@ -4981,6 +5321,7 @@ ja = "平行投影の高さ"
 pt = "Altura ortográfica"
 it = "Altezza ortografica"
 id = "Tinggi ortografis"
+pl = "Wysokość ortograficzna"
 
 ["Out of date"]
 en = "Out of date"
@@ -4995,6 +5336,7 @@ ja = "期限切れ"
 pt = "Desatualizado"
 it = "Non aggiornato"
 id = "Kedaluwarsa"
+pl = "Przestarzałe"
 
 ["Outline"]
 en = "Outline"
@@ -5009,6 +5351,7 @@ ja = "アウトライン"
 pt = "Contorno"
 it = "Contorno"
 id = "Garis luar"
+pl = "Kontur"
 
 ["Outline method"]
 en = "Outline method"
@@ -5023,6 +5366,7 @@ ja = "アウトライン方式"
 pt = "Método de contorno"
 it = "Metodo contorno"
 id = "Metode garis luar"
+pl = "Metoda konturu"
 
 ["Outline opacity"]
 en = "Outline opacity"
@@ -5037,6 +5381,7 @@ ja = "アウトライン不透明度"
 pt = "Opacidade do contorno"
 it = "Opacità contorno"
 id = "Opasitas garis luar"
+pl = "Nieprzezroczystość konturu"
 
 ["Outline quality"]
 en = "Outline quality"
@@ -5051,6 +5396,7 @@ ja = "アウトライン品質"
 pt = "Qualidade do contorno"
 it = "Qualità contorno"
 id = "Kualitas garis luar"
+pl = "Jakość konturu"
 
 ["Outline width"]
 en = "Outline width"
@@ -5065,6 +5411,7 @@ ja = "アウトライン幅"
 pt = "Largura do contorno"
 it = "Larghezza contorno"
 id = "Lebar garis luar"
+pl = "Szerokość konturu"
 
 ["Outro"]
 en = "Outro"
@@ -5079,6 +5426,7 @@ ja = "アウトロ"
 pt = "Encerramento"
 it = "Outro"
 id = "Outro"
+pl = "Zakończenie"
 
 ["Padding randomness"]
 en = "Padding randomness"
@@ -5093,6 +5441,7 @@ ja = "余白のランダム性"
 pt = "Aleatoriedade de preenchimento"
 it = "Casualità margine"
 id = "Keacakan bantalan"
+pl = "Losowość odstępu"
 
 ["Page"]
 en = "Page"
@@ -5107,6 +5456,7 @@ ja = "ページ"
 pt = "Página"
 it = "Pagina"
 id = "Halaman"
+pl = "Strona"
 
 ["Palette levels"]
 en = "Palette levels"
@@ -5121,6 +5471,7 @@ ja = "パレットレベル"
 pt = "Níveis da paleta"
 it = "Livelli palette"
 id = "Level palet"
+pl = "Poziomy palety"
 
 ["Parameters"]
 en = "Parameters"
@@ -5135,6 +5486,7 @@ ja = "パラメーター"
 pt = "Parâmetros"
 it = "Parametri"
 id = "Parameter"
+pl = "Parametry"
 
 ["Partial mode"]
 en = "Partial mode"
@@ -5149,6 +5501,7 @@ ja = "部分モード"
 pt = "Modo parcial"
 it = "Modalità parziale"
 id = "Mode parsial"
+pl = "Tryb częściowy"
 
 ["Paste Modifier"]
 en = "Paste Modifier"
@@ -5163,6 +5516,7 @@ ja = "モディファイアを貼り付け"
 pt = "Colar modificador"
 it = "Incolla modificatore"
 id = "Tempel Modifier"
+pl = "Wklej modyfikator"
 
 ["Path mode"]
 en = "Path mode"
@@ -5177,6 +5531,7 @@ ja = "パスモード"
 pt = "Modo de caminho"
 it = "Modalità percorso"
 id = "Mode jalur"
+pl = "Tryb ścieżki"
 
 ["Path precision"]
 en = "Path precision"
@@ -5191,6 +5546,7 @@ ja = "パス精度"
 pt = "Precisão do caminho"
 it = "Precisione percorso"
 id = "Presisi jalur"
+pl = "Precyzja ścieżki"
 
 ["Pattern"]
 en = "Pattern"
@@ -5205,6 +5561,7 @@ ja = "パターン"
 pt = "Padrão"
 it = "Pattern"
 id = "Pola"
+pl = "Wzór"
 
 ["Pattern softness"]
 en = "Pattern softness"
@@ -5219,6 +5576,7 @@ ja = "パターンの柔らかさ"
 pt = "Suavidade do padrão"
 it = "Morbidezza pattern"
 id = "Kelembutan pola"
+pl = "Miękkość wzoru"
 
 ["Pentagon"]
 en = "Pentagon"
@@ -5233,6 +5591,7 @@ ja = "五角形"
 pt = "Pentágono"
 it = "Pentagono"
 id = "Pentagon"
+pl = "Pięciokąt"
 
 ["Percentage"]
 en = "Percentage"
@@ -5247,6 +5606,7 @@ ja = "割合"
 pt = "Porcentagem"
 it = "Percentuale"
 id = "Persentase"
+pl = "Procent"
 
 ["Persistence"]
 en = "Persistence"
@@ -5261,6 +5621,7 @@ ja = "持続性"
 pt = "Persistência"
 it = "Persistenza"
 id = "Persistensi"
+pl = "Wytrwałość"
 
 ["Perspective"]
 en = "Perspective"
@@ -5275,6 +5636,7 @@ ja = "透視投影"
 pt = "Perspectiva"
 it = "Prospettiva"
 id = "Perspektif"
+pl = "Perspektywa"
 
 ["Phase"]
 en = "Phase"
@@ -5289,6 +5651,7 @@ ja = "位相"
 pt = "Fase"
 it = "Fase"
 id = "Fase"
+pl = "Faza"
 
 ["Picture"]
 en = "Picture"
@@ -5303,6 +5666,7 @@ ja = "ピクチャー"
 pt = "Imagem"
 it = "Immagine"
 id = "Gambar"
+pl = "Zdjęcie"
 
 ["Ping-pong"]
 en = "Ping-pong"
@@ -5317,6 +5681,7 @@ ja = "ピンポン"
 pt = "Pingue-pongue"
 it = "Ping-pong"
 id = "Ping-pong"
+pl = "Ping-pong"
 
 ["Pitch"]
 en = "Pitch"
@@ -5331,6 +5696,7 @@ ja = "ピッチ"
 pt = "Pitch"
 it = "Pitch"
 id = "Pitch"
+pl = "Wysokość dźwięku"
 
 ["Pitch offset"]
 en = "Pitch offset"
@@ -5345,6 +5711,7 @@ ja = "ピッチオフセット"
 pt = "Deslocamento de pitch"
 it = "Offset pitch"
 id = "Ofset titinada"
+pl = "Przesunięcie wysokości dźwięku"
 
 ["Pixel size"]
 en = "Pixel size"
@@ -5359,6 +5726,7 @@ ja = "ピクセルサイズ"
 pt = "Tamanho do pixel"
 it = "Dimensione pixel"
 id = "Ukuran piksel"
+pl = "Rozmiar pikseli"
 
 ["Pixelate"]
 en = "Pixelate"
@@ -5373,6 +5741,7 @@ ja = "ピクセル化"
 pt = "Pixelizar"
 it = "Pixelizza"
 id = "Pikselasi"
+pl = "Pikselizuj"
 
 ["Pixels"]
 en = "Pixels"
@@ -5387,6 +5756,7 @@ ja = "ピクセル"
 pt = "Pixels"
 it = "Pixels"
 id = "Piksel"
+pl = "Piksele"
 
 ["Playback"]
 en = "Playback"
@@ -5401,6 +5771,7 @@ ja = "再生"
 pt = "Reprodução"
 it = "Riproduzione"
 id = "Pemutaran"
+pl = "Odtwarzanie"
 
 ["Point type"]
 en = "Point type"
@@ -5415,6 +5786,7 @@ ja = "ポイント種別"
 pt = "Tipo de ponto"
 it = "Tipo di punto"
 id = "Jenis titik"
+pl = "Typ punktu"
 
 ["Point %{number}"]
 en = "Point %{number}"
@@ -5429,6 +5801,7 @@ ja = "ポイント %{number}"
 pt = "Ponto %{number}"
 it = "Punto %{number}"
 id = "Titik %{number}"
+pl = "Punkt %{number}"
 
 ["Points"]
 en = "Points"
@@ -5443,6 +5816,7 @@ ja = "ポイント"
 pt = "Pontos"
 it = "Punti"
 id = "Titik"
+pl = "Punkty"
 
 ["Polygon"]
 en = "Polygon"
@@ -5457,6 +5831,7 @@ ja = "多角形"
 pt = "Polígono"
 it = "Poligono"
 id = "Poligon"
+pl = "Wielokąt"
 
 ["Position"]
 en = "Position"
@@ -5471,6 +5846,7 @@ ja = "位置"
 pt = "Posição"
 it = "Posizione"
 id = "Posisi"
+pl = "Pozycja"
 
 ["Position X"]
 en = "Position X"
@@ -5485,6 +5861,7 @@ ja = "位置 X"
 pt = "Posição X"
 it = "Posizione X"
 id = "Posisi X"
+pl = "Pozycja X"
 
 ["Position Y"]
 en = "Position Y"
@@ -5499,6 +5876,7 @@ ja = "位置 Y"
 pt = "Posição Y"
 it = "Posizione Y"
 id = "Posisi Y"
+pl = "Pozycja Y"
 
 ["Pre-delay"]
 en = "Pre-delay"
@@ -5513,6 +5891,7 @@ ja = "プリディレイ"
 pt = "Pré-atraso"
 it = "Pre-delay"
 id = "Pra-tunda"
+pl = "Przed-opóźnienie"
 
 ["Precompute compact CPU mask frames so normal playback does not run SAM2"]
 en = "Precompute compact CPU mask frames so normal playback does not run SAM2"
@@ -5527,6 +5906,7 @@ ja = "通常再生でSAM2を実行しないようCPUマスクを事前計算"
 pt = "Pré-computar quadros de máscara compactos na CPU para que a reprodução normal não execute SAM2"
 it = "Pre-calcola i fotogrammi della maschera CPU compattati così la riproduzione normale non esegue SAM2"
 id = "Hitung awal bingkai masker CPU yang ringkas agar pemutaran normal tidak menjalankan SAM2"
+pl = "Wstępnie oblicz kompaktowe klatki maski CPU, aby normalne odtwarzanie nie używało SAM2"
 
 ["Precompute exact one-bit transparency masks for every frame"]
 en = "Precompute exact one-bit transparency masks for every frame"
@@ -5541,6 +5921,7 @@ ja = "全フレームの正確な1ビット透明マスクを事前計算"
 pt = "Pré-computar máscaras de transparência exatas de um bit para cada quadro"
 it = "Pre-calcola maschere di trasparenza esatte a un bit per ogni fotogramma"
 id = "Hitung awal masker transparansi 1-bit yang presisi untuk setiap bingkai"
+pl = "Wstępnie oblicz jednobitowe maski przezroczystości dla każdej klatki"
 
 ["Preference for a steady camera velocity"]
 en = "Preference for a steady camera velocity"
@@ -5555,6 +5936,7 @@ ja = "一定のカメラ速度を優先"
 pt = "Preferência por velocidade constante da câmera"
 it = "Preferenza per una velocità della telecamera costante"
 id = "Preferensi untuk kecepatan kamera yang stabil"
+pl = "Preferencja dla stałej prędkości kamery"
 
 ["Preference for frames with no camera motion"]
 en = "Preference for frames with no camera motion"
@@ -5569,6 +5951,7 @@ ja = "カメラが動かないフレームを優先"
 pt = "Preferência por quadros sem movimento da câmera"
 it = "Preferenza per fotogrammi senza movimento di telecamera"
 id = "Preferensi untuk bingkai tanpa gerakan kamera"
+pl = "Preferencja dla klatek bez ruchu kamery"
 
 ["Preference for smoothly changing camera motion"]
 en = "Preference for smoothly changing camera motion"
@@ -5583,6 +5966,7 @@ ja = "滑らかに変化するカメラ動作を優先"
 pt = "Preferência por transições suaves de movimento da câmera"
 it = "Preferenza per movimenti di telecamera fluidi"
 id = "Preferensi untuk perubahan gerakan kamera yang mulus"
+pl = "Preferencja dla płynnej zmiany ruchu kamery"
 
 ["Preserve formants"]
 en = "Preserve formants"
@@ -5597,6 +5981,7 @@ ja = "フォルマントを維持"
 pt = "Preservar formantes"
 it = "Preserva formanti"
 id = "Pertahankan forman"
+pl = "Zachowaj formanty"
 
 ["Preserve pitch"]
 en = "Preserve pitch"
@@ -5611,6 +5996,7 @@ ja = "ピッチを維持"
 pt = "Preservar tom"
 it = "Preserva pitch"
 id = "Pertahankan titinada"
+pl = "Zachowaj wysokość dźwięku"
 
 ["Preview Downsampling"]
 en = "Preview Downsampling"
@@ -5625,6 +6011,7 @@ ja = "プレビューのダウンサンプリング"
 pt = "Redução da pré-visualização"
 it = "Downsampling anteprima"
 id = "Downsampling Pratinjau"
+pl = "Pogląd downsamplingu"
 
 ["Preview Render Method"]
 en = "Preview Render Method"
@@ -5639,6 +6026,7 @@ ja = "プレビューのレンダリング方式"
 pt = "Método de renderização da pré-visualização"
 it = "Metodo rendering anteprima"
 id = "Metode Render Pratinjau"
+pl = "Metoda podglądu renderowania"
 
 ["Previous keyframe"]
 en = "Previous keyframe"
@@ -5653,6 +6041,7 @@ ja = "前のキーフレーム"
 pt = "Quadro-chave anterior"
 it = "Keyframe precedente"
 id = "Keyframe sebelumnya"
+pl = "Poprzednia klatka kluczowa"
 
 ["Project"]
 en = "Project"
@@ -5667,6 +6056,7 @@ ja = "プロジェクト"
 pt = "Projeto"
 it = "Progetto"
 id = "Proyek"
+pl = "Projekt"
 
 ["Project File"]
 en = "Project File"
@@ -5681,6 +6071,7 @@ ja = "プロジェクトファイル"
 pt = "Arquivo do projeto"
 it = "File progetto"
 id = "Berkas Proyek"
+pl = "Plik projektu"
 
 ["Projection"]
 en = "Projection"
@@ -5695,6 +6086,7 @@ ja = "投影"
 pt = "Projeção"
 it = "Proiezione"
 id = "Proyeksi"
+pl = "Projekcja"
 
 ["Pulse width"]
 en = "Pulse width"
@@ -5709,6 +6101,7 @@ ja = "パルス幅"
 pt = "Largura do pulso"
 it = "Larghezza impulso"
 id = "Lebar pulsa"
+pl = "Szerokość pulsu"
 
 ["Quality"]
 en = "Quality"
@@ -5723,6 +6116,7 @@ ja = "品質"
 pt = "Qualidade"
 it = "Qualità"
 id = "Kualitas"
+pl = "Jakość"
 
 ["Queued"]
 en = "Queued"
@@ -5737,6 +6131,7 @@ ja = "待機中"
 pt = "Na fila"
 it = "In coda"
 id = "Dalam antrean"
+pl = "W kolejce"
 
 ["Radius"]
 en = "Radius"
@@ -5751,6 +6146,7 @@ ja = "半径"
 pt = "Raio"
 it = "Raggio"
 id = "Radius"
+pl = "Promień"
 
 ["Range"]
 en = "Range"
@@ -5765,6 +6161,7 @@ ja = "範囲"
 pt = "Intervalo"
 it = "Intervallo"
 id = "Rentang"
+pl = "Zasięg"
 
 ["Rate"]
 en = "Rate"
@@ -5779,6 +6176,7 @@ ja = "レート"
 pt = "Taxa"
 it = "Frequenza"
 id = "Laju"
+pl = "Prędkość"
 
 ["Ratio"]
 en = "Ratio"
@@ -5793,6 +6191,7 @@ ja = "比率"
 pt = "Proporção"
 it = "Rapporto"
 id = "Rasio"
+pl = "Stosunek"
 
 ["Ready (%{sample_count} samples)"]
 en = "Ready (%{sample_count} samples)"
@@ -5807,6 +6206,7 @@ ja = "準備完了（%{sample_count}サンプル）"
 pt = "Pronto (%{sample_count} amostras)"
 it = "Pronto (%{sample_count} campioni)"
 id = "Siap (%{sample_count} sampel)"
+pl = "Gotowe (%{sample_count} próbek)"
 
 ["Reanalyze"]
 en = "Reanalyze"
@@ -5821,6 +6221,7 @@ ja = "再解析"
 pt = "Reanalisar"
 it = "Rianalizza"
 id = "Analisis ulang"
+pl = "Przeanalizuj ponownie"
 
 ["Rebake"]
 en = "Rebake"
@@ -5835,6 +6236,7 @@ ja = "再ベイク"
 pt = "Pré-computar novamente"
 it = "Ricalcola"
 id = "Bake ulang"
+pl = "Wypal ponownie"
 
 ["Rebuild"]
 en = "Rebuild"
@@ -5849,6 +6251,7 @@ ja = "再構築"
 pt = "Reconstruir"
 it = "Ricostruisci"
 id = "Bangun ulang"
+pl = "Przebuduj"
 
 ["Rectangle"]
 en = "Rectangle"
@@ -5863,6 +6266,7 @@ ja = "長方形"
 pt = "Retângulo"
 it = "Rettangolo"
 id = "Persegi panjang"
+pl = "Prostokąt"
 
 ["Reduction"]
 en = "Reduction"
@@ -5877,6 +6281,7 @@ ja = "低減"
 pt = "Redução"
 it = "Riduzione"
 id = "Pengurangan"
+pl = "Redukcja"
 
 ["Reflection opacity"]
 en = "Reflection opacity"
@@ -5891,6 +6296,7 @@ ja = "反射の不透明度"
 pt = "Opacidade do reflexo"
 it = "Opacità riflesso"
 id = "Opasitas pantulan"
+pl = "Nieprzezroczystość odbicia"
 
 ["Refresh interval"]
 en = "Refresh interval"
@@ -5905,6 +6311,7 @@ ja = "更新間隔"
 pt = "Intervalo de atualização"
 it = "Intervallo aggiornamento"
 id = "Interval penyegaran"
+pl = "Interwał odświeżania"
 
 ["Release"]
 en = "Release"
@@ -5919,6 +6326,7 @@ ja = "リリース"
 pt = "Liberação"
 it = "Rilascio"
 id = "Release"
+pl = "Publikacja"
 
 ["Reload Blender file and scene metadata"]
 en = "Reload Blender file and scene metadata"
@@ -5933,6 +6341,7 @@ ja = "Blenderファイルとシーンメタデータを再読み込み"
 pt = "Recarregar arquivo do Blender e metadados da cena"
 it = "Ricarica file e metadati della scena di Blender"
 id = "Muat ulang berkas Blender dan metadata adegan"
+pl = "Załaduj ponownie plik Blender i metadane sceny"
 
 ["Reload Python source and rebuild Manim scene states"]
 en = "Reload Python source and rebuild Manim scene states"
@@ -5947,6 +6356,7 @@ ja = "Pythonソースを再読み込みしてManimシーン状態を再構築"
 pt = "Recarregar código Python e reconstruir estados da cena do Manim"
 it = "Ricarica sorgente Python e ricostruisci stati della scena Manim"
 id = "Muat ulang sumber Python dan bangun ulang status adegan Manim"
+pl = "Załaduj ponownie źródło i przebuduj stany scen Manim"
 
 ["Remove"]
 en = "Remove"
@@ -5961,6 +6371,7 @@ ja = "削除"
 pt = "Remover"
 it = "Rimuovi"
 id = "Hapus"
+pl = "Usuń"
 
 ["Remove box"]
 en = "Remove box"
@@ -5975,6 +6386,7 @@ ja = "ボックスを削除"
 pt = "Remover caixa"
 it = "Rimuovi riquadro"
 id = "Hapus kotak"
+pl = "Usun pudło"
 
 ["Remove color"]
 en = "Remove color"
@@ -5989,6 +6401,7 @@ ja = "色を削除"
 pt = "Remover cor"
 it = "Rimuovi colore"
 id = "Hapus warna"
+pl = "Usuń kolor"
 
 ["Remove point"]
 en = "Remove point"
@@ -6003,6 +6416,7 @@ ja = "ポイントを削除"
 pt = "Remover ponto"
 it = "Rimuovi punto"
 id = "Hapus titik"
+pl = "Usuń punkt"
 
 ["Replace"]
 en = "Replace"
@@ -6017,6 +6431,7 @@ ja = "置換"
 pt = "Substituir"
 it = "Sostituisci"
 id = "Ganti"
+pl = "Zamień"
 
 ["Replace image"]
 en = "Replace image"
@@ -6031,6 +6446,7 @@ ja = "画像を置換"
 pt = "Substituir imagem"
 it = "Sostituisci immagine"
 id = "Ganti gambar"
+pl = "Zamień obraz"
 
 ["Replace model"]
 en = "Replace model"
@@ -6045,6 +6461,7 @@ ja = "モデルを置換"
 pt = "Substituir modelo"
 it = "Sostituisci modello"
 id = "Ganti model"
+pl = "Zamień model"
 
 ["Reset"]
 en = "Reset"
@@ -6059,6 +6476,7 @@ ja = "リセット"
 pt = "Redefinir"
 it = "Reimposta"
 id = "Atur ulang"
+pl = "Zresetuj"
 
 ["Resolution"]
 en = "Resolution"
@@ -6073,6 +6491,7 @@ ja = "解像度"
 pt = "Resolução"
 it = "Risoluzione"
 id = "Resolusi"
+pl = "Rozdzielczość"
 
 ["Resonance"]
 en = "Resonance"
@@ -6087,6 +6506,7 @@ ja = "レゾナンス"
 pt = "Ressonância"
 it = "Risonanza"
 id = "Resonansi"
+pl = "Rezonans"
 
 ["Right"]
 en = "Right"
@@ -6101,6 +6521,7 @@ ja = "右"
 pt = "Direita"
 it = "Destra"
 id = "Kanan"
+pl = "Prawe"
 
 ["Rim power"]
 en = "Rim power"
@@ -6115,6 +6536,7 @@ ja = "リムパワー"
 pt = "Potência do contorno"
 it = "Potenza bordo"
 id = "Daya rim"
+pl = "Moc obręczy"
 
 ["Rim strength"]
 en = "Rim strength"
@@ -6129,6 +6551,7 @@ ja = "リム強度"
 pt = "Intensidade do contorno"
 it = "Intensità bordo"
 id = "Kekuatan rim"
+pl = "Siła obręczy"
 
 ["Rim tint"]
 en = "Rim tint"
@@ -6143,6 +6566,7 @@ ja = "リム色"
 pt = "Tonalidade do contorno"
 it = "Tinta bordo"
 id = "Tint rim"
+pl = "Barwa obręczy"
 
 ["Room capture"]
 en = "Room capture"
@@ -6157,6 +6581,7 @@ ja = "ルームキャプチャー"
 pt = "Captura de sala"
 it = "Acquisizione stanza"
 id = "Tangkapan ruangan"
+pl = "Przechwyt pomieszczenia"
 
 ["Room scale"]
 en = "Room scale"
@@ -6171,6 +6596,7 @@ ja = "部屋の規模"
 pt = "Escala da sala"
 it = "Scala stanza"
 id = "Skala ruangan"
+pl = "Skala pomieszczenia"
 
 ["Rotation"]
 en = "Rotation"
@@ -6185,6 +6611,7 @@ ja = "回転"
 pt = "Rotação"
 it = "Rotazione"
 id = "Rotasi"
+pl = "Obrót"
 
 ["Rotation order"]
 en = "Rotation order"
@@ -6199,6 +6626,7 @@ ja = "回転順序"
 pt = "Ordem de rotação"
 it = "Ordine rotazione"
 id = "Urutan rotasi"
+pl = "Kolejność obrotu"
 
 ["Roughness"]
 en = "Roughness"
@@ -6213,6 +6641,7 @@ ja = "粗さ"
 pt = "Rugosidade"
 it = "Roughness"
 id = "Kekasaran"
+pl = "Szorstkość"
 
 ["Rounded"]
 en = "Rounded"
@@ -6227,6 +6656,7 @@ ja = "角丸"
 pt = "Arredondado"
 it = "Arrotondato"
 id = "Membulat"
+pl = "Zaokrąglone"
 
 ["Rounding"]
 en = "Rounding"
@@ -6241,6 +6671,7 @@ ja = "丸み"
 pt = "Arredondamento"
 it = "Arrotondamento"
 id = "Pembulatan"
+pl = "Zaokrąglenie"
 
 ["Roundness"]
 en = "Roundness"
@@ -6255,6 +6686,7 @@ ja = "丸み"
 pt = "Arredondamento"
 it = "Rotondità"
 id = "Kebulatan"
+pl = "Zaokrąglenie"
 
 ["Row offset"]
 en = "Row offset"
@@ -6269,6 +6701,7 @@ ja = "行オフセット"
 pt = "Deslocamento de linha"
 it = "Offset riga"
 id = "Ofset baris"
+pl = "Przesunięcie wiersza"
 
 ["Sample Rate"]
 en = "Sample Rate"
@@ -6283,6 +6716,7 @@ ja = "サンプルレート"
 pt = "Taxa de amostragem"
 it = "Frequenza campionamento"
 id = "Laju Sampel"
+pl = "Częstotliwość próbkowania"
 
 ["Sample rate"]
 en = "Sample rate"
@@ -6297,6 +6731,7 @@ ja = "サンプルレート"
 pt = "Taxa de amostragem"
 it = "Frequenza campionamento"
 id = "Laju sampel"
+pl = "Częstotliwość próbkowania"
 
 ["Samples"]
 en = "Samples"
@@ -6311,6 +6746,7 @@ ja = "サンプル"
 pt = "Amostras"
 it = "Campioni"
 id = "Sampel"
+pl = "Próbki"
 
 ["Saturation"]
 en = "Saturation"
@@ -6325,6 +6761,7 @@ ja = "彩度"
 pt = "Saturação"
 it = "Saturazione"
 id = "Saturasi"
+pl = "Saturacja"
 
 ["Scale"]
 en = "Scale"
@@ -6339,6 +6776,7 @@ ja = "スケール"
 pt = "Escala"
 it = "Scala"
 id = "Skala"
+pl = "Skala"
 
 ["Scene"]
 en = "Scene"
@@ -6353,6 +6791,7 @@ ja = "シーン"
 pt = "Cena"
 it = "Scena"
 id = "Adegan"
+pl = "Scena"
 
 ["Scene Renderer"]
 en = "Scene Renderer"
@@ -6367,6 +6806,7 @@ ja = "シーンレンダラー"
 pt = "Renderizador de cena"
 it = "Renderer scena"
 id = "Renderer Adegan"
+pl = "Renderer sceny"
 
 ["Scramble, resize, then reveal the new text"]
 en = "Scramble, resize, then reveal the new text"
@@ -6381,6 +6821,7 @@ ja = "並べ替えとサイズ変更後に新しいテキストを表示"
 pt = "Embaralhar, redimensionar e revelar o novo texto"
 it = "Mescola, ridimensiona, poi mostra il nuovo testo"
 id = "Acak, ubah ukuran, lalu tampilkan teks baru"
+pl = "Pomieszaj, zmień rozmiar, potem pokaż nowy tekst"
 
 ["Search fonts or paste a Google Fonts specimen URL"]
 en = "Search fonts or paste a Google Fonts specimen URL"
@@ -6395,6 +6836,7 @@ ja = "フォントを検索、またはGoogle FontsのURLを貼り付け"
 pt = "Pesquisar fontes ou colar URL de amostra do Google Fonts"
 it = "Cerca font o incolla URL campione di Google Fonts"
 id = "Cari font atau tempel URL spesimen Google Fonts"
+pl = "Szukaj czcionek lub wklej URL czcionki z Google Fonts"
 
 ["Search interpolations"]
 en = "Search interpolations"
@@ -6409,6 +6851,7 @@ ja = "補間を検索"
 pt = "Pesquisar interpolações"
 it = "Cerca interpolazioni"
 id = "Cari interpolasi"
+pl = "Szukaj interpolacji"
 
 ["Search modifiers"]
 en = "Search modifiers"
@@ -6423,6 +6866,7 @@ ja = "モディファイアを検索"
 pt = "Pesquisar modificadores"
 it = "Cerca modificatori"
 id = "Cari modifier"
+pl = "Szukaj modyfikatorów"
 
 ["Searching Google Fonts…"]
 en = "Searching Google Fonts…"
@@ -6437,6 +6881,7 @@ ja = "Google Fontsを検索中…"
 pt = "Pesquisando no Google Fonts…"
 it = "Ricerca in Google Fonts…"
 id = "Mencari Google Fonts…"
+pl = "Przeszukiwanie Google Fonts…"
 
 ["Seed"]
 en = "Seed"
@@ -6451,6 +6896,7 @@ ja = "シード"
 pt = "Semente"
 it = "Seed"
 id = "Seed"
+pl = "Ziarno"
 
 ["Seed frequency"]
 en = "Seed frequency"
@@ -6465,6 +6911,7 @@ ja = "シード周波数"
 pt = "Frequência da semente"
 it = "Frequenza seed"
 id = "Frekuensi seed"
+pl = "Częstotliwość ziarna"
 
 ["Segment length"]
 en = "Segment length"
@@ -6479,6 +6926,7 @@ ja = "セグメント長"
 pt = "Comprimento do segmento"
 it = "Lunghezza segmento"
 id = "Panjang segmen"
+pl = "Długość segmentu"
 
 ["Segments"]
 en = "Segments"
@@ -6493,6 +6941,7 @@ ja = "セグメント"
 pt = "Segmentos"
 it = "Segmenti"
 id = "Segmen"
+pl = "Segmenty"
 
 ["Select"]
 en = "Select"
@@ -6507,6 +6956,7 @@ ja = "選択"
 pt = "Selecionar"
 it = "Seleziona"
 id = "Pilih"
+pl = "Wybierz"
 
 ["Select 3D model"]
 en = "Select 3D model"
@@ -6521,6 +6971,7 @@ ja = "3Dモデルを選択"
 pt = "Selecionar modelo 3D"
 it = "Seleziona modello 3D"
 id = "Pilih model 3D"
+pl = "Wybierz model 3D"
 
 ["Select environment image"]
 en = "Select environment image"
@@ -6535,6 +6986,7 @@ ja = "環境画像を選択"
 pt = "Selecionar imagem de ambiente"
 it = "Seleziona immagine ambiente"
 id = "Pilih gambar lingkungan"
+pl = "Wybierz obraz środowiska"
 
 ["Select image"]
 en = "Select image"
@@ -6549,6 +7001,7 @@ ja = "画像を選択"
 pt = "Selecionar imagem"
 it = "Seleziona immagine"
 id = "Pilih gambar"
+pl = "Wybierz obraz"
 
 ["Select model"]
 en = "Select model"
@@ -6563,6 +7016,7 @@ ja = "モデルを選択"
 pt = "Selecionar modelo"
 it = "Seleziona modello"
 id = "Pilih model"
+pl = "Wybierz model"
 
 ["Select paint texture"]
 en = "Select paint texture"
@@ -6577,6 +7031,7 @@ ja = "ペイントテクスチャを選択"
 pt = "Selecionar textura de pintura"
 it = "Seleziona texture pittura"
 id = "Pilih tekstur lukisan"
+pl = "Wybierz teksturę farby"
 
 ["Semitones"]
 en = "Semitones"
@@ -6591,6 +7046,7 @@ ja = "半音"
 pt = "Semitons"
 it = "Semitoni"
 id = "Seminada"
+pl = "Semitony"
 
 ["Sensitivity"]
 en = "Sensitivity"
@@ -6605,6 +7061,7 @@ ja = "感度"
 pt = "Sensibilidade"
 it = "Sensibilità"
 id = "Sensitivitas"
+pl = "Wrażliwość"
 
 ["Sequential"]
 en = "Sequential"
@@ -6619,6 +7076,7 @@ ja = "順次"
 pt = "Sequencial"
 it = "Sequenziale"
 id = "Berurutan"
+pl = "Sekwencyjny"
 
 ["Shader"]
 en = "Shader"
@@ -6633,6 +7091,7 @@ ja = "シェーダー"
 pt = "Shader"
 it = "Shader"
 id = "Shader"
+pl = "Shader"
 
 ["Shadow blur"]
 en = "Shadow blur"
@@ -6647,6 +7106,7 @@ ja = "影のぼかし"
 pt = "Desfoque da sombra"
 it = "Sfocatura ombra"
 id = "Buram bayangan"
+pl = "Rozmycie cienia"
 
 ["Shadow color"]
 en = "Shadow color"
@@ -6661,6 +7121,7 @@ ja = "影の色"
 pt = "Cor da sombra"
 it = "Colore ombra"
 id = "Warna bayangan"
+pl = "Kolor cienia"
 
 ["Shadow direction"]
 en = "Shadow direction"
@@ -6675,6 +7136,7 @@ ja = "影の方向"
 pt = "Direção da sombra"
 it = "Direzione ombra"
 id = "Arah bayangan"
+pl = "Kierunek cienia"
 
 ["Shadow distance"]
 en = "Shadow distance"
@@ -6689,6 +7151,7 @@ ja = "影の距離"
 pt = "Distância da sombra"
 it = "Distanza ombra"
 id = "Jarak bayangan"
+pl = "Odległość cienia"
 
 ["Shadow kind"]
 en = "Shadow kind"
@@ -6703,6 +7166,7 @@ ja = "影の種類"
 pt = "Tipo de sombra"
 it = "Tipo ombra"
 id = "Jenis bayangan"
+pl = "Typ cienia"
 
 ["Shadow quality"]
 en = "Shadow quality"
@@ -6717,6 +7181,7 @@ ja = "影の品質"
 pt = "Qualidade da sombra"
 it = "Qualità ombra"
 id = "Kualitas bayangan"
+pl = "Jakość cienia"
 
 ["Shadow strength"]
 en = "Shadow strength"
@@ -6731,6 +7196,7 @@ ja = "影の強度"
 pt = "Intensidade da sombra"
 it = "Intensità ombra"
 id = "Kekuatan bayangan"
+pl = "Siła cienia"
 
 ["Shadow width"]
 en = "Shadow width"
@@ -6745,6 +7211,7 @@ ja = "影の幅"
 pt = "Largura da sombra"
 it = "Larghezza ombra"
 id = "Lebar bayangan"
+pl = "Szerokość cienia"
 
 ["Shaft width"]
 en = "Shaft width"
@@ -6759,6 +7226,7 @@ ja = "軸の幅"
 pt = "Largura do corpo"
 it = "Larghezza asta"
 id = "Lebar batang"
+pl = "Szerokość wału"
 
 ["Sharpness"]
 en = "Sharpness"
@@ -6773,6 +7241,7 @@ ja = "シャープネス"
 pt = "Nitidez"
 it = "Nitidezza"
 id = "Ketajaman"
+pl = "Ostrość"
 
 ["Shear"]
 en = "Shear"
@@ -6787,6 +7256,7 @@ ja = "シアー"
 pt = "Cisalhamento"
 it = "Inclinazione"
 id = "Geser"
+pl = "Ścięcie"
 
 ["Sheen"]
 en = "Sheen"
@@ -6801,6 +7271,7 @@ ja = "光沢"
 pt = "Brilho suave"
 it = "Lucentezza"
 id = "Sheen"
+pl = "Połysk"
 
 ["Show in folder"]
 en = "Show in folder"
@@ -6815,6 +7286,7 @@ ja = "フォルダーに表示"
 pt = "Mostrar na pasta"
 it = "Mostra nella cartella"
 id = "Tampilkan di folder"
+pl = "Pokaż w folderze"
 
 ["Show project file in folder"]
 en = "Show project file in folder"
@@ -6829,6 +7301,7 @@ ja = "プロジェクトファイルをフォルダーに表示"
 pt = "Mostrar arquivo do projeto na pasta"
 it = "Mostra file progetto nella cartella"
 id = "Tampilkan berkas proyek di folder"
+pl = "Pokaż plik projektu w folderze"
 
 ["Sigma"]
 en = "Sigma"
@@ -6843,6 +7316,7 @@ ja = "シグマ"
 pt = "Sigma"
 it = "Sigma"
 id = "Sigma"
+pl = "Sigma"
 
 ["Sigma ratio"]
 en = "Sigma ratio"
@@ -6857,6 +7331,7 @@ ja = "シグマ比"
 pt = "Proporção de sigma"
 it = "Rapporto sigma"
 id = "Rasio sigma"
+pl = "Stosunek sigma"
 
 ["Similarity"]
 en = "Similarity"
@@ -6871,6 +7346,7 @@ ja = "類似度"
 pt = "Similaridade"
 it = "Similarità"
 id = "Kemiripan"
+pl = "Podobieństwo"
 
 ["Simplify tolerance"]
 en = "Simplify tolerance"
@@ -6885,6 +7361,7 @@ ja = "簡略化許容値"
 pt = "Tolerância de simplificação"
 it = "Tolleranza semplificazione"
 id = "Toleransi penyederhanaan"
+pl = "Tolerancja uproszczenia"
 
 ["Simultaneous"]
 en = "Simultaneous"
@@ -6899,6 +7376,7 @@ ja = "同時"
 pt = "Simultâneo"
 it = "Simultaneo"
 id = "Simultan"
+pl = "Jednoczesne"
 
 ["Size"]
 en = "Size"
@@ -6913,6 +7391,7 @@ ja = "サイズ"
 pt = "Tamanho"
 it = "Dimensione"
 id = "Ukuran"
+pl = "Rozmiar"
 
 ["Size randomness"]
 en = "Size randomness"
@@ -6927,6 +7406,7 @@ ja = "サイズのランダム性"
 pt = "Aleatoriedade de tamanho"
 it = "Casualità dimensione"
 id = "Keacakan ukuran"
+pl = "Losowość rozmiaru"
 
 ["Skia drawing"]
 en = "Skia drawing"
@@ -6941,6 +7421,7 @@ ja = "Skia描画"
 pt = "Desenho Skia"
 it = "Disegno Skia"
 id = "Gambar Skia"
+pl = "Rysowanie Skia"
 
 ["Smoothing"]
 en = "Smoothing"
@@ -6955,6 +7436,7 @@ ja = "スムージング"
 pt = "Suavização"
 it = "Smussatura"
 id = "Penghalusan"
+pl = "Wygładzanie"
 
 ["Smoothing radius"]
 en = "Smoothing radius"
@@ -6969,6 +7451,7 @@ ja = "平滑化半径"
 pt = "Raio de suavização"
 it = "Raggio smussatura"
 id = "Radius penghalusan"
+pl = "Promień wygładzania"
 
 ["Smoothness"]
 en = "Smoothness"
@@ -6983,6 +7466,7 @@ ja = "滑らかさ"
 pt = "Suavidade"
 it = "Levigatura"
 id = "Kemulusan"
+pl = "Gładkość"
 
 ["Soft shadow"]
 en = "Soft shadow"
@@ -6997,6 +7481,7 @@ ja = "ソフトシャドウ"
 pt = "Sombra suave"
 it = "Ombra morbida"
 id = "Bayangan lembut"
+pl = "Lekki cień"
 
 ["Softness"]
 en = "Softness"
@@ -7011,6 +7496,7 @@ ja = "柔らかさ"
 pt = "Suavidade"
 it = "Morbidezza"
 id = "Kelembutan"
+pl = "Lekkość"
 
 ["Solid"]
 en = "Solid"
@@ -7025,6 +7511,7 @@ ja = "ソリッド"
 pt = "Sólido"
 it = "Pieno"
 id = "Solid"
+pl = "Solidny"
 
 ["Solid color"]
 en = "Solid color"
@@ -7039,6 +7526,7 @@ ja = "単色"
 pt = "Cor sólida"
 it = "Colore pieno"
 id = "Warna solid"
+pl = "Kolor solidny"
 
 ["Source"]
 en = "Source"
@@ -7053,6 +7541,7 @@ ja = "ソース"
 pt = "Origem"
 it = "Sorgente"
 id = "Sumber"
+pl = "Źródło"
 
 ["Spacing"]
 en = "Spacing"
@@ -7067,6 +7556,7 @@ ja = "間隔"
 pt = "Espaçamento"
 it = "Spaziatura"
 id = "Spasi"
+pl = "Spacjowanie"
 
 ["Speckle size"]
 en = "Speckle size"
@@ -7081,6 +7571,7 @@ ja = "斑点サイズ"
 pt = "Tamanho do granulado"
 it = "Dimensione macchia"
 id = "Ukuran bintik"
+pl = "Rozmiar plamek"
 
 ["Specular size"]
 en = "Specular size"
@@ -7095,6 +7586,7 @@ ja = "スペキュラーサイズ"
 pt = "Tamanho especular"
 it = "Dimensione speculare"
 id = "Ukuran spekular"
+pl = "Rozmiar odbicia spekularnego"
 
 ["Specular strength"]
 en = "Specular strength"
@@ -7109,6 +7601,7 @@ ja = "スペキュラー強度"
 pt = "Intensidade especular"
 it = "Intensità speculare"
 id = "Kekuatan spekular"
+pl = "Siła odbicia spekularnego"
 
 ["Speed method"]
 en = "Speed method"
@@ -7123,6 +7616,7 @@ ja = "速度方式"
 pt = "Método de velocidade"
 it = "Metodo velocità"
 id = "Metode kecepatan"
+pl = "Metoda prędkości"
 
 ["Spill"]
 en = "Spill"
@@ -7137,6 +7631,7 @@ ja = "スピル"
 pt = "Vazamento de cor"
 it = "Spill"
 id = "Spill"
+pl = "Rozlanie"
 
 ["Spin"]
 en = "Spin"
@@ -7151,6 +7646,7 @@ ja = "スピン"
 pt = "Giro"
 it = "Giro"
 id = "Putar"
+pl = "Kręć"
 
 ["Splice threshold"]
 en = "Splice threshold"
@@ -7165,6 +7661,7 @@ ja = "スプライスしきい値"
 pt = "Limiar de emenda"
 it = "Soglia giunzione"
 id = "Ambang batas sambungan"
+pl = "Próg splatania"
 
 ["Square"]
 en = "Square"
@@ -7179,6 +7676,7 @@ ja = "正方形"
 pt = "Quadrado"
 it = "Quadrato"
 id = "Persegi"
+pl = "Kwadrat"
 
 ["Stabilization"]
 en = "Stabilization"
@@ -7193,6 +7691,7 @@ ja = "手ぶれ補正"
 pt = "Estabilização"
 it = "Stabilizzazione"
 id = "Stabilisasi"
+pl = "Stabilizacja"
 
 ["Stabilization cache"]
 en = "Stabilization cache"
@@ -7207,6 +7706,7 @@ ja = "手ぶれ補正キャッシュ"
 pt = "Cache de estabilização"
 it = "Cache stabilizzazione"
 id = "Cache stabilisasi"
+pl = "Cache stabilizacji"
 
 ["Start cap"]
 en = "Start cap"
@@ -7221,6 +7721,7 @@ ja = "始端キャップ"
 pt = "Extremidade inicial"
 it = "Estremità iniziale"
 id = "Ujung awal"
+pl = "Początek"
 
 ["Start taper"]
 en = "Start taper"
@@ -7235,6 +7736,7 @@ ja = "始端テーパー"
 pt = "Afilamento inicial"
 it = "Cono iniziale"
 id = "Pengecilan awal"
+pl = "Zwężenie początku"
 
 ["Start taper distance"]
 en = "Start taper distance"
@@ -7249,6 +7751,7 @@ ja = "始端テーパー距離"
 pt = "Distância do afilamento inicial"
 it = "Distanza cono iniziale"
 id = "Jarak pengecilan awal"
+pl = "Odległość zwężenia początku"
 
 ["Starting angle"]
 en = "Starting angle"
@@ -7263,6 +7766,7 @@ ja = "開始角度"
 pt = "Ângulo inicial"
 it = "Angolo iniziale"
 id = "Sudut awal"
+pl = "Kąt początkowy"
 
 ["Starting scale"]
 en = "Starting scale"
@@ -7277,6 +7781,7 @@ ja = "開始スケール"
 pt = "Escala inicial"
 it = "Scala iniziale"
 id = "Skala awal"
+pl = "Skala początkowa"
 
 ["Static-camera weight"]
 en = "Static-camera weight"
@@ -7291,6 +7796,7 @@ ja = "固定カメラウェイト"
 pt = "Peso de câmera estática"
 it = "Peso telecamera statica"
 id = "Bobot kamera statis"
+pl = "Waga kamery statycznej"
 
 ["Step"]
 en = "Step"
@@ -7305,6 +7811,7 @@ ja = "ステップ"
 pt = "Passo"
 it = "Passo"
 id = "Langkah"
+pl = "Krok"
 
 ["Step size"]
 en = "Step size"
@@ -7319,6 +7826,7 @@ ja = "ステップサイズ"
 pt = "Tamanho do passo"
 it = "Dimensione passo"
 id = "Ukuran langkah"
+pl = "Rozmiar kroku"
 
 ["Strategy"]
 en = "Strategy"
@@ -7333,6 +7841,7 @@ ja = "方式"
 pt = "Estratégia"
 it = "Strategia"
 id = "Strategi"
+pl = "Strategia"
 
 ["Strength"]
 en = "Strength"
@@ -7347,6 +7856,7 @@ ja = "強度"
 pt = "Intensidade"
 it = "Intensità"
 id = "Kekuatan"
+pl = "Siła"
 
 ["Stroke color %{number}"]
 en = "Stroke color %{number}"
@@ -7361,6 +7871,7 @@ ja = "線の色 %{number}"
 pt = "Cor do traço %{number}"
 it = "Colore tratto %{number}"
 id = "Warna goresan %{number}"
+pl = "Kolor obrysu %{number}"
 
 ["Stroke overlap"]
 en = "Stroke overlap"
@@ -7375,6 +7886,7 @@ ja = "ストロークの重なり"
 pt = "Sobreposição de traços"
 it = "Sovrapposizione tratti"
 id = "Tumpang tindih goresan"
+pl = "Zachodzenie obrysu"
 
 ["Strokes"]
 en = "Strokes"
@@ -7389,6 +7901,7 @@ ja = "ストローク"
 pt = "Traços"
 it = "Tratti"
 id = "Goresan"
+pl = "Obrysy"
 
 ["Style"]
 en = "Style"
@@ -7403,6 +7916,7 @@ ja = "スタイル"
 pt = "Estilo"
 it = "Stile"
 id = "Gaya"
+pl = "Styl"
 
 ["Subdivision spacing"]
 en = "Subdivision spacing"
@@ -7417,6 +7931,7 @@ ja = "細分化間隔"
 pt = "Espaçamento de subdivisão"
 it = "Spaziatura suddivisione"
 id = "Spasi subdivisi"
+pl = "Odstęp między podziałami"
 
 ["Subsurface"]
 en = "Subsurface"
@@ -7431,6 +7946,7 @@ ja = "サブサーフェス"
 pt = "Subsuperfície"
 it = "Subsuperficie"
 id = "Bawah permukaan"
+pl = "Podpowierzchniowe"
 
 ["Temperature"]
 en = "Temperature"
@@ -7445,6 +7961,7 @@ ja = "色温度"
 pt = "Temperatura"
 it = "Temperatura"
 id = "Suhu"
+pl = "Temperatura"
 
 ["Text color"]
 en = "Text color"
@@ -7459,6 +7976,7 @@ ja = "テキスト色"
 pt = "Cor do texto"
 it = "Colore testo"
 id = "Warna teks"
+pl = "Kolor tekstu"
 
 ["Texture"]
 en = "Texture"
@@ -7473,6 +7991,7 @@ ja = "テクスチャ"
 pt = "Textura"
 it = "Texture"
 id = "Tekstur"
+pl = "Tekstura"
 
 ["Texture filter"]
 en = "Texture filter"
@@ -7487,6 +8006,7 @@ ja = "テクスチャフィルター"
 pt = "Filtro de textura"
 it = "Filtro texture"
 id = "Filter tekstur"
+pl = "Filtr tekstury"
 
 ["Texture rotation"]
 en = "Texture rotation"
@@ -7501,6 +8021,7 @@ ja = "テクスチャ回転"
 pt = "Rotação da textura"
 it = "Rotazione texture"
 id = "Rotasi tekstur"
+pl = "Obrót rekstury"
 
 ["Texture scale"]
 en = "Texture scale"
@@ -7515,6 +8036,7 @@ ja = "テクスチャスケール"
 pt = "Escala da textura"
 it = "Scala texture"
 id = "Skala tekstur"
+pl = "Skala tekstury"
 
 ["Textures"]
 en = "Textures"
@@ -7529,6 +8051,7 @@ ja = "テクスチャ"
 pt = "Texturas"
 it = "Textures"
 id = "Tekstur"
+pl = "Tekstury"
 
 ["Threshold"]
 en = "Threshold"
@@ -7543,6 +8066,7 @@ ja = "しきい値"
 pt = "Limiar"
 it = "Soglia"
 id = "Ambang batas"
+pl = "Próg"
 
 ["Timeline Duration"]
 en = "Timeline Duration"
@@ -7557,6 +8081,7 @@ ja = "タイムライン上の長さ"
 pt = "Duração na linha do tempo"
 it = "Durata timeline"
 id = "Durasi Lini Masa"
+pl = "Długość trwania osi czasu"
 
 ["Tint"]
 en = "Tint"
@@ -7571,6 +8096,7 @@ ja = "色合い"
 pt = "Tonalidade"
 it = "Tinta"
 id = "Tint"
+pl = "Barwa"
 
 ["Tolerance"]
 en = "Tolerance"
@@ -7585,6 +8111,7 @@ ja = "許容値"
 pt = "Tolerância"
 it = "Tolleranza"
 id = "Toleransi"
+pl = "Tolerancja"
 
 ["Tone"]
 en = "Tone"
@@ -7599,6 +8126,7 @@ ja = "トーン"
 pt = "Tom"
 it = "Tono"
 id = "Nada"
+pl = "Ton"
 
 ["Top"]
 en = "Top"
@@ -7613,6 +8141,7 @@ ja = "上"
 pt = "Superior"
 it = "In alto"
 id = "Atas"
+pl = "Góra"
 
 ["Top left"]
 en = "Top left"
@@ -7627,6 +8156,7 @@ ja = "左上"
 pt = "Superior esquerdo"
 it = "In alto a sinistra"
 id = "Kiri atas"
+pl = "Lewa góra"
 
 ["Top right"]
 en = "Top right"
@@ -7641,6 +8171,7 @@ ja = "右上"
 pt = "Superior direito"
 it = "In alto a destra"
 id = "Kanan atas"
+pl = "Prawa góra"
 
 ["Track"]
 en = "Track"
@@ -7655,6 +8186,7 @@ ja = "トラック"
 pt = "Faixa"
 it = "Traccia"
 id = "Track"
+pl = "Ścieżka"
 
 ["Tracking"]
 en = "Tracking"
@@ -7669,6 +8201,7 @@ ja = "トラッキング"
 pt = "Rastreamento"
 it = "Tracking"
 id = "Pelacakan"
+pl = "Śledzenie"
 
 ["Tracking method"]
 en = "Tracking method"
@@ -7683,6 +8216,7 @@ ja = "トラッキング方式"
 pt = "Método de rastreamento"
 it = "Metodo tracking"
 id = "Metode pelacakan"
+pl = "Metoda śledzenia"
 
 ["Tracks"]
 en = "Tracks"
@@ -7697,6 +8231,7 @@ ja = "トラック"
 pt = "Faixas"
 it = "Tracce"
 id = "Tracks"
+pl = "Ścieżki"
 
 ["Trail length"]
 en = "Trail length"
@@ -7711,6 +8246,7 @@ ja = "軌跡の長さ"
 pt = "Comprimento do rastro"
 it = "Lunghezza scia"
 id = "Panjang jejak"
+pl = "Długość ścieżki"
 
 ["Transform"]
 en = "Transform"
@@ -7725,6 +8261,7 @@ ja = "変形"
 pt = "Transformação"
 it = "Trasforma"
 id = "Transformasi"
+pl = "Transformacja"
 
 ["Transition"]
 en = "Transition"
@@ -7739,6 +8276,7 @@ ja = "トランジション"
 pt = "Transição"
 it = "Transizione"
 id = "Transisi"
+pl = "Przejście"
 
 ["Transmission"]
 en = "Transmission"
@@ -7753,6 +8291,7 @@ ja = "透過"
 pt = "Transmissão"
 it = "Trasmissione"
 id = "Transmisi"
+pl = "Transmisja"
 
 ["Triangle"]
 en = "Triangle"
@@ -7767,6 +8306,7 @@ ja = "三角形"
 pt = "Triângulo"
 it = "Triangolo"
 id = "Segitiga"
+pl = "Trójkąt"
 
 ["Type"]
 en = "Type"
@@ -7781,6 +8321,7 @@ ja = "種類"
 pt = "Tipo"
 it = "Tipo"
 id = "Jenis"
+pl = "Typ"
 
 ["Unavailable (%{id})"]
 en = "Unavailable (%{id})"
@@ -7795,6 +8336,7 @@ ja = "利用不可（%{id}）"
 pt = "Indisponível (%{id})"
 it = "Non disponibile (%{id})"
 id = "Tidak tersedia (%{id})"
+pl = "Niedostępne (%{id})"
 
 ["Unavailable while an alpha-mask stream is selected"]
 en = "Unavailable while an alpha-mask stream is selected"
@@ -7809,6 +8351,7 @@ ja = "アルファマスクストリーム選択中は利用不可"
 pt = "Indisponível enquanto um fluxo de máscara alfa estiver selecionado"
 it = "Non disponibile con uno stream di maschera alpha selezionato"
 id = "Tidak tersedia saat stream masker alfa dipilih"
+pl = "Niedostępne kiedy strumień maski alfa jest zaznaczony"
 
 ["Upsampling"]
 en = "Upsampling"
@@ -7823,6 +8366,7 @@ ja = "アップサンプリング"
 pt = "Sobreamostragem"
 it = "Upsampling"
 id = "Upsampling"
+pl = "Upsampling"
 
 ["Using the reusable chunked analysis cache"]
 en = "Using the reusable chunked analysis cache"
@@ -7837,6 +8381,7 @@ ja = "再利用可能なチャンク解析キャッシュを使用中"
 pt = "Usando cache de análise segmentada reutilizável"
 it = "Uso della cache di analisi a blocchi riutilizzabile"
 id = "Menggunakan cache analisis potongan yang dapat digunakan kembali"
+pl = "Używanie segmentowanej pamięci cache analizy do wielokrotnego użytku"
 
 ["V align"]
 en = "V align"
@@ -7851,6 +8396,7 @@ ja = "垂直揃え"
 pt = "Alinhamento V"
 it = "Allinea V"
 id = "Perataan V"
+pl = "Wyrównaj pionowo"
 
 ["Value"]
 en = "Value"
@@ -7865,6 +8411,7 @@ ja = "値"
 pt = "Valor"
 it = "Valore"
 id = "Nilai"
+pl = "Wartość"
 
 ["Variation"]
 en = "Variation"
@@ -7879,6 +8426,7 @@ ja = "変化"
 pt = "Variação"
 it = "Variazione"
 id = "Variasi"
+pl = "Zmienność"
 
 ["Vertical"]
 en = "Vertical"
@@ -7893,6 +8441,7 @@ ja = "垂直"
 pt = "Vertical"
 it = "Verticale"
 id = "Vertikal"
+pl = "Pionowe"
 
 ["Vertical FOV"]
 en = "Vertical FOV"
@@ -7907,6 +8456,7 @@ ja = "垂直視野角"
 pt = "Campo de visão vertical"
 it = "FOV verticale"
 id = "FOV Vertikal"
+pl = "Pionowe pole widzenia (FOV)"
 
 ["Vertical alignment"]
 en = "Vertical alignment"
@@ -7921,6 +8471,7 @@ ja = "垂直揃え"
 pt = "Alinhamento vertical"
 it = "Allineamento verticale"
 id = "Perataan vertikal"
+pl = "Pionowe wyrównanie"
 
 ["Video Stream"]
 en = "Video Stream"
@@ -7935,6 +8486,7 @@ ja = "ビデオストリーム"
 pt = "Fluxo de vídeo"
 it = "Stream video"
 id = "Stream Video"
+pl = "Strumień wideo"
 
 ["Video stream %{number}"]
 en = "Video stream %{number}"
@@ -7949,6 +8501,7 @@ ja = "ビデオストリーム %{number}"
 pt = "Fluxo de vídeo %{number}"
 it = "Stream video %{number}"
 id = "Stream video %{number}"
+pl = "Strumień wideo %{number}"
 
 ["View Layer"]
 en = "View Layer"
@@ -7963,6 +8516,7 @@ ja = "ビューレイヤー"
 pt = "Camada de visualização"
 it = "Livello vista"
 id = "Lapisan Tampilan"
+pl = "Zobacz warstwę"
 
 ["Visible"]
 en = "Visible"
@@ -7977,6 +8531,7 @@ ja = "表示"
 pt = "Visível"
 it = "Visibile"
 id = "Terlihat"
+pl = "Widzialne"
 
 ["Visible source area after stabilization"]
 en = "Visible source area after stabilization"
@@ -7991,6 +8546,7 @@ ja = "手ぶれ補正後に表示されるソース領域"
 pt = "Área de origem visível após estabilização"
 it = "Area sorgente visibile dopo la stabilizzazione"
 id = "Area sumber yang terlihat setelah stabilisasi"
+pl = "Widzialny obszar źródła po stabilizacji"
 
 ["Visual"]
 en = "Visual"
@@ -8005,6 +8561,7 @@ ja = "ビジュアル"
 pt = "Visual"
 it = "Visuale"
 id = "Visual"
+pl = "Wizualne"
 
 ["Visual track %{index}"]
 en = "Visual track %{index}"
@@ -8019,6 +8576,7 @@ ja = "ビジュアルトラック %{index}"
 pt = "Faixa visual %{index}"
 it = "Traccia visuale %{index}"
 id = "Trek visual %{index}"
+pl = "Ścieżka wizualna %{index}"
 
 ["Warp amount"]
 en = "Warp amount"
@@ -8033,6 +8591,7 @@ ja = "ワープ量"
 pt = "Quantidade de distorção"
 it = "Quantità deformazione"
 id = "Jumlah lengkungan"
+pl = "Siła zniekształcenia"
 
 ["Warp scale"]
 en = "Warp scale"
@@ -8047,6 +8606,7 @@ ja = "ワープスケール"
 pt = "Escala de distorção"
 it = "Scala deformazione"
 id = "Skala lengkungan"
+pl = "Skala zniekształcenia"
 
 ["Waveform"]
 en = "Waveform"
@@ -8061,6 +8621,7 @@ ja = "波形"
 pt = "Forma de onda"
 it = "Forma d'onda"
 id = "Bentuk gelombang"
+pl = "Przebieg fali"
 
 ["Wavelength"]
 en = "Wavelength"
@@ -8075,6 +8636,7 @@ ja = "波長"
 pt = "Comprimento de onda"
 it = "Lunghezza d'onda"
 id = "Panjang gelombang"
+pl = "Długość fali"
 
 ["Width frequency"]
 en = "Width frequency"
@@ -8089,6 +8651,7 @@ ja = "幅の周波数"
 pt = "Frequência da largura"
 it = "Frequenza larghezza"
 id = "Frekuensi lebar"
+pl = "Częstotliwość szerokości"
 
 ["Width randomness"]
 en = "Width randomness"
@@ -8103,6 +8666,7 @@ ja = "幅のランダム性"
 pt = "Aleatoriedade da largura"
 it = "Casualità larghezza"
 id = "Keacakan lebar"
+pl = "Losowość szerokości"
 
 ["Width variation"]
 en = "Width variation"
@@ -8117,6 +8681,7 @@ ja = "幅の変化"
 pt = "Variação da largura"
 it = "Variazione larghezza"
 id = "Variasi lebar"
+pl = "Zmienność szerokości"
 
 ["Wipe"]
 en = "Wipe"
@@ -8131,6 +8696,7 @@ ja = "ワイプ"
 pt = "Varredura"
 it = "Wipe"
 id = "Wipe"
+pl = "Zamiatanie"
 
 ["Wobble"]
 en = "Wobble"
@@ -8145,6 +8711,7 @@ ja = "揺れ"
 pt = "Oscilação"
 it = "Oscillazione"
 id = "Goyangan"
+pl = "Falowanie"
 
 ["Wobble position"]
 en = "Wobble position"
@@ -8159,6 +8726,7 @@ ja = "揺れ位置"
 pt = "Posição da oscilação"
 it = "Posizione oscillazione"
 id = "Posisi goyangan"
+pl = "Pozycja falowania"
 
 ["Wobble scale"]
 en = "Wobble scale"
@@ -8173,6 +8741,7 @@ ja = "揺れスケール"
 pt = "Escala da oscilação"
 it = "Scala oscillazione"
 id = "Skala goyangan"
+pl = "Skala falowania"
 
 ["Word"]
 en = "Word"
@@ -8187,6 +8756,7 @@ ja = "単語"
 pt = "Palavra"
 it = "Parola"
 id = "Kata"
+pl = "Słowo"
 
 ["Zoom"]
 en = "Zoom"
@@ -8201,6 +8771,7 @@ ja = "ズーム"
 pt = "Zoom"
 it = "Zoom"
 id = "Zoom"
+pl = "Przybliżenie"
 
 ["Arrow"]
 en = "Arrow"
@@ -8215,6 +8786,7 @@ ja = "矢印"
 pt = "Seta"
 it = "Freccia"
 id = "Panah"
+pl = "Strzałka"
 
 ["Blue X"]
 en = "Blue X"
@@ -8229,6 +8801,7 @@ ja = "青 X"
 pt = "Azul X"
 it = "Blu X"
 id = "Biru X"
+pl = "Niebieskie X"
 
 ["Blue Y"]
 en = "Blue Y"
@@ -8243,6 +8816,7 @@ ja = "青 Y"
 pt = "Azul Y"
 it = "Blu Y"
 id = "Biru Y"
+pl = "Niebieskie Y"
 
 ["Blue ← blue"]
 en = "Blue ← blue"
@@ -8257,6 +8831,7 @@ ja = "青 ← 青"
 pt = "Azul ← azul"
 it = "Blu ← blu"
 id = "Biru ← biru"
+pl = "Niebieski ← niebieski"
 
 ["Blue ← green"]
 en = "Blue ← green"
@@ -8271,6 +8846,7 @@ ja = "青 ← 緑"
 pt = "Azul ← verde"
 it = "Blu ← verde"
 id = "Biru ← hijau"
+pl = "Niebieski ← zielony"
 
 ["Blue ← red"]
 en = "Blue ← red"
@@ -8285,6 +8861,7 @@ ja = "青 ← 赤"
 pt = "Azul ← vermelho"
 it = "Blu ← rosso"
 id = "Biru ← merah"
+pl = "Niebieski ← czerwony"
 
 ["Capsule"]
 en = "Capsule"
@@ -8299,6 +8876,7 @@ ja = "カプセル"
 pt = "Cápsula"
 it = "Capsula"
 id = "Kapsul"
+pl = "Kapsuła"
 
 ["Casual"]
 en = "Casual"
@@ -8313,6 +8891,7 @@ ja = "カジュアル"
 pt = "Casual"
 it = "Casual"
 id = "Santai"
+pl = "Zwykłe"
 
 ["Clock Wipe"]
 en = "Clock Wipe"
@@ -8327,6 +8906,7 @@ ja = "クロックワイプ"
 pt = "Varredura de relógio"
 it = "Wipe orario"
 id = "Clock Wipe"
+pl = "Zamiatanie zegarowe"
 
 ["Cone"]
 en = "Cone"
@@ -8341,6 +8921,7 @@ ja = "円錐"
 pt = "Cone"
 it = "Cono"
 id = "Kerucut"
+pl = "Stożek"
 
 ["Contour Current"]
 en = "Contour Current"
@@ -8355,6 +8936,7 @@ ja = "輪郭電流"
 pt = "Corrente de contorno"
 it = "Corrente contorno"
 id = "Arus Kontur"
+pl = "Przebieg konturu"
 
 ["Cross Fade"]
 en = "Cross Fade"
@@ -8369,6 +8951,7 @@ ja = "クロスフェード"
 pt = "Fade cruzado"
 it = "Crossfade"
 id = "Cross Fade"
+pl = "Przejście krzyżowe"
 
 ["Cursive"]
 en = "Cursive"
@@ -8383,6 +8966,7 @@ ja = "筆記体"
 pt = "Cursiva"
 it = "Cursivo"
 id = "Kursif"
+pl = "Kursywa"
 
 ["Direct"]
 en = "Direct"
@@ -8397,6 +8981,7 @@ ja = "直接"
 pt = "Direto"
 it = "Diretta"
 id = "Langsung"
+pl = "Bezpośrednie"
 
 ["Disk / cylinder"]
 en = "Disk / cylinder"
@@ -8411,6 +8996,7 @@ ja = "円盤 / 円柱"
 pt = "Disco / cilindro"
 it = "Disco / cilindro"
 id = "Cakram / silinder"
+pl = "Dysk / cylinder"
 
 ["Dissolve"]
 en = "Dissolve"
@@ -8425,6 +9011,7 @@ ja = "ディゾルブ"
 pt = "Dissolvência"
 it = "Dissolvenza"
 id = "Dissolve"
+pl = "Rozpuść"
 
 ["Equal Power"]
 en = "Equal Power"
@@ -8439,6 +9026,7 @@ ja = "等パワー"
 pt = "Potência igual"
 it = "Potenza uguale"
 id = "Daya Seimbang"
+pl = "Równa moc"
 
 ["F0 method"]
 en = "F0 method"
@@ -8453,6 +9041,7 @@ ja = "F0方式"
 pt = "Método F0"
 it = "Metodo F0"
 id = "Metode F0"
+pl = "Metoda F0"
 
 ["Facet Assembly"]
 en = "Facet Assembly"
@@ -8467,6 +9056,7 @@ ja = "ファセット構成"
 pt = "Montagem de facetas"
 it = "Assemblaggio faccette"
 id = "Perakitan Faset"
+pl = "Składanie faset"
 
 ["Fade Through Color"]
 en = "Fade Through Color"
@@ -8481,6 +9071,7 @@ ja = "カラーフェード"
 pt = "Esmaecer para cor"
 it = "Fade attraverso colore"
 id = "Fade Lewat Warna"
+pl = "Przejście przez kolor"
 
 ["Feature contours · multipass"]
 en = "Feature contours · multipass"
@@ -8495,6 +9086,7 @@ ja = "特徴輪郭 · マルチパス"
 pt = "Contornos de feições · múltiplos passos"
 it = "Contorni elementi · multipass"
 id = "Kontur fitur · multipass"
+pl = "Kontury cech · wieloprzebiegowo"
 
 ["Google"]
 en = "Google"
@@ -8509,6 +9101,7 @@ ja = "Google"
 pt = "Google"
 it = "Google"
 id = "Google"
+pl = "Google"
 
 ["Green ← blue"]
 en = "Green ← blue"
@@ -8523,6 +9116,7 @@ ja = "緑 ← 青"
 pt = "Verde ← azul"
 it = "Verde ← blu"
 id = "Hijau ← biru"
+pl = "Zielony ← niebieski"
 
 ["Green ← green"]
 en = "Green ← green"
@@ -8537,6 +9131,7 @@ ja = "緑 ← 緑"
 pt = "Verde ← verde"
 it = "Verde ← verde"
 id = "Hijau ← hijau"
+pl = "Zielony ← zielony"
 
 ["Green ← red"]
 en = "Green ← red"
@@ -8551,6 +9146,7 @@ ja = "緑 ← 赤"
 pt = "Verde ← vermelho"
 it = "Verde ← rosso"
 id = "Hijau ← merah"
+pl = "Zielony ← czerwony"
 
 ["High · 24 samples"]
 en = "High · 24 samples"
@@ -8565,6 +9161,7 @@ ja = "高 · 24サンプル"
 pt = "Alta · 24 amostras"
 it = "Alta · 24 campioni"
 id = "Tinggi · 24 sampel"
+pl = "Wysokie · 24 próbki"
 
 ["High · 8 probes"]
 en = "High · 8 probes"
@@ -8579,6 +9176,7 @@ ja = "高 · 8プローブ"
 pt = "Alta · 8 sondas"
 it = "Alta · 8 sonde"
 id = "Tinggi · 8 probe"
+pl = "Wysokie · 8 próbek"
 
 ["Kuwahara · painterly"]
 en = "Kuwahara · painterly"
@@ -8593,6 +9191,7 @@ ja = "Kuwahara · 絵画調"
 pt = "Kuwahara · pictórico"
 it = "Kuwahara · pittorico"
 id = "Kuwahara · lukisan"
+pl = "Kuwahara · malarski"
 
 ["Live Performance"]
 en = "Live Performance"
@@ -8607,6 +9206,7 @@ ja = "ライブパフォーマンス"
 pt = "Desempenho em tempo real"
 it = "Prestazione live"
 id = "Performa Langsung"
+pl = "Wydajność na żywo"
 
 ["Last %{last} · Avg %{average} · Min %{minimum} · Max %{maximum} · %{samples} samples%{percentage}"]
 en = "Last %{last} · Avg %{average} · Min %{minimum} · Max %{maximum} · %{samples} samples%{percentage}"
@@ -8621,6 +9221,7 @@ ja = "直近 %{last} · 平均 %{average} · 最小 %{minimum} · 最大 %{maxim
 pt = "Último %{last} · Méd. %{average} · Mín. %{minimum} · Máx. %{maximum} · %{samples} amostras%{percentage}"
 it = "Ultimo %{last} · Medio %{average} · Min %{minimum} · Max %{maximum} · %{samples} campioni%{percentage}"
 id = "Terakhir %{last} · Rata-rata %{average} · Min %{minimum} · Maks %{maximum} · %{samples} sampel%{percentage}"
+pl = "Ostatnie %{last} · Śred. %{average} · Min. %{minimum} · Maks. %{maximum} · %{samples} próbek%{percentage}"
 
 ["Living Fill"]
 en = "Living Fill"
@@ -8635,6 +9236,7 @@ ja = "リビングフィル"
 pt = "Preenchimento vivo"
 it = "Riempimento dinamico"
 id = "Isian Hidup"
+pl = "Żywe wypełnienie"
 
 ["Caption markup: **bold**, *italic*, __underline__, {milliseconds} karaoke, [base/ruby]"]
 en = "Caption markup: **bold**, *italic*, __underline__, {milliseconds} karaoke, [base/ruby]"
@@ -8649,6 +9251,7 @@ ja = "キャプションマークアップ: **太字**、*斜体*、__下線__�
 pt = "Marcação de legenda: **negrito**, *itálico*, __sublinhado__, {milissegundos} karaokê, [base/ruby]"
 it = "Marcatura sottotitoli: **grassetto**, *corsivo*, __sottolineato__, {milliseconds} karaoke, [base/ruby]"
 id = "Markup subtitel: **tebal**, *miring*, __garis bawah__, {milliseconds} karaoke, [dasar/ruby]"
+pl = "Znaczniki napisów: **pogrubienie**, *kursywa*, __podkreślenie__, {milisekundy} karaoke, [baza/ruby]"
 
 ["Missing item"]
 en = "Missing item"
@@ -8663,6 +9266,7 @@ ja = "項目がありません"
 pt = "Item ausente"
 it = "Elemento mancante"
 id = "Item hilang"
+pl = "Brakujący element"
 
 ["Morphological Resolve"]
 en = "Morphological Resolve"
@@ -8677,6 +9281,7 @@ ja = "形態学的解決"
 pt = "Resolução morfológica"
 it = "Morphological Resolve"
 id = "Resolusi Morfologis"
+pl = "Przekształcenie morfologiczne"
 
 ["Naive"]
 en = "Naive"
@@ -8691,6 +9296,7 @@ ja = "単純"
 pt = "Simples"
 it = "Naive"
 id = "Sederhana"
+pl = "Naiwne"
 
 ["Native"]
 en = "Native"
@@ -8705,6 +9311,7 @@ ja = "ネイティブ"
 pt = "Nativo"
 it = "Nativo"
 id = "Asli"
+pl = "Natywne"
 
 ["Oblique"]
 en = "Oblique"
@@ -8719,6 +9326,7 @@ ja = "斜体"
 pt = "Oblíquo"
 it = "Obliquo"
 id = "Oblik"
+pl = "Pochyła"
 
 ["Off (Full Resolution)"]
 en = "Off (Full Resolution)"
@@ -8733,6 +9341,7 @@ ja = "オフ（フル解像度）"
 pt = "Desativado (resolução máxima)"
 it = "Off (risoluzione completa)"
 id = "Mati (Resolusi Penuh)"
+pl = "Wyłączone (pełna rozdzielczość)"
 
 ["Origami"]
 en = "Origami"
@@ -8747,6 +9356,7 @@ ja = "折り紙"
 pt = "Origami"
 it = "Origami"
 id = "Origami"
+pl = "Origami"
 
 ["Path tracing"]
 en = "Path tracing"
@@ -8761,6 +9371,7 @@ ja = "パストレーシング"
 pt = "Traçado de caminhos"
 it = "Path tracing"
 id = "Path tracing"
+pl = "Śledzenie ścieżek"
 
 ["Pools"]
 en = "Pools"
@@ -8775,6 +9386,7 @@ ja = "プール"
 pt = "Pools"
 it = "Pool"
 id = "Kolam"
+pl = "Pule"
 
 ["Push"]
 en = "Push"
@@ -8789,6 +9401,7 @@ ja = "プッシュ"
 pt = "Empurrar"
 it = "Push"
 id = "Dorong"
+pl = "Wypychanie"
 
 ["Radial + Fresnel"]
 en = "Radial + Fresnel"
@@ -8803,6 +9416,7 @@ ja = "放射 + フレネル"
 pt = "Radial + Fresnel"
 it = "Radiale + Fresnel"
 id = "Radial + Fresnel"
+pl = "Radialne + Fresnel"
 
 ["Radial probes"]
 en = "Radial probes"
@@ -8817,6 +9431,7 @@ ja = "放射プローブ"
 pt = "Sondas radiais"
 it = "Probes radiali"
 id = "Probe radial"
+pl = "Próbki radialne"
 
 ["Red X"]
 en = "Red X"
@@ -8831,6 +9446,7 @@ ja = "赤 X"
 pt = "Vermelho X"
 it = "Rosso X"
 id = "Merah X"
+pl = "Czerwony X"
 
 ["Red Y"]
 en = "Red Y"
@@ -8845,6 +9461,7 @@ ja = "赤 Y"
 pt = "Vermelho Y"
 it = "Rosso Y"
 id = "Merah Y"
+pl = "Czerwony Y"
 
 ["Red ← blue"]
 en = "Red ← blue"
@@ -8859,6 +9476,7 @@ ja = "赤 ← 青"
 pt = "Vermelho ← azul"
 it = "Rosso ← blu"
 id = "Merah ← biru"
+pl = "Czerwony ← niebieski"
 
 ["Red ← green"]
 en = "Red ← green"
@@ -8873,6 +9491,7 @@ ja = "赤 ← 緑"
 pt = "Vermelho ← verde"
 it = "Rosso ← verde"
 id = "Merah ← hijau"
+pl = "Czerwony ← zielony"
 
 ["Red ← red"]
 en = "Red ← red"
@@ -8887,6 +9506,7 @@ ja = "赤 ← 赤"
 pt = "Vermelho ← vermelho"
 it = "Rosso ← rosso"
 id = "Merah ← merah"
+pl = "Czerwony ← czerwony"
 
 ["Render Style"]
 en = "Render Style"
@@ -8901,6 +9521,7 @@ ja = "レンダリングスタイル"
 pt = "Estilo de renderização"
 it = "Stile di render"
 id = "Gaya Render"
+pl = "Styl renderowania"
 
 ["Repeat"]
 en = "Repeat"
@@ -8915,6 +9536,7 @@ ja = "繰り返し"
 pt = "Repetir"
 it = "Ripeti"
 id = "Ulangi"
+pl = "Powtórz"
 
 ["Reverse Diffusion"]
 en = "Reverse Diffusion"
@@ -8929,6 +9551,7 @@ ja = "逆拡散"
 pt = "Difusão reversa"
 it = "Diffusione inversa"
 id = "Difusi Terbalik"
+pl = "Odwrotna dyfuzja"
 
 ["Rotated LTR"]
 en = "Rotated LTR"
@@ -8943,6 +9566,7 @@ ja = "回転・左から右"
 pt = "Girado da esq. para dir."
 it = "Ruotato LTR"
 id = "Diputar LTR"
+pl = "Obrócone od lewej do prawej"
 
 ["Rotated RTL"]
 en = "Rotated RTL"
@@ -8957,6 +9581,7 @@ ja = "回転・右から左"
 pt = "Girado da dir. para esq."
 it = "Ruotato RTL"
 id = "Diputar RTL"
+pl = "Obrócone od prawej do lewej"
 
 ["SVG Colors"]
 en = "SVG Colors"
@@ -8971,6 +9596,7 @@ ja = "SVGの色"
 pt = "Cores SVG"
 it = "Colori SVG"
 id = "Warna SVG"
+pl = "Kolory SVG"
 
 ["SVG color"]
 en = "SVG color"
@@ -8985,6 +9611,7 @@ ja = "SVGの色"
 pt = "Cor SVG"
 it = "Colore SVG"
 id = "Warna SVG"
+pl = "Kolor SVG"
 
 ["Serif"]
 en = "Serif"
@@ -8999,6 +9626,7 @@ ja = "明朝体"
 pt = "Com serifa"
 it = "Serif"
 id = "Serif"
+pl = "Szeryfowa"
 
 ["Silhouette"]
 en = "Silhouette"
@@ -9013,6 +9641,7 @@ ja = "シルエット"
 pt = "Silhueta"
 it = "Silhouette"
 id = "Siluet"
+pl = "Sylwetka"
 
 ["Silhouette + creases"]
 en = "Silhouette + creases"
@@ -9027,6 +9656,7 @@ ja = "シルエット + 折り目"
 pt = "Silhueta + vincos"
 it = "Silhouette + pieghe"
 id = "Siluet + lipatan"
+pl = "Sylwetka + zagięcia"
 
 ["Slide"]
 en = "Slide"
@@ -9041,6 +9671,7 @@ ja = "スライド"
 pt = "Deslizar"
 it = "Scorrimento"
 id = "Geser"
+pl = "Przesuwanie"
 
 ["Slide + Fade"]
 en = "Slide + Fade"
@@ -9055,6 +9686,7 @@ ja = "スライド + フェード"
 pt = "Deslizar + esmaecer"
 it = "Scorrimento + Fade"
 id = "Geser + Fade"
+pl = "Przesuwanie + zanikanie"
 
 ["Small Capitals"]
 en = "Small Capitals"
@@ -9069,6 +9701,7 @@ ja = "スモールキャップ"
 pt = "Versaletes"
 it = "Maiuscoletto"
 id = "Kapital Kecil"
+pl = "Kapitaliki"
 
 ["Soft Refraction"]
 en = "Soft Refraction"
@@ -9083,6 +9716,7 @@ ja = "ソフト屈折"
 pt = "Refração suave"
 it = "Rifrazione morbida"
 id = "Bias Lembut"
+pl = "Miękkie załamanie"
 
 ["Sphere"]
 en = "Sphere"
@@ -9097,6 +9731,7 @@ ja = "球"
 pt = "Esfera"
 it = "Sfera"
 id = "Bola"
+pl = "Kula"
 
 ["Standard · 12 samples"]
 en = "Standard · 12 samples"
@@ -9111,6 +9746,7 @@ ja = "標準 · 12サンプル"
 pt = "Padrão · 12 amostras"
 it = "Standard · 12 campioni"
 id = "Standar · 12 sampel"
+pl = "Standardowe · 12 próbek"
 
 ["Standard · 4 probes"]
 en = "Standard · 4 probes"
@@ -9125,6 +9761,7 @@ ja = "標準 · 4プローブ"
 pt = "Padrão · 4 sondas"
 it = "Standard · 4 sonde"
 id = "Standar · 4 probe"
+pl = "Standardowe · 4 próbki"
 
 ["Star"]
 en = "Star"
@@ -9139,6 +9776,7 @@ ja = "星"
 pt = "Estrela"
 it = "Stella"
 id = "Bintang"
+pl = "Gwiazda"
 
 ["Streak Wipe"]
 en = "Streak Wipe"
@@ -9153,6 +9791,7 @@ ja = "ストリークワイプ"
 pt = "Varredura de faixas"
 it = "Streak Wipe"
 id = "Sapuan Garis"
+pl = "Zamiatanie smugą"
 
 ["Streamline"]
 en = "Streamline"
@@ -9167,6 +9806,7 @@ ja = "流線"
 pt = "Linha fluida"
 it = "Streamline"
 id = "Streamline"
+pl = "Linia opływowa"
 
 ["Stroke Transform"]
 en = "Stroke Transform"
@@ -9181,6 +9821,7 @@ ja = "ストローク変形"
 pt = "Transformação de traço"
 it = "Trasformazione tratto"
 id = "Transformasi Goresan"
+pl = "Transformacja obrysu"
 
 ["System default"]
 en = "System default"
@@ -9195,6 +9836,7 @@ ja = "システム既定"
 pt = "Padrão do sistema"
 it = "Predefinito di sistema"
 id = "Bawaan sistem"
+pl = "Domyślne systemowe"
 
 ["Thinning"]
 en = "Thinning"
@@ -9209,6 +9851,7 @@ ja = "細線化"
 pt = "Afinamento"
 it = "Assottigliamento"
 id = "Penipisan"
+pl = "Ścienianie"
 
 ["Torus"]
 en = "Torus"
@@ -9223,6 +9866,7 @@ ja = "トーラス"
 pt = "Toro"
 it = "Toro"
 id = "Torus"
+pl = "Torus"
 
 ["Track %{track} · Item %{item}"]
 en = "Track %{track} · Item %{item}"
@@ -9237,6 +9881,7 @@ ja = "トラック %{track} · 項目 %{item}"
 pt = "Faixa %{track} · Item %{item}"
 it = "Traccia %{track} · Elemento %{item}"
 id = "Trek %{track} · Item %{item}"
+pl = "Ścieżka %{track} · Element %{item}"
 
 ["Triangular Fold"]
 en = "Triangular Fold"
@@ -9251,6 +9896,7 @@ ja = "三角折り"
 pt = "Dobra triangular"
 it = "Piega triangolare"
 id = "Lipatan Segitiga"
+pl = "Trójkątne zagięcie"
 
 ["Ultra · 16 probes"]
 en = "Ultra · 16 probes"
@@ -9265,6 +9911,7 @@ ja = "最高 · 16プローブ"
 pt = "Ultra · 16 sondas"
 it = "Ultra · 16 sonde"
 id = "Ultra · 16 probe"
+pl = "Ultra · 16 próbek"
 
 ["Ultra · 48 samples"]
 en = "Ultra · 48 samples"
@@ -9279,6 +9926,7 @@ ja = "最高 · 48サンプル"
 pt = "Ultra · 48 amostras"
 it = "Ultra · 48 campioni"
 id = "Ultra · 48 sampel"
+pl = "Ultra · 48 próbek"
 
 ["Unwrite"]
 en = "Unwrite"
@@ -9293,6 +9941,7 @@ ja = "消去"
 pt = "Apagar"
 it = "Cancellazione testo"
 id = "Hapus tulisan"
+pl = "Cofanie pisania"
 
 ["Vertical LTR"]
 en = "Vertical LTR"
@@ -9307,6 +9956,7 @@ ja = "縦書き・左から右"
 pt = "Vertical da esq. para dir."
 it = "Verticale da sinistra a destra"
 id = "Vertikal LTR"
+pl = "Pionowe od lewej do prawej"
 
 ["Vertical RTL"]
 en = "Vertical RTL"
@@ -9321,6 +9971,7 @@ ja = "縦書き・右から左"
 pt = "Vertical da dir. para esq."
 it = "Verticale da destra a sinistra"
 id = "Vertikal RTL"
+pl = "Pionowe od prawej do lewej"
 
 ["Video / Render request"]
 en = "Video / Render request"
@@ -9335,6 +9986,7 @@ ja = "ビデオ / レンダリング要求"
 pt = "Solicitação de vídeo / renderização"
 it = "Richiesta video / render"
 id = "Permintaan video / render"
+pl = "Żądanie wideo / renderowania"
 
 ["Visual track %{number}"]
 en = "Visual track %{number}"
@@ -9349,6 +10001,7 @@ ja = "ビジュアルトラック %{number}"
 pt = "Faixa visual %{number}"
 it = "Traccia video %{number}"
 id = "Trek visual %{number}"
+pl = "Ścieżka wizualna %{number}"
 
 ["Write"]
 en = "Write"
@@ -9363,6 +10016,7 @@ ja = "書く"
 pt = "Escrever"
 it = "Scrivi"
 id = "Tulis"
+pl = "Pisanie"
 
 ["Writing"]
 en = "Writing"
@@ -9377,6 +10031,7 @@ ja = "書き込み"
 pt = "Escrita"
 it = "Scrittura"
 id = "Menulis"
+pl = "Pismo"
 
 ["%{axis} variation axis"]
 en = "%{axis} variation axis"
@@ -9391,6 +10046,7 @@ ja = "%{axis} バリエーション軸"
 pt = "Eixo de variação %{axis}"
 it = "Asse di variazione %{axis}"
 id = "Sumbu variasi %{axis}"
+pl = "Oś zmienności %{axis}"
 
 ["%{name} copied"]
 en = "%{name} copied"
@@ -9405,6 +10061,7 @@ ja = "%{name} をコピーしました"
 pt = "%{name} copiado"
 it = "%{name} copiato"
 id = "%{name} disalin"
+pl = "Skopiowano %{name}"
 
 ["%{label} (Unavailable)"]
 en = "%{label} (Unavailable)"
@@ -9419,6 +10076,7 @@ ja = "%{label}（利用不可）"
 pt = "%{label} (Indisponível)"
 it = "%{label} (non disponibile)"
 id = "%{label} (Tidak tersedia)"
+pl = "%{label} (niedostępne)"
 
 ["%{message} %{completed}/%{total}"]
 en = "%{message} %{completed}/%{total}"
@@ -9433,6 +10091,7 @@ ja = "%{message} %{completed}/%{total}"
 pt = "%{message} %{completed}/%{total}"
 it = "%{message} %{completed}/%{total}"
 id = "%{message} %{completed}/%{total}"
+pl = "%{message} %{completed}/%{total}"
 
 ["Output: %{output}"]
 en = "Output: %{output}"
@@ -9447,6 +10106,7 @@ ja = "出力: %{output}"
 pt = "Saída: %{output}"
 it = "Output: %{output}"
 id = "Output: %{output}"
+pl = "Wyjście: %{output}"
 
 ["%{strokes} strokes, %{fills} fills"]
 en = "%{strokes} strokes, %{fills} fills"
@@ -9461,6 +10121,7 @@ ja = "%{strokes} ストローク、%{fills} 塗り"
 pt = "%{strokes} traços, %{fills} preenchimentos"
 it = "%{strokes} tratti, %{fills} riempimenti"
 id = "%{strokes} goresan, %{fills} isian"
+pl = "%{strokes} obrysów, %{fills} wypełnień"
 
 ["1 keyframe copied"]
 en = "1 keyframe copied"
@@ -9475,6 +10136,7 @@ ja = "キーフレームを1件コピーしました"
 pt = "1 quadro-chave copiado"
 it = "1 keyframe copiato"
 id = "1 keyframe disalin"
+pl = "Skopiowano 1 klatkę kluczową"
 
 ["1 keyframe pasted"]
 en = "1 keyframe pasted"
@@ -9489,6 +10151,7 @@ ja = "キーフレームを1件貼り付けました"
 pt = "1 quadro-chave colado"
 it = "1 keyframe incollato"
 id = "1 keyframe ditempel"
+pl = "Wklejono 1 klatkę kluczową"
 
 ["%{count} keyframes copied"]
 en = "%{count} keyframes copied"
@@ -9503,6 +10166,7 @@ ja = "%{count}件のキーフレームをコピーしました"
 pt = "%{count} quadros-chave copiados"
 it = "%{count} keyframes copiati"
 id = "%{count} keyframe disalin"
+pl = "Skopiowano klatek kluczowych: %{count}"
 
 ["%{count} keyframes pasted"]
 en = "%{count} keyframes pasted"
@@ -9517,6 +10181,7 @@ ja = "%{count}件のキーフレームを貼り付けました"
 pt = "%{count} quadros-chave colados"
 it = "%{count} keyframes incollati"
 id = "%{count} keyframe ditempel"
+pl = "Wklejono klatek kluczowych: %{count}"
 
 ["Analysis starts as source-time chunks are viewed"]
 en = "Analysis starts as source-time chunks are viewed"
@@ -9531,6 +10196,7 @@ ja = "ソース時間チャンクの表示時に解析を開始"
 pt = "A análise inicia conforme os trechos temporais de origem são visualizados"
 it = "L'analisi inizia quando si visualizzano i frammenti della sequenza sorgente"
 id = "Analisis dimulai saat potongan waktu sumber dilihat"
+pl = "Analiza rozpoczyna się podczas przeglądania fragmentów czasu źródłowego"
 
 ["Benchmark report copied"]
 en = "Benchmark report copied"
@@ -9545,6 +10211,7 @@ ja = "ベンチマークレポートをコピーしました"
 pt = "Relatório de benchmark copiado"
 it = "Rapporto prestazioni copiato"
 id = "Laporan tolok ukur disalin"
+pl = "Skopiowano raport testu wydajności"
 
 ["Checking compute server..."]
 en = "Checking compute server..."
@@ -9559,6 +10226,7 @@ ja = "計算サーバーを確認中..."
 pt = "Verificando servidor de computação..."
 it = "Controllo del server di calcolo..."
 id = "Memeriksa server komputasi..."
+pl = "Sprawdzanie serwera obliczeniowego..."
 
 ["Choose a compatible Blender binary in Preferences"]
 en = "Choose a compatible Blender binary in Preferences"
@@ -9573,6 +10241,7 @@ ja = "設定で互換性のあるBlender実行ファイルを選択してくだ�
 pt = "Escolha um executável compatível do Blender nas Preferências"
 it = "Scegli un binario Blender compatibile nelle Preferenze"
 id = "Pilih biner Blender yang kompatibel di Preferensi"
+pl = "Wybierz zgodny plik wykonywalny Blender w Preferencjach"
 
 ["Expression output unavailable"]
 en = "Expression output unavailable"
@@ -9587,6 +10256,7 @@ ja = "式の出力を利用できません"
 pt = "Saída de expressão indisponível"
 it = "Output dell'espressione non disponibile"
 id = "Output ekspresi tidak tersedia"
+pl = "Wynik wyrażenia niedostępny"
 
 ["Jacobi passes used to minimize the MeshFlow energy"]
 en = "Jacobi passes used to minimize the MeshFlow energy"
@@ -9601,6 +10271,7 @@ ja = "MeshFlowエネルギーを最小化するJacobiパス数"
 pt = "Passos de Jacobi usados para minimizar a energia do MeshFlow"
 it = "Passaggi Jacobi usati per minimizzare l'energia di MeshFlow"
 id = "Lulusan Jacobi digunakan untuk meminimalkan energi MeshFlow"
+pl = "Przebiegi Jacobiego użyte do minimalizacji energii MeshFlow"
 
 ["Ready (%{count} samples)"]
 en = "Ready (%{count} samples)"
@@ -9615,6 +10286,7 @@ ja = "準備完了（%{count}サンプル）"
 pt = "Pronto (%{count} amostras)"
 it = "Pronto (%{count} campioni)"
 id = "Siap (%{count} sampel)"
+pl = "Gotowe (%{count} próbek)"
 
 ["Selected tracking method is unavailable"]
 en = "Selected tracking method is unavailable"
@@ -9629,6 +10301,7 @@ ja = "選択したトラッキング方式は利用できません"
 pt = "O método de rastreamento selecionado está indisponível"
 it = "Il metodo di tracking selezionato non è disponibile"
 id = "Metode pelacakan yang dipilih tidak tersedia"
+pl = "Wybrana metoda śledzenia jest niedostępna"
 
 ["Source track is empty"]
 en = "Source track is empty"
@@ -9643,6 +10316,7 @@ ja = "ソーストラックが空です"
 pt = "A faixa de origem está vazia"
 it = "La traccia sorgente è vuota"
 id = "Trek sumber kosong"
+pl = "Ścieżka źródłowa jest pusta"
 
 ["Source track unavailable"]
 en = "Source track unavailable"
@@ -9657,6 +10331,7 @@ ja = "ソーストラックを利用できません"
 pt = "Faixa de origem indisponível"
 it = "Traccia sorgente non disponibile"
 id = "Trek sumber tidak tersedia"
+pl = "Ścieżka źródłowa niedostępna"
 
 ["3-band EQ"]
 en = "3-band EQ"
@@ -9671,6 +10346,7 @@ ja = "3バンドEQ"
 pt = "Equalizador de 3 bandas"
 it = "Equalizzatore a 3 bande"
 id = "EQ 3-band"
+pl = "3-pasmowy EQ"
 
 ["3D Object"]
 en = "3D Object"
@@ -9685,6 +10361,7 @@ ja = "3Dオブジェクト"
 pt = "Objeto 3D"
 it = "Oggetto 3D"
 id = "Objek 3D"
+pl = "Obiekt 3D"
 
 ["3D Shape"]
 en = "3D Shape"
@@ -9699,6 +10376,7 @@ ja = "3D図形"
 pt = "Forma 3D"
 it = "Forma 3D"
 id = "Bentuk 3D"
+pl = "Kształt 3D"
 
 ["3D Text"]
 en = "3D Text"
@@ -9713,6 +10391,7 @@ ja = "3Dテキスト"
 pt = "Texto 3D"
 it = "Testo 3D"
 id = "Teks 3D"
+pl = "Tekst 3D"
 
 ["Alpha outline"]
 en = "Alpha outline"
@@ -9727,6 +10406,7 @@ ja = "アルファアウトライン"
 pt = "Contorno alfa"
 it = "Contorno alpha"
 id = "Garis luar alfa"
+pl = "Kontur alfa"
 
 ["Append"]
 en = "Append"
@@ -9741,6 +10421,7 @@ ja = "末尾に追加"
 pt = "Anexar ao final"
 it = "Aggiungi alla fine"
 id = "Tambahkan di akhir"
+pl = "Dołącz"
 
 ["Bitcrusher"]
 en = "Bitcrusher"
@@ -9755,6 +10436,7 @@ ja = "ビットクラッシャー"
 pt = "Bitcrusher"
 it = "Bitcrusher"
 id = "Bitcrusher"
+pl = "Bitcrusher"
 
 ["Bulge"]
 en = "Bulge"
@@ -9769,6 +10451,7 @@ ja = "膨張"
 pt = "Abaulamento"
 it = "Rigonfiamento"
 id = "Cembung"
+pl = "Wybrzuszenie"
 
 ["Cache"]
 en = "Cache"
@@ -9783,6 +10466,7 @@ ja = "キャッシュ"
 pt = "Cache"
 it = "Cache"
 id = "Cache"
+pl = "Cache"
 
 ["Channel mixer"]
 en = "Channel mixer"
@@ -9797,6 +10481,7 @@ ja = "チャンネルミキサー"
 pt = "Misturador de canais"
 it = "Mixer di canali"
 id = "Mixer saluran"
+pl = "Mikser kanałów"
 
 ["Chorus"]
 en = "Chorus"
@@ -9811,6 +10496,7 @@ ja = "コーラス"
 pt = "Chorus"
 it = "Coro"
 id = "Chorus"
+pl = "Chorus"
 
 ["Chroma key"]
 en = "Chroma key"
@@ -9825,6 +10511,7 @@ ja = "クロマキー"
 pt = "Chroma key"
 it = "Chroma key"
 id = "Chroma key"
+pl = "Klucz chroma"
 
 ["Chromatic aberration"]
 en = "Chromatic aberration"
@@ -9839,6 +10526,7 @@ ja = "色収差"
 pt = "Aberração cromática"
 it = "Aberrazione cromatica"
 id = "Aberasi kromatik"
+pl = "Aberracja chromatyczna"
 
 ["Close up"]
 en = "Close up"
@@ -9853,6 +10541,7 @@ ja = "クローズアップ"
 pt = "Primeiro plano"
 it = "Primo piano"
 id = "Close up"
+pl = "Zbliżenie"
 
 ["Color correction"]
 en = "Color correction"
@@ -9867,6 +10556,7 @@ ja = "色補正"
 pt = "Correção de cor"
 it = "Correzione colore"
 id = "Koreksi warna"
+pl = "Korekcja koloru"
 
 ["Compressor"]
 en = "Compressor"
@@ -9881,6 +10571,7 @@ ja = "コンプレッサー"
 pt = "Compressor"
 it = "Compressore"
 id = "Kompresor"
+pl = "Kompresor"
 
 ["Corner Pin"]
 en = "Corner Pin"
@@ -9895,6 +10586,7 @@ ja = "コーナーピン"
 pt = "Deformação de cantos"
 it = "Ancoraggio angoli"
 id = "Corner Pin"
+pl = "Przypięcie narożników"
 
 ["Crop"]
 en = "Crop"
@@ -9909,6 +10601,7 @@ ja = "クロップ"
 pt = "Recortar"
 it = "Ritaglio"
 id = "Pangkas"
+pl = "Przycinanie"
 
 ["Decode"]
 en = "Decode"
@@ -9923,6 +10616,7 @@ ja = "デコード"
 pt = "Decodificar"
 it = "Decodifica"
 id = "Dekode"
+pl = "Dekodowanie"
 
 ["Denoise"]
 en = "Denoise"
@@ -9937,6 +10631,7 @@ ja = "ノイズ除去"
 pt = "Redução de ruído"
 it = "Riduzione rumore"
 id = "Denoise"
+pl = "Redukcja szumów"
 
 ["Directional blur"]
 en = "Directional blur"
@@ -9951,6 +10646,7 @@ ja = "方向ぼかし"
 pt = "Desfoque direcional"
 it = "Sfocatura direzionale"
 id = "Buram terarah"
+pl = "Rozmycie kierunkowe"
 
 ["Displacement map"]
 en = "Displacement map"
@@ -9965,6 +10661,7 @@ ja = "ディスプレイスメントマップ"
 pt = "Mapa de deslocamento"
 it = "Mappa di spostamento"
 id = "Displacement map"
+pl = "Mapa przemieszczenia"
 
 ["Dithering"]
 en = "Dithering"
@@ -9979,6 +10676,7 @@ ja = "ディザリング"
 pt = "Dithering"
 it = "Dithering"
 id = "Dithering"
+pl = "Dithering"
 
 ["Drop shadow"]
 en = "Drop shadow"
@@ -9993,6 +10691,7 @@ ja = "ドロップシャドウ"
 pt = "Sombra projetada"
 it = "Ombra esterna"
 id = "Bayangan luar"
+pl = "Cień rzucany"
 
 ["Duotone"]
 en = "Duotone"
@@ -10007,6 +10706,7 @@ ja = "デュオトーン"
 pt = "Duotono"
 it = "Duotono"
 id = "Duotone"
+pl = "Duoton"
 
 ["Echo"]
 en = "Echo"
@@ -10021,6 +10721,7 @@ ja = "エコー"
 pt = "Eco"
 it = "Eco"
 id = "Gema"
+pl = "Echo"
 
 ["Edge detection"]
 en = "Edge detection"
@@ -10035,6 +10736,7 @@ ja = "エッジ検出"
 pt = "Detecção de bordas"
 it = "Rilevamento bordi"
 id = "Deteksi tepi"
+pl = "Wykrywanie krawędzi"
 
 ["Emboss"]
 en = "Emboss"
@@ -10049,6 +10751,7 @@ ja = "エンボス"
 pt = "Relevo"
 it = "Rilievo"
 id = "Embos"
+pl = "Wytłoczenie"
 
 ["Erode"]
 en = "Erode"
@@ -10063,6 +10766,7 @@ ja = "収縮"
 pt = "Erosão"
 it = "Erosione"
 id = "Erosi"
+pl = "Erozja"
 
 ["Filter"]
 en = "Filter"
@@ -10077,6 +10781,7 @@ ja = "フィルター"
 pt = "Filtro"
 it = "Filtro"
 id = "Filter"
+pl = "Filtr"
 
 ["Fisheye"]
 en = "Fisheye"
@@ -10091,6 +10796,7 @@ ja = "魚眼"
 pt = "Olho-de-peixe"
 it = "Fisheye"
 id = "Fisheye"
+pl = "Rybie oko"
 
 ["Gain"]
 en = "Gain"
@@ -10105,6 +10811,7 @@ ja = "ゲイン"
 pt = "Ganho"
 it = "Guadagno"
 id = "Gain"
+pl = "Wzmocnienie"
 
 ["Gaussian blur"]
 en = "Gaussian blur"
@@ -10119,6 +10826,7 @@ ja = "ガウスぼかし"
 pt = "Desfoque gaussiano"
 it = "Sfocatura gaussiana"
 id = "Buram Gaussian"
+pl = "Rozmycie gaussowskie"
 
 ["Glow"]
 en = "Glow"
@@ -10133,6 +10841,7 @@ ja = "グロー"
 pt = "Brilho"
 it = "Bagliore"
 id = "Pijar"
+pl = "Poświata"
 
 ["Ground"]
 en = "Ground"
@@ -10147,6 +10856,7 @@ ja = "地面"
 pt = "Chão"
 it = "Suolo"
 id = "Dasar"
+pl = "Podłoże"
 
 ["Halftone"]
 en = "Halftone"
@@ -10161,6 +10871,7 @@ ja = "ハーフトーン"
 pt = "Meio-tom"
 it = "Semitono"
 id = "Halftone"
+pl = "Półton"
 
 ["Insert"]
 en = "Insert"
@@ -10175,6 +10886,7 @@ ja = "挿入"
 pt = "Inserir"
 it = "Inserisci"
 id = "Sisipkan"
+pl = "Wstaw"
 
 ["Jump"]
 en = "Jump"
@@ -10189,6 +10901,7 @@ ja = "ジャンプ"
 pt = "Salto"
 it = "Salto"
 id = "Lompat"
+pl = "Skok"
 
 ["Kaleidoscope"]
 en = "Kaleidoscope"
@@ -10203,6 +10916,7 @@ ja = "万華鏡"
 pt = "Caleidoscópio"
 it = "Caleidoscopio"
 id = "Kaleidoskop"
+pl = "Kalejdoskop"
 
 ["Kuwahara"]
 en = "Kuwahara"
@@ -10217,6 +10931,7 @@ ja = "Kuwahara"
 pt = "Kuwahara"
 it = "Kuwahara"
 id = "Kuwahara"
+pl = "Kuwahara"
 
 ["Lens distortion"]
 en = "Lens distortion"
@@ -10231,6 +10946,7 @@ ja = "レンズ歪み"
 pt = "Distorção de lente"
 it = "Distorsione lente"
 id = "Distorsi lensa"
+pl = "Zniekształcenie obiektywu"
 
 ["Limiter"]
 en = "Limiter"
@@ -10245,6 +10961,7 @@ ja = "リミッター"
 pt = "Limitador"
 it = "Limitatore"
 id = "Limiter"
+pl = "Limiter"
 
 ["Luma key"]
 en = "Luma key"
@@ -10259,6 +10976,7 @@ ja = "ルマキー"
 pt = "Chave de luma"
 it = "Luma key"
 id = "Luma key"
+pl = "Klucz luma"
 
 ["Manim Smooth"]
 en = "Manim Smooth"
@@ -10273,6 +10991,7 @@ ja = "Manimスムーズ"
 pt = "Suavização do Manim"
 it = "Smussamento Manim"
 id = "Halus Manim"
+pl = "Wygładzanie Manim"
 
 ["Mosaic"]
 en = "Mosaic"
@@ -10287,6 +11006,7 @@ ja = "モザイク"
 pt = "Mosaico"
 it = "Mosaico"
 id = "Mosaik"
+pl = "Mozaika"
 
 ["Noise"]
 en = "Noise"
@@ -10301,6 +11021,7 @@ ja = "ノイズ"
 pt = "Ruído"
 it = "Rumore"
 id = "Derau"
+pl = "Szum"
 
 ["Noise gate"]
 en = "Noise gate"
@@ -10315,6 +11036,7 @@ ja = "ノイズゲート"
 pt = "Gate de ruído"
 it = "Noise gate"
 id = "Gerbang derau"
+pl = "Bramka szumów"
 
 ["Pan"]
 en = "Pan"
@@ -10329,6 +11051,7 @@ ja = "パン"
 pt = "Panorâmica"
 it = "Panoramica"
 id = "Pan"
+pl = "Panoramowanie"
 
 ["Path offset"]
 en = "Path offset"
@@ -10343,6 +11066,7 @@ ja = "パスオフセット"
 pt = "Deslocamento do caminho"
 it = "Offset del percorso"
 id = "Ofset jalur"
+pl = "Przesunięcie ścieżki"
 
 ["Phone mic"]
 en = "Phone mic"
@@ -10357,6 +11081,7 @@ ja = "電話マイク"
 pt = "Microfone de telefone"
 it = "Microfono telefono"
 id = "Mikrofon ponsel"
+pl = "Mikrofon telefonu"
 
 ["Point Light"]
 en = "Point Light"
@@ -10371,6 +11096,7 @@ ja = "ポイントライト"
 pt = "Luz pontual"
 it = "Luce puntiforme"
 id = "Cahaya Titik"
+pl = "Światło punktowe"
 
 ["Posterize"]
 en = "Posterize"
@@ -10385,6 +11111,7 @@ ja = "ポスタリゼーション"
 pt = "Posterizar"
 it = "Posterizza"
 id = "Posterisasi"
+pl = "Posteryzacja"
 
 ["Radial blur"]
 en = "Radial blur"
@@ -10399,6 +11126,7 @@ ja = "放射状ぼかし"
 pt = "Desfoque radial"
 it = "Blur radiale"
 id = "Buram radial"
+pl = "Rozmycie radialne"
 
 ["Rasterize"]
 en = "Rasterize"
@@ -10413,6 +11141,7 @@ ja = "ラスタライズ"
 pt = "Rasterizar"
 it = "Rasterizza"
 id = "Rasterisasi"
+pl = "Rasteryzacja"
 
 ["Reverb"]
 en = "Reverb"
@@ -10427,6 +11156,7 @@ ja = "リバーブ"
 pt = "Reverberação"
 it = "Riverbero"
 id = "Reverb"
+pl = "Pogłos"
 
 ["Rewrite"]
 en = "Rewrite"
@@ -10441,6 +11171,7 @@ ja = "書き直し"
 pt = "Reescrever"
 it = "Riscrivi"
 id = "Tulis ulang"
+pl = "Przepisać"
 
 ["Sampling"]
 en = "Sampling"
@@ -10455,6 +11186,7 @@ ja = "サンプリング"
 pt = "Amostragem"
 it = "Campionamento"
 id = "Pengambilan sampel"
+pl = "Próbkowanie"
 
 ["Shaky path"]
 en = "Shaky path"
@@ -10469,6 +11201,7 @@ ja = "揺れるパス"
 pt = "Caminho trêmulo"
 it = "Tracciato tremolante"
 id = "Jalur bergetar"
+pl = "Drżąca ścieżka"
 
 ["Sharpen"]
 en = "Sharpen"
@@ -10483,6 +11216,7 @@ ja = "シャープ"
 pt = "Nitidez"
 it = "Nitidezza"
 id = "Pertajam"
+pl = "Wyostrzanie"
 
 ["Stereo width"]
 en = "Stereo width"
@@ -10497,6 +11231,7 @@ ja = "ステレオ幅"
 pt = "Largura estéreo"
 it = "Larghezza stereo"
 id = "Lebar stereo"
+pl = "Szerokość stereo"
 
 ["Sun"]
 en = "Sun"
@@ -10511,6 +11246,7 @@ ja = "太陽"
 pt = "Sol"
 it = "Sole"
 id = "Matahari"
+pl = "Słońce"
 
 ["Text mask"]
 en = "Text mask"
@@ -10525,6 +11261,7 @@ ja = "テキストマスク"
 pt = "Máscara de texto"
 it = "Maschera di testo"
 id = "Mask teks"
+pl = "Maska tekstowa"
 
 ["Texture bounds"]
 en = "Texture bounds"
@@ -10539,6 +11276,7 @@ ja = "テクスチャ境界"
 pt = "Limites da textura"
 it = "Limiti della texture"
 id = "Batas tekstur"
+pl = "Granice tekstury"
 
 ["Transparent Fill"]
 en = "Transparent Fill"
@@ -10553,6 +11291,7 @@ ja = "透明塗り"
 pt = "Preenchimento transparente"
 it = "Riempimento trasparente"
 id = "Isian Transparan"
+pl = "Przezroczyste wypełnienie"
 
 ["Tremolo"]
 en = "Tremolo"
@@ -10567,6 +11306,7 @@ ja = "トレモロ"
 pt = "Trêmolo"
 it = "Tremolo"
 id = "Tremolo"
+pl = "Tremolo"
 
 ["Twirl"]
 en = "Twirl"
@@ -10581,6 +11321,7 @@ ja = "渦巻き"
 pt = "Redemoinho"
 it = "Vortice"
 id = "Pusaran"
+pl = "Zawirowanie"
 
 ["Vectorize"]
 en = "Vectorize"
@@ -10595,6 +11336,7 @@ ja = "ベクター化"
 pt = "Vetorizar"
 it = "Vettorizza"
 id = "Vektorisasi"
+pl = "Wektoryzacja"
 
 ["Vignette"]
 en = "Vignette"
@@ -10609,6 +11351,7 @@ ja = "ビネット"
 pt = "Vinheta"
 it = "Vignettatura"
 id = "Vinyet"
+pl = "Winieta"
 
 ["Voice Change"]
 en = "Voice Change"
@@ -10623,6 +11366,7 @@ ja = "ボイスチェンジ"
 pt = "Mudança de voz"
 it = "Modifica voce"
 id = "Ubah Suara"
+pl = "Zmiana głosu"
 
 ["Wave"]
 en = "Wave"
@@ -10637,6 +11381,7 @@ ja = "波"
 pt = "Onda"
 it = "Onda"
 id = "Gelombang"
+pl = "Fala"
 
 ["Zoom blur"]
 en = "Zoom blur"
@@ -10651,6 +11396,7 @@ ja = "ズームぼかし"
 pt = "Desfoque de zoom"
 it = "Blur zoom"
 id = "Buram zoom"
+pl = "Rozmycie zbliżeniowe"
 
 ["Diff"]
 en = "Diff"
@@ -10665,6 +11411,7 @@ ja = "差分"
 pt = "Diferença"
 it = "Differenza"
 id = "Diff"
+pl = "Różnica"
 
 ["Back In"]
 en = "Back In"
@@ -10679,6 +11426,7 @@ ja = "バック・イン"
 pt = "Recuo de entrada"
 it = "Back In"
 id = "Mundur Masuk"
+pl = "Wsteczne wejście"
 
 ["Back Out"]
 en = "Back Out"
@@ -10693,6 +11441,7 @@ ja = "バック・アウト"
 pt = "Recuo de saída"
 it = "Back Out"
 id = "Mundur Keluar"
+pl = "Wsteczne wyjście"
 
 ["Back In Out"]
 en = "Back In Out"
@@ -10707,6 +11456,7 @@ ja = "バック・インアウト"
 pt = "Recuo de entrada e saída"
 it = "Back In Out"
 id = "Mundur Masuk Keluar"
+pl = "Wsteczne wejście i wyjście"
 
 ["Bounce In"]
 en = "Bounce In"
@@ -10721,6 +11471,7 @@ ja = "バウンス・イン"
 pt = "Rebote de entrada"
 it = "Bounce In"
 id = "Pantul Masuk"
+pl = "Odbijające wejście"
 
 ["Bounce Out"]
 en = "Bounce Out"
@@ -10735,6 +11486,7 @@ ja = "バウンス・アウト"
 pt = "Rebote de saída"
 it = "Bounce Out"
 id = "Pantul Keluar"
+pl = "Odbijające wyjście"
 
 ["Bounce In Out"]
 en = "Bounce In Out"
@@ -10749,6 +11501,7 @@ ja = "バウンス・インアウト"
 pt = "Rebote de entrada e saída"
 it = "Bounce In Out"
 id = "Pantul Masuk Keluar"
+pl = "Odbijające wejście i wyjście"
 
 ["Circular In"]
 en = "Circular In"
@@ -10763,6 +11516,7 @@ ja = "円・イン"
 pt = "Circular de entrada"
 it = "Circular In"
 id = "Melingkar Masuk"
+pl = "Kołowe wejście"
 
 ["Circular Out"]
 en = "Circular Out"
@@ -10777,6 +11531,7 @@ ja = "円・アウト"
 pt = "Circular de saída"
 it = "Circular Out"
 id = "Melingkar Keluar"
+pl = "Kołowe wyjście"
 
 ["Circular In Out"]
 en = "Circular In Out"
@@ -10791,6 +11546,7 @@ ja = "円・インアウト"
 pt = "Circular de entrada e saída"
 it = "Circular In Out"
 id = "Melingkar Masuk Keluar"
+pl = "Kołowe wejście i wyjście"
 
 ["Cubic In"]
 en = "Cubic In"
@@ -10805,6 +11561,7 @@ ja = "3次・イン"
 pt = "Cúbica de entrada"
 it = "Cubic In"
 id = "Kubik Masuk"
+pl = "Sześcienne wejście"
 
 ["Cubic Out"]
 en = "Cubic Out"
@@ -10819,6 +11576,7 @@ ja = "3次・アウト"
 pt = "Cúbica de saída"
 it = "Cubic Out"
 id = "Kubik Keluar"
+pl = "Sześcienne wyjście"
 
 ["Cubic In Out"]
 en = "Cubic In Out"
@@ -10833,6 +11591,7 @@ ja = "3次・インアウト"
 pt = "Cúbica de entrada e saída"
 it = "Cubic In Out"
 id = "Kubik Masuk Keluar"
+pl = "Sześcienne wejście i wyjście"
 
 ["Elastic In"]
 en = "Elastic In"
@@ -10847,6 +11606,7 @@ ja = "弾性・イン"
 pt = "Elástica de entrada"
 it = "Elastic In"
 id = "Elastis Masuk"
+pl = "Elastyczne wejście"
 
 ["Elastic Out"]
 en = "Elastic Out"
@@ -10861,6 +11621,7 @@ ja = "弾性・アウト"
 pt = "Elástica de saída"
 it = "Elastic Out"
 id = "Elastis Keluar"
+pl = "Elastyczne wyjście"
 
 ["Elastic In Out"]
 en = "Elastic In Out"
@@ -10875,6 +11636,7 @@ ja = "弾性・インアウト"
 pt = "Elástica de entrada e saída"
 it = "Elastic In Out"
 id = "Elastis Masuk Keluar"
+pl = "Elastyczne wejście i wyjście"
 
 ["Exponential In"]
 en = "Exponential In"
@@ -10889,6 +11651,7 @@ ja = "指数・イン"
 pt = "Exponencial de entrada"
 it = "Exponential In"
 id = "Eksponensial Masuk"
+pl = "Wykładnicze wejście"
 
 ["Exponential Out"]
 en = "Exponential Out"
@@ -10903,6 +11666,7 @@ ja = "指数・アウト"
 pt = "Exponencial de saída"
 it = "Exponential Out"
 id = "Eksponensial Keluar"
+pl = "Wykładnicze wyjście"
 
 ["Exponential In Out"]
 en = "Exponential In Out"
@@ -10917,6 +11681,7 @@ ja = "指数・インアウト"
 pt = "Exponencial de entrada e saída"
 it = "Exponential In Out"
 id = "Eksponensial Masuk Keluar"
+pl = "Wykładnicze wejście i wyjście"
 
 ["Quad In"]
 en = "Quad In"
@@ -10931,6 +11696,7 @@ ja = "2次・イン"
 pt = "Quadrática de entrada"
 it = "Quad In"
 id = "Kuadratik Masuk"
+pl = "Kwadratowe wejście"
 
 ["Quad Out"]
 en = "Quad Out"
@@ -10945,6 +11711,7 @@ ja = "2次・アウト"
 pt = "Quadrática de saída"
 it = "Quad Out"
 id = "Kuadratik Keluar"
+pl = "Kwadratowe wyjście"
 
 ["Quad In Out"]
 en = "Quad In Out"
@@ -10959,6 +11726,7 @@ ja = "2次・インアウト"
 pt = "Quadrática de entrada e saída"
 it = "Quad In Out"
 id = "Kuadratik Masuk Keluar"
+pl = "Kwadratowe wejście i wyjście"
 
 ["Quart In"]
 en = "Quart In"
@@ -10973,6 +11741,7 @@ ja = "4次・イン"
 pt = "Quártica de entrada"
 it = "Quart In"
 id = "Kuartik Masuk"
+pl = "Kwartyczne wejście"
 
 ["Quart Out"]
 en = "Quart Out"
@@ -10987,6 +11756,7 @@ ja = "4次・アウト"
 pt = "Quártica de saída"
 it = "Quart Out"
 id = "Kuartik Keluar"
+pl = "Kwartyczne wyjście"
 
 ["Quart In Out"]
 en = "Quart In Out"
@@ -11001,6 +11771,7 @@ ja = "4次・インアウト"
 pt = "Quártica de entrada e saída"
 it = "Quart In Out"
 id = "Kuartik Masuk Keluar"
+pl = "Kwartyczne wejście i wyjście"
 
 ["Quint In"]
 en = "Quint In"
@@ -11015,6 +11786,7 @@ ja = "5次・イン"
 pt = "Quíntica de entrada"
 it = "Quint In"
 id = "Kuintik Masuk"
+pl = "Kwintyczne wejście"
 
 ["Quint Out"]
 en = "Quint Out"
@@ -11029,6 +11801,7 @@ ja = "5次・アウト"
 pt = "Quíntica de saída"
 it = "Quint Out"
 id = "Kuintik Keluar"
+pl = "Kwintyczne wyjście"
 
 ["Quint In Out"]
 en = "Quint In Out"
@@ -11043,6 +11816,7 @@ ja = "5次・インアウト"
 pt = "Quíntica de entrada e saída"
 it = "Quint In Out"
 id = "Kuintik Masuk Keluar"
+pl = "Kwintyczne wejście i wyjście"
 
 ["Sine In"]
 en = "Sine In"
@@ -11057,6 +11831,7 @@ ja = "サイン・イン"
 pt = "Seno de entrada"
 it = "Sine In"
 id = "Sinus Masuk"
+pl = "Sinusoidalne wejście"
 
 ["Sine Out"]
 en = "Sine Out"
@@ -11071,6 +11846,7 @@ ja = "サイン・アウト"
 pt = "Seno de saída"
 it = "Sine Out"
 id = "Sinus Keluar"
+pl = "Sinusoidalne wyjście"
 
 ["Sine In Out"]
 en = "Sine In Out"
@@ -11085,6 +11861,7 @@ ja = "サイン・インアウト"
 pt = "Seno de entrada e saída"
 it = "Sine In Out"
 id = "Sinus Masuk Keluar"
+pl = "Sinusoidalne wejście i wyjście"
 
 ["1 video track"]
 en = "1 video track"
@@ -11099,6 +11876,7 @@ ja = "ビデオトラック1本"
 pt = "1 faixa de vídeo"
 it = "1 traccia video"
 id = "1 trek video"
+pl = "1 ścieżka wideo"
 
 ["%{count} video tracks"]
 en = "%{count} video tracks"
@@ -11113,6 +11891,7 @@ ja = "ビデオトラック%{count}本"
 pt = "%{count} faixas de vídeo"
 it = "%{count} tracce video"
 id = "%{count} trek video"
+pl = "%{count} ścieżek wideo"
 
 ["1 audio track"]
 en = "1 audio track"
@@ -11127,6 +11906,7 @@ ja = "オーディオトラック1本"
 pt = "1 faixa de áudio"
 it = "1 traccia audio"
 id = "1 trek audio"
+pl = "1 ścieżka dźwiękowa"
 
 ["%{count} audio tracks"]
 en = "%{count} audio tracks"
@@ -11141,6 +11921,7 @@ ja = "オーディオトラック%{count}本"
 pt = "%{count} faixas de áudio"
 it = "%{count} tracce audio"
 id = "%{count} trek audio"
+pl = "%{count} ścieżek dźwiękowych"
 
 ["1 caption track"]
 en = "1 caption track"
@@ -11155,6 +11936,7 @@ ja = "字幕トラック1本"
 pt = "1 faixa de legendas"
 it = "1 traccia sottotitoli"
 id = "1 track subtitel"
+pl = "1 ścieżka napisów"
 
 ["%{count} caption tracks"]
 en = "%{count} caption tracks"
@@ -11169,6 +11951,7 @@ ja = "字幕トラック%{count}本"
 pt = "%{count} faixas de legendas"
 it = "%{count} tracce sottotitoli"
 id = "%{count} track subtitel"
+pl = "%{count} ścieżek napisów"
 
 ["1 page"]
 en = "1 page"
@@ -11183,6 +11966,7 @@ ja = "1ページ"
 pt = "1 página"
 it = "1 pagina"
 id = "1 halaman"
+pl = "1 strona"
 
 ["%{count} pages"]
 en = "%{count} pages"
@@ -11197,6 +11981,7 @@ ja = "%{count}ページ"
 pt = "%{count} páginas"
 it = "%{count} pagine"
 id = "%{count} halaman"
+pl = "%{count} stron"
 
 ["3D models"]
 en = "3D models"
@@ -11211,6 +11996,7 @@ ja = "3Dモデル"
 pt = "Modelos 3D"
 it = "Modelli 3D"
 id = "Model 3D"
+pl = "Modele 3D"
 
 ["OptiX denoiser"]
 en = "OptiX denoiser"
@@ -11225,6 +12011,7 @@ ja = "OptiX デノイザー"
 pt = "Redutor de ruído OptiX"
 it = "Riduzione del rumore OptiX"
 id = "Pereduksi derau OptiX"
+pl = "Redukcja szumów OptiX"
 
 ["2× rotated grid"]
 en = "2× rotated grid"
@@ -11239,6 +12026,7 @@ ja = "2倍回転グリッド"
 pt = "Grade rotacionada 2×"
 it = "Griglia ruotata 2×"
 id = "Kisi diputar 2×"
+pl = "Siatka obrócona 2×"
 
 ["4× grid"]
 en = "4× grid"
@@ -11253,6 +12041,7 @@ ja = "4倍グリッド"
 pt = "Grade 4×"
 it = "Griglia 4×"
 id = "Kisi 4×"
+pl = "Siatka 4×"
 
 ["8× stochastic"]
 en = "8× stochastic"
@@ -11267,6 +12056,7 @@ ja = "8倍確率的"
 pt = "Estocástico 8×"
 it = "Stocastico 8×"
 id = "Stokastik 8×"
+pl = "8× stochastyczne"
 
 ["FLAC · Lossless"]
 en = "FLAC · Lossless"
@@ -11281,6 +12071,7 @@ ja = "FLAC · ロスレス"
 pt = "FLAC · Sem perdas"
 it = "FLAC · Lossless"
 id = "FLAC · Lossless"
+pl = "FLAC · Bezstratne"
 
 ["H.265 · Balanced"]
 en = "H.265 · Balanced"
@@ -11295,6 +12086,7 @@ ja = "H.265 · バランス"
 pt = "H.265 · Equilibrado"
 it = "H.265 · Bilanciato"
 id = "H.265 · Seimbang"
+pl = "H.265 · Zrównoważone"
 
 ["H.265 · Compact"]
 en = "H.265 · Compact"
@@ -11309,6 +12101,7 @@ ja = "H.265 · コンパクト"
 pt = "H.265 · Compacto"
 it = "H.265 · Compatto"
 id = "H.265 · Ringkas"
+pl = "H.265 · Kompaktowe"
 
 ["H.265 · High"]
 en = "H.265 · High"
@@ -11323,6 +12116,7 @@ ja = "H.265 · 高品質"
 pt = "H.265 · Alto"
 it = "H.265 · Alto"
 id = "H.265 · Tinggi"
+pl = "H.265 · Wysokie"
 
 ["H.265 · Lossless"]
 en = "H.265 · Lossless"
@@ -11337,6 +12131,7 @@ ja = "H.265 · ロスレス"
 pt = "H.265 · Sem perdas"
 it = "H.265 · Lossless"
 id = "H.265 · Lossless"
+pl = "H.265 · Bezstratne"
 
 ["Monospace Sans"]
 en = "Monospace Sans"
@@ -11351,6 +12146,7 @@ ja = "等幅サンセリフ"
 pt = "Monoespaçada sem serifa"
 it = "Monospace Sans"
 id = "Monospace Sans"
+pl = "Monospace bezszeryfowe"
 
 ["Monospace Serif"]
 en = "Monospace Serif"
@@ -11365,6 +12161,7 @@ ja = "等幅セリフ"
 pt = "Monoespaçada com serifa"
 it = "Monospace Serif"
 id = "Monospace Serif"
+pl = "Monospace szeryfowe"
 
 ["Opus · Balanced"]
 en = "Opus · Balanced"
@@ -11379,6 +12176,7 @@ ja = "Opus · バランス"
 pt = "Opus · Equilibrado"
 it = "Opus · Bilanciato"
 id = "Opus · Seimbang"
+pl = "Opus · Zrównoważone"
 
 ["Opus · Compact"]
 en = "Opus · Compact"
@@ -11393,6 +12191,7 @@ ja = "Opus · コンパクト"
 pt = "Opus · Compacto"
 it = "Opus · Compatto"
 id = "Opus · Ringkas"
+pl = "Opus · Kompaktowe"
 
 ["Opus · High"]
 en = "Opus · High"
@@ -11407,3 +12206,4 @@ ja = "Opus · 高品質"
 pt = "Opus · Alto"
 it = "Opus · Alto"
 id = "Opus · Tinggi"
+pl = "Opus · Wysokie"

--- a/crates/ui/i18n-core/locales/media.toml
+++ b/crates/ui/i18n-core/locales/media.toml
@@ -13,6 +13,7 @@ ja = "サーバーに接続しています…"
 pt = "Conectando ao servidor…"
 it = "Connessione al server…"
 id = "Menghubungkan ke server…"
+pl = "Łączenie z serwerem…"
 
 ["Generate"]
 en = "Generate"
@@ -27,6 +28,7 @@ ja = "生成"
 pt = "Gerar"
 it = "Genera"
 id = "Hasilkan"
+pl = "Wygeneruj" 
 
 ["Regenerate"]
 en = "Regenerate"
@@ -41,6 +43,7 @@ ja = "再生成"
 pt = "Regenerar"
 it = "Rigenera"
 id = "Hasilkan Ulang"
+pl = "Wygeneruj ponownie"
 
 ["Ready"]
 en = "Ready"
@@ -55,6 +58,7 @@ ja = "準備完了"
 pt = "Pronto"
 it = "Pronto"
 id = "Siap"
+pl = "Gotowe" 
 
 ["Select a model"]
 en = "Select a model"
@@ -69,6 +73,7 @@ ja = "モデルを選択してください"
 pt = "Selecione um modelo"
 it = "Seleziona un modello"
 id = "Pilih model"
+pl = "Wybierz model" 
 
 ["Generated"]
 en = "Generated"
@@ -83,6 +88,7 @@ ja = "生成完了"
 pt = "Gerado"
 it = "Generato"
 id = "Dihasilkan"
+pl = "Wygenerowano" 
 
 ["Add…"]
 en = "Add…"
@@ -97,6 +103,7 @@ ja = "追加…"
 pt = "Adicionar…"
 it = "Aggiungi…"
 id = "Tambah…"
+pl = "Dodaj…" 
 
 ["Show in Folder"]
 en = "Show in Folder"
@@ -111,6 +118,7 @@ ja = "フォルダーに表示"
 pt = "Mostrar na pasta"
 it = "Mostra nella cartella"
 id = "Tampilkan di Folder"
+pl = "Pokaż w folderze" 
 
 ["Choose an audio file"]
 en = "Choose an audio file"
@@ -125,6 +133,7 @@ ja = "音声ファイルを選択"
 pt = "Escolher um arquivo de áudio"
 it = "Scegli un file audio"
 id = "Pilih file audio"
+pl = "Wybierz plik audio" 
 
 ["Reference audio actions"]
 en = "Reference audio actions"
@@ -139,6 +148,7 @@ ja = "参照音声の操作"
 pt = "Ações de áudio de referência"
 it = "Azioni audio di riferimento"
 id = "Tindakan audio referensi"
+pl = "Akcje dźwięku referencyjnego" 
 
 ["Add row"]
 en = "Add row"
@@ -153,6 +163,7 @@ ja = "行を追加"
 pt = "Adicionar linha"
 it = "Aggiungi fila"
 id = "Tambah baris"
+pl = "Dodaj wiersz"
 
 ["Remove row"]
 en = "Remove row"
@@ -167,6 +178,7 @@ ja = "行を削除"
 pt = "Remover linha"
 it = "Rimuovi fila"
 id = "Hapus baris"
+pl = "Usuń wiersz" 
 
 ["Export"]
 en = "Export"
@@ -181,6 +193,7 @@ ja = "書き出し"
 pt = "Exportar"
 it = "Esporta"
 id = "Ekspor"
+pl = "Eksportuj"
 
 ["Export video"]
 en = "Export video"
@@ -195,6 +208,7 @@ ja = "動画を書き出す"
 pt = "Exportar vídeo"
 it = "Esporta video"
 id = "Ekspor video"
+pl = "Eksportuj wideo"
 
 ["Export captions (YTT)"]
 en = "Export captions (YTT)"
@@ -209,6 +223,7 @@ ja = "字幕を書き出す（YTT）"
 pt = "Exportar legendas (YTT)"
 it = "Esporta sottotitoli (YTT)"
 id = "Ekspor subtitel (YTT)"
+pl = "Eksportuj napisy (YTT)"
 
 ["Export JSON"]
 en = "Export JSON"
@@ -223,6 +238,7 @@ ja = "JSONを書き出す"
 pt = "Exportar JSON"
 it = "Esporta JSON"
 id = "Ekspor JSON"
+pl = "Eksportuj JSON" 
 
 ["Merge into one file"]
 en = "Merge into one file"
@@ -237,6 +253,7 @@ ja = "1つのファイルに結合"
 pt = "Mesclar em um único arquivo"
 it = "Unisci in un unico file"
 id = "Gabungkan ke satu file"
+pl = "Połącz w jeden plik" 
 
 ["Export each track separately"]
 en = "Export each track separately"
@@ -251,6 +268,7 @@ ja = "各トラックを個別に書き出す"
 pt = "Exportar cada faixa separadamente"
 it = "Esporta ogni traccia separatamente"
 id = "Ekspor tiap trek secara terpisah"
+pl = "Eksportuj każdą ścieżkę osobno" 
 
 ["Export YTT"]
 en = "Export YTT"
@@ -265,6 +283,7 @@ ja = "YTTを書き出す"
 pt = "Exportar YTT"
 it = "Esporta YTT"
 id = "Ekspor YTT"
+pl = "Eksportuj YTT"
 
 ["Export Captions"]
 en = "Export Captions"
@@ -279,6 +298,7 @@ ja = "字幕を書き出す"
 pt = "Exportar legendas"
 it = "Esporta sottotitoli"
 id = "Ekspor Subtitel"
+pl = "Eksportuj napisy"
 
 ["Export YouTube Captions"]
 en = "Export YouTube Captions"
@@ -293,6 +313,7 @@ ja = "YouTube字幕を書き出す"
 pt = "Exportar legendas do YouTube"
 it = "Esporta sottotitoli YouTube"
 id = "Ekspor Subtitel YouTube"
+pl = "Eksportuj napisy YouTube"
 
 ["Captions exported"]
 en = "Captions exported"
@@ -307,6 +328,7 @@ ja = "字幕を書き出しました"
 pt = "Legendas exportadas"
 it = "Sottotitoli esportati"
 id = "Subtitel diekspor"
+pl = "Napisy wyeksportowane"
 
 ["%{count} caption files exported"]
 en = "%{count} caption files exported"
@@ -321,6 +343,7 @@ ja = "%{count}個の字幕ファイルを書き出しました"
 pt = "%{count} arquivos de legenda exportados"
 it = "%{count} file di sottotitoli esportati"
 id = "%{count} file subtitel diekspor"
+pl = "Wyeksportowano %{count} plików z napisami"
 
 ["Export format"]
 en = "Export format"
@@ -335,6 +358,7 @@ ja = "書き出し形式"
 pt = "Formato de exportação"
 it = "Formato di esportazione"
 id = "Format ekspor"
+pl = "Format eksportu"
 
 ["Container"]
 en = "Container"
@@ -349,6 +373,7 @@ ja = "コンテナ"
 pt = "Contêiner"
 it = "Contenitore"
 id = "Kontainer"
+pl = "Kontener"
 
 ["Background Alpha"]
 en = "Background Alpha"
@@ -363,6 +388,7 @@ ja = "背景のアルファ"
 pt = "Alfa do fundo"
 it = "Alpha dello sfondo"
 id = "Alfa Latar Belakang"
+pl = "Alfa tła"
 
 ["Values below 128 are transparent in GIF output"]
 en = "Values below 128 are transparent in GIF output"
@@ -377,6 +403,7 @@ ja = "128未満の値はGIF出力で透明になります"
 pt = "Valores abaixo de 128 ficam transparentes na saída em GIF"
 it = "I valori inferiori a 128 sono trasparenti nell'output GIF"
 id = "Nilai di bawah 128 transparan pada output GIF"
+pl = "Wartości poniżej 128 są przezroczyste w wyjściowym GIF"
 
 ["Rate Control"]
 en = "Rate Control"
@@ -391,6 +418,7 @@ ja = "レート制御"
 pt = "Controle de taxa"
 it = "Controllo del bitrate"
 id = "Kontrol Bitrate"
+pl = "Kontrola bitrate"
 
 ["Constant QP"]
 en = "Constant QP"
@@ -405,6 +433,7 @@ ja = "固定QP"
 pt = "QP constante"
 it = "QP costante"
 id = "QP Konstan"
+pl = "Stałe QP" 
 
 ["Constant Bitrate"]
 en = "Constant Bitrate"
@@ -419,6 +448,7 @@ ja = "固定ビットレート"
 pt = "Taxa de bits constante"
 it = "Bitrate costante"
 id = "Bitrate Konstan"
+pl = "Stały bitrate"
 
 ["Variable Bitrate"]
 en = "Variable Bitrate"
@@ -433,6 +463,7 @@ ja = "可変ビットレート"
 pt = "Taxa de bits variável"
 it = "Bitrate variabile"
 id = "Bitrate Variabel"
+pl = "Zmienny bitrate"
 
 ["Variable Bitrate with Target Quality"]
 en = "Variable Bitrate with Target Quality"
@@ -447,6 +478,7 @@ ja = "目標品質付き可変ビットレート"
 pt = "Taxa de bits variável com qualidade alvo"
 it = "Bitrate variabile con qualità obiettivo"
 id = "Bitrate Variabel dengan Kualitas Target"
+pl = "Zmienny bitrate z docelową jakością"
 
 ["Lossless"]
 en = "Lossless"
@@ -461,6 +493,7 @@ ja = "可逆"
 pt = "Sem perdas"
 it = "Senza perdite"
 id = "Lossless"
+pl = "Bez utraty danych"
 
 ["Video Bitrate"]
 en = "Video Bitrate"
@@ -475,6 +508,7 @@ ja = "動画ビットレート"
 pt = "Taxa de bits do vídeo"
 it = "Bitrate video"
 id = "Bitrate Video"
+pl = "Bitrate wideo"
 
 ["Kbps for CBR/VBR"]
 en = "Kbps for CBR/VBR"
@@ -489,6 +523,7 @@ ja = "CBR/VBRのKbps"
 pt = "Kbps para CBR/VBR"
 it = "Kbps per CBR/VBR"
 id = "Kbps untuk CBR/VBR"
+pl = "Kbps dla CBR/VBR"
 
 ["Max Video Bitrate"]
 en = "Max Video Bitrate"
@@ -503,6 +538,7 @@ ja = "最大動画ビットレート"
 pt = "Taxa máxima de bits do vídeo"
 it = "Bitrate video massimo"
 id = "Bitrate Video Maksimum"
+pl = "Maksymalny bitrate wideo"
 
 ["Kbps for VBR"]
 en = "Kbps for VBR"
@@ -517,6 +553,7 @@ ja = "VBRのKbps"
 pt = "Kbps para VBR"
 it = "Kbps per VBR"
 id = "Kbps untuk VBR"
+pl = "Kbps dla VBR"
 
 ["Target Quality"]
 en = "Target Quality"
@@ -531,6 +568,7 @@ ja = "目標品質"
 pt = "Qualidade alvo"
 it = "Qualità obiettivo"
 id = "Kualitas Target"
+pl = "Jakość docelowa"
 
 ["Lower values are higher quality"]
 en = "Lower values are higher quality"
@@ -545,6 +583,7 @@ ja = "値が小さいほど高品質です"
 pt = "Valores menores significam maior qualidade"
 it = "Valori più bassi hanno qualità maggiore"
 id = "Nilai yang lebih rendah memiliki kualitas lebih tinggi"
+pl = "Niższe wartości oznaczają wyższą jakość"
 
 ["Keyframe Interval"]
 en = "Keyframe Interval"
@@ -559,6 +598,7 @@ ja = "キーフレーム間隔"
 pt = "Intervalo de quadros-chave"
 it = "Intervallo tra keyframe"
 id = "Interval Keyframe"
+pl = "Odstęp między klatkami kluczowymi"
 
 ["Seconds; 0 lets NVENC choose"]
 en = "Seconds; 0 lets NVENC choose"
@@ -573,6 +613,7 @@ ja = "秒。0の場合はNVENCが選択します"
 pt = "Segundos; 0 permite que o NVENC escolha"
 it = "Secondi; 0 lascia scegliere a NVENC"
 id = "Detik; 0 membiarkan NVENC memilih"
+pl = "Sekundy; 0 pozwala NVENC wybrać automatycznie"
 
 ["P1: Fastest (Lowest Quality)"]
 en = "P1: Fastest (Lowest Quality)"
@@ -587,6 +628,7 @@ ja = "P1: 最速（最低品質）"
 pt = "P1: Mais rápido (Menor qualidade)"
 it = "P1: Il più veloce (qualità minima)"
 id = "P1: Tercepat (Kualitas Terendah)"
+pl = "P1: Najszybsze (Najsłabsza jakość)"
 
 ["P2: Faster (Lower Quality)"]
 en = "P2: Faster (Lower Quality)"
@@ -601,6 +643,7 @@ ja = "P2: 高速（低品質）"
 pt = "P2: Mais rápido (Qualidade inferior)"
 it = "P2: Più veloce (qualità bassa)"
 id = "P2: Lebih Cepat (Kualitas Lebih Rendah)"
+pl = "P2: Szybsze (Słabsza jakość)"
 
 ["P3: Fast (Low Quality)"]
 en = "P3: Fast (Low Quality)"
@@ -615,6 +658,7 @@ ja = "P3: 速い（低品質）"
 pt = "P3: Rápido (Baixa qualidade)"
 it = "P3: Veloce (qualità bassa)"
 id = "P3: Cepat (Kualitas Rendah)"
+pl = "P3: Szybkie (Słaba jakość)"
 
 ["P4: Medium (Medium Quality)"]
 en = "P4: Medium (Medium Quality)"
@@ -629,6 +673,7 @@ ja = "P4: 標準（標準品質）"
 pt = "P4: Médio (Qualidade média)"
 it = "P4: Medio (qualità media)"
 id = "P4: Sedang (Kualitas Sedang)"
+pl = "P4: Średnie (Średnia jakość)"
 
 ["P5: Slow (Good Quality)"]
 en = "P5: Slow (Good Quality)"
@@ -643,6 +688,7 @@ ja = "P5: 低速（高品質）"
 pt = "P5: Lento (Boa qualidade)"
 it = "P5: Lento (buona qualità)"
 id = "P5: Lambat (Kualitas Bagus)"
+pl = "P5: Wolne (Dobra jakość)"
 
 ["P6: Slower (Better Quality)"]
 en = "P6: Slower (Better Quality)"
@@ -657,6 +703,7 @@ ja = "P6: より低速（より高品質）"
 pt = "P6: Mais lento (Melhor qualidade)"
 it = "P6: Più lento (migliore qualità)"
 id = "P6: Lebih Lambat (Kualitas Lebih Baik)"
+pl = "P6: Wolniejsze (Lepsza jakość)"
 
 ["P7: Slowest (Best Quality)"]
 en = "P7: Slowest (Best Quality)"
@@ -671,6 +718,7 @@ ja = "P7: 最低速（最高品質）"
 pt = "P7: O mais lento (Melhor qualidade)"
 it = "P7: Il più lento (qualità massima)"
 id = "P7: Terlambat (Kualitas Terbaik)"
+pl = "P7: Najwolniejsze (Najlepsza jakość)"
 
 ["Tuning"]
 en = "Tuning"
@@ -685,6 +733,7 @@ ja = "チューニング"
 pt = "Ajuste fino"
 it = "Ottimizzazione"
 id = "Penyetelan"
+pl = "Dostrajanie"
 
 ["Ultra High Quality"]
 en = "Ultra High Quality"
@@ -699,6 +748,7 @@ ja = "超高品質"
 pt = "Qualidade ultra-alta"
 it = "Qualità ultra alta"
 id = "Kualitas Sangat Tinggi"
+pl = "Ultra wysoka jakość"
 
 ["High Quality"]
 en = "High Quality"
@@ -713,6 +763,7 @@ ja = "高品質"
 pt = "Alta qualidade"
 it = "Qualità alta"
 id = "Kualitas Tinggi"
+pl = "Wysoka jakość"
 
 ["Low Latency"]
 en = "Low Latency"
@@ -727,6 +778,7 @@ ja = "低遅延"
 pt = "Baixa latência"
 it = "Bassa latenza"
 id = "Latensi Rendah"
+pl = "Niskie opóźnienie"
 
 ["Ultra Low Latency"]
 en = "Ultra Low Latency"
@@ -741,6 +793,7 @@ ja = "超低遅延"
 pt = "Latência ultrabaixa"
 it = "Latenza ultra bassa"
 id = "Latensi Sangat Rendah"
+pl = "Ultra niskie opóźnienie"
 
 ["Multi Pass"]
 en = "Multi Pass"
@@ -755,6 +808,7 @@ ja = "マルチパス"
 pt = "Múltiplas passagens"
 it = "Multi-pass"
 id = "Multi-pass"
+pl = "Wieloprzebiegowe"
 
 ["Single Pass"]
 en = "Single Pass"
@@ -769,6 +823,7 @@ ja = "1パス"
 pt = "Passagem única"
 it = "Passaggio singolo"
 id = "Single-pass"
+pl = "Jednoprzebiegowe"
 
 ["Two Passes (Quarter Resolution)"]
 en = "Two Passes (Quarter Resolution)"
@@ -783,6 +838,7 @@ ja = "2パス（4分の1解像度）"
 pt = "Duas passagens (Um quarto da resolução)"
 it = "Due passaggi (un quarto di risoluzione)"
 id = "Dua Putaran (Seperempat Resolusi)"
+pl = "Dwa przebiegi (ćwierć rozdzielczości)"
 
 ["Two Passes (Full Resolution)"]
 en = "Two Passes (Full Resolution)"
@@ -797,6 +853,7 @@ ja = "2パス（フル解像度）"
 pt = "Duas passagens (resolução máxima)"
 it = "Due passaggi (risoluzione piena)"
 id = "Dua Putaran (Resolusi Penuh)"
+pl = "Dwa przebiegi (pełna rozdzielczość)"
 
 ["Profile"]
 en = "Profile"
@@ -811,6 +868,7 @@ ja = "プロファイル"
 pt = "Perfil"
 it = "Profilo"
 id = "Profil"
+pl = "Profil"
 
 ["Look-ahead"]
 en = "Look-ahead"
@@ -825,6 +883,7 @@ ja = "先読み"
 pt = "Look-ahead"
 it = "Look-ahead"
 id = "Look-ahead"
+pl = "Look-ahead"
 
 ["Adaptive Quantization"]
 en = "Adaptive Quantization"
@@ -839,6 +898,7 @@ ja = "適応量子化"
 pt = "Quantização adaptativa"
 it = "Quantizzazione adattiva"
 id = "Kuantisasi Adaptif"
+pl = "Adaptacyjna kwantyzacja"
 
 ["B Frames"]
 en = "B Frames"
@@ -853,6 +913,7 @@ ja = "Bフレーム"
 pt = "Quadros B"
 it = "B frames"
 id = "Frame B"
+pl = "B-klatki"
 
 ["B Frame as Reference"]
 en = "B Frame as Reference"
@@ -867,6 +928,7 @@ ja = "Bフレームを参照に使用"
 pt = "Quadro B como referência"
 it = "B frames come riferimento"
 id = "Frame B sebagai Referensi"
+pl = "B-klatka jako odniesienie"
 
 ["Audio Encoder"]
 en = "Audio Encoder"
@@ -881,6 +943,7 @@ ja = "音声エンコーダー"
 pt = "Codificador de áudio"
 it = "Encoder audio"
 id = "Enkoder Audio"
+pl = "Enkoder audio"
 
 ["Audio Sample Rate"]
 en = "Audio Sample Rate"
@@ -895,6 +958,7 @@ ja = "音声サンプルレート"
 pt = "Taxa de amostragem de áudio"
 it = "Frequenza di campionamento audio"
 id = "Sample Rate Audio"
+pl = "Częstotliwość próbkowania dźwięku"
 
 ["Audio Bitrate"]
 en = "Audio Bitrate"
@@ -909,6 +973,7 @@ ja = "音声ビットレート"
 pt = "Taxa de bits de áudio"
 it = "Bitrate audio"
 id = "Bitrate Audio"
+pl = "Bitrate audio"
 
 ["Kbps"]
 en = "Kbps"
@@ -923,6 +988,7 @@ ja = "Kbps"
 pt = "Kbps"
 it = "Kbps"
 id = "Kbps"
+pl = "Kbps"
 
 ["Video format"]
 en = "Video format"
@@ -937,6 +1003,7 @@ ja = "動画形式"
 pt = "Formato de vídeo"
 it = "Formato video"
 id = "Format video"
+pl = "Format wideo"
 
 ["Encoder settings"]
 en = "Encoder settings"
@@ -951,6 +1018,7 @@ ja = "エンコーダー設定"
 pt = "Configurações do codificador"
 it = "Impostazioni encoder"
 id = "Pengaturan enkoder"
+pl = "Ustawienia enkodera"
 
 ["Export Video"]
 en = "Export Video"
@@ -965,6 +1033,7 @@ ja = "動画を書き出す"
 pt = "Exportar vídeo"
 it = "Esporta video"
 id = "Ekspor Video"
+pl = "Eksportuj wideo"
 
 ["Video exported in %{duration}"]
 en = "Video exported in %{duration}"
@@ -979,6 +1048,7 @@ ja = "%{duration}で動画を書き出しました"
 pt = "Vídeo exportado em %{duration}"
 it = "Video esportato in %{duration}"
 id = "Video diekspor dalam %{duration}"
+pl = "Wideo wyeksportowane w %{duration}"
 
 ["Exporting Video"]
 en = "Exporting Video"
@@ -993,6 +1063,7 @@ ja = "動画を書き出しています"
 pt = "Exportando vídeo"
 it = "Esportazione video"
 id = "Mengekspor Video"
+pl = "Eksportowanie wideo"
 
 ["Preparing"]
 en = "Preparing"
@@ -1007,6 +1078,7 @@ ja = "準備中"
 pt = "Preparando"
 it = "Preparazione"
 id = "Menyiapkan"
+pl = "Przygotowywanie"
 
 ["Stabilizing source video"]
 en = "Stabilizing source video"
@@ -1021,6 +1093,7 @@ ja = "元の動画を安定化しています"
 pt = "Estabilizando vídeo de origem"
 it = "Stabilizzazione del video sorgente"
 id = "Menstabilkan video sumber"
+pl = "Stabilizowanie źródła wideo"
 
 ["Opening output file"]
 en = "Opening output file"
@@ -1035,6 +1108,7 @@ ja = "出力ファイルを開いています"
 pt = "Abrindo arquivo de saída"
 it = "Apertura del file di output"
 id = "Membuka file output"
+pl = "Otwieranie pliku wyjściowego"
 
 ["Preparing video renderer"]
 en = "Preparing video renderer"
@@ -1049,6 +1123,7 @@ ja = "動画レンダラーを準備しています"
 pt = "Preparando renderizador de vídeo"
 it = "Preparazione del renderer video"
 id = "Menyiapkan perender video"
+pl = "Przygotowywanie renderera wideo"
 
 ["Preparing hardware frames"]
 en = "Preparing hardware frames"
@@ -1063,6 +1138,7 @@ ja = "ハードウェアフレームを準備しています"
 pt = "Preparando quadros de hardware"
 it = "Preparazione dei fotogrammi hardware"
 id = "Menyiapkan frame perangkat keras"
+pl = "Przygotowywanie klatek sprzętowych"
 
 ["Opening video encoder"]
 en = "Opening video encoder"
@@ -1077,6 +1153,7 @@ ja = "動画エンコーダーを開いています"
 pt = "Abrindo codificador de vídeo"
 it = "Apertura dell'encoder video"
 id = "Membuka enkoder video"
+pl = "Otwieranie enkodera wideo"
 
 ["Opening audio encoder"]
 en = "Opening audio encoder"
@@ -1091,6 +1168,7 @@ ja = "音声エンコーダーを開いています"
 pt = "Abrindo codificador de áudio"
 it = "Apertura dell'encoder audio"
 id = "Membuka enkoder audio"
+pl = "Otwieranie enkodera audio"
 
 ["Writing media header"]
 en = "Writing media header"
@@ -1105,6 +1183,7 @@ ja = "メディアヘッダーを書き込んでいます"
 pt = "Gravando cabeçalho de mídia"
 it = "Scrittura dell'intestazione media"
 id = "Menulis header media"
+pl = "Zapisywanie nagłówka multimediów"
 
 ["Preparing audio"]
 en = "Preparing audio"
@@ -1119,6 +1198,7 @@ ja = "音声を準備しています"
 pt = "Preparando áudio"
 it = "Preparazione audio"
 id = "Menyiapkan audio"
+pl = "Przygotowywanie audio"
 
 ["Preparing audio (%{percent}%)"]
 en = "Preparing audio (%{percent}%)"
@@ -1133,6 +1213,7 @@ ja = "音声を準備しています（%{percent}%）"
 pt = "Preparando áudio (%{percent}%)"
 it = "Preparazione audio (%{percent}%)"
 id = "Menyiapkan audio (%{percent}%)"
+pl = "Przygotowywanie audio (%{percent}%)"
 
 ["Encoding audio"]
 en = "Encoding audio"
@@ -1147,6 +1228,7 @@ ja = "音声をエンコードしています"
 pt = "Codificando áudio"
 it = "Codifica audio"
 id = "Mengenkode audio"
+pl = "Kodowanie audio"
 
 ["Encoding audio (%{percent}%)"]
 en = "Encoding audio (%{percent}%)"
@@ -1161,6 +1243,7 @@ ja = "音声をエンコードしています（%{percent}%）"
 pt = "Codificando áudio (%{percent}%)"
 it = "Codifica audio (%{percent}%)"
 id = "Mengenkode audio (%{percent}%)"
+pl = "Kodowanie audio (%{percent}%)"
 
 ["Rendering frames"]
 en = "Rendering frames"
@@ -1175,6 +1258,7 @@ ja = "フレームをレンダリングしています"
 pt = "Renderizando quadros"
 it = "Rendering dei fotogrammi"
 id = "Merender frame"
+pl = "Renderowanie klatek"
 
 ["%{current} of %{total} frames (%{percent}%)"]
 en = "%{current} of %{total} frames (%{percent}%)"
@@ -1189,6 +1273,7 @@ ja = "%{total}フレーム中%{current}（%{percent}%）"
 pt = "%{current} de %{total} quadros (%{percent}%)"
 it = "%{current} di %{total} fotogrammi (%{percent}%)"
 id = "%{current} dari %{total} frame (%{percent}%)"
+pl = "%{current} z %{total} klatek (%{percent}%)"
 
 ["%{current} of %{total} frames (%{percent}%) - %{fps} fps - %{eta} left"]
 en = "%{current} of %{total} frames (%{percent}%) - %{fps} fps - %{eta} left"
@@ -1203,6 +1288,7 @@ ja = "%{total}フレーム中%{current}（%{percent}%）- %{fps} fps - 残り%{e
 pt = "%{current} de %{total} quadros (%{percent}%) - %{fps} fps - %{eta} restantes"
 it = "%{current} di %{total} fotogrammi (%{percent}%) - %{fps} fps - rimanenti %{eta}"
 id = "%{current} dari %{total} frame (%{percent}%) - %{fps} fps - tersisa %{eta}"
+pl = "%{current} z %{total} klatek (%{percent}%) - %{fps} fps - %{eta} pozostało"
 
 ["Finishing file"]
 en = "Finishing file"
@@ -1217,6 +1303,7 @@ ja = "ファイルを仕上げています"
 pt = "Finalizando arquivo"
 it = "Completamento del file"
 id = "Menyelesaikan file"
+pl = "Finalizowanie pliku"
 
 ["Finishing"]
 en = "Finishing"
@@ -1231,6 +1318,7 @@ ja = "仕上げ中"
 pt = "Finalizando"
 it = "Completamento"
 id = "Menyelesaikan"
+pl = "Kończenie"
 
 ["JSON exported"]
 en = "JSON exported"
@@ -1245,6 +1333,7 @@ ja = "JSONを書き出しました"
 pt = "JSON exportado"
 it = "JSON esportato"
 id = "JSON diekspor"
+pl = "JSON wyeksportowane"
 
 ["Step back one frame"]
 en = "Step back one frame"
@@ -1259,6 +1348,7 @@ ja = "1フレーム戻る"
 pt = "Voltar um quadro"
 it = "Indietro di un fotogramma"
 id = "Mundur satu frame"
+pl = "Cofnij się o jedną klatkę"
 
 ["Play"]
 en = "Play"
@@ -1273,6 +1363,7 @@ ja = "再生"
 pt = "Reproduzir"
 it = "Riproduci"
 id = "Putar"
+pl = "Odtwórz"
 
 ["Pause"]
 en = "Pause"
@@ -1287,6 +1378,7 @@ ja = "一時停止"
 pt = "Pausar"
 it = "Pausa"
 id = "Jeda"
+pl = "Wstrzymaj"
 
 ["Step forward one frame"]
 en = "Step forward one frame"
@@ -1301,6 +1393,7 @@ ja = "1フレーム進む"
 pt = "Avançar um quadro"
 it = "Avanti di un fotogramma"
 id = "Maju satu frame"
+pl = "Idź do przodu o jedną klatkę"
 
 ["Fullscreen preview"]
 en = "Fullscreen preview"
@@ -1315,6 +1408,7 @@ ja = "全画面プレビュー"
 pt = "Pré-visualização em tela cheia"
 it = "Anteprima a schermo intero"
 id = "Pratinjau layar penuh"
+pl = "Podgląd pełnoekranowy"
 
 ["Restore preview"]
 en = "Restore preview"
@@ -1329,6 +1423,7 @@ ja = "プレビューを元に戻す"
 pt = "Restaurar pré-visualização"
 it = "Ripristina anteprima"
 id = "Pulihkan pratinjau"
+pl = "Przywróć podgląd"
 
 ["Guide"]
 en = "Guide"
@@ -1343,6 +1438,7 @@ ja = "ガイド"
 pt = "Guia"
 it = "Guida"
 id = "Garis Panduan"
+pl = "Linie pomocnicze"
 
 ["Playback speed"]
 en = "Playback speed"
@@ -1357,6 +1453,7 @@ ja = "再生速度"
 pt = "Velocidade de reprodução"
 it = "Velocità di riproduzione"
 id = "Kecepatan pemutaran"
+pl = "Prędkość odtwarzania"
 
 ["x1"]
 en = "x1"
@@ -1371,6 +1468,7 @@ ja = "x1"
 pt = "1x"
 it = "x1"
 id = "x1"
+pl = "x1"
 
 ["--"]
 en = "--"
@@ -1385,6 +1483,7 @@ ja = "--"
 pt = "--"
 it = "--"
 id = "--"
+pl = "--"
 
 ["Playback speed %{speed}"]
 en = "Playback speed %{speed}"
@@ -1399,6 +1498,7 @@ ja = "再生速度: %{speed}"
 pt = "Velocidade de reprodução %{speed}"
 it = "Velocità di riproduzione %{speed}"
 id = "Kecepatan pemutaran %{speed}"
+pl = "Prędkość odtwarzania %{speed}"
 
 ["Pen (B)"]
 en = "Pen (B)"
@@ -1413,6 +1513,7 @@ ja = "ペン（B）"
 pt = "Caneta (B)"
 it = "Penna (B)"
 id = "Pena (B)"
+pl = "Pióro (B)"
 
 ["Fill (F)"]
 en = "Fill (F)"
@@ -1427,6 +1528,7 @@ ja = "塗りつぶし（F）"
 pt = "Preenchimento (F)"
 it = "Riempi (F)"
 id = "Isi (F)"
+pl = "Wypełnienie (F)"
 
 ["Stroke Transform (T)"]
 en = "Stroke Transform (T)"
@@ -1441,6 +1543,7 @@ ja = "ストローク変形（T）"
 pt = "Transformar traço (T)"
 it = "Trasforma tratto (T)"
 id = "Transformasi Goresan (T)"
+pl = "Transformacja obrysu (T)"
 
 ["Eraser (E)"]
 en = "Eraser (E)"
@@ -1455,6 +1558,7 @@ ja = "消しゴム（E）"
 pt = "Borracha (E)"
 it = "Gomma (E)"
 id = "Penghapus (E)"
+pl = "Gumka (E)"
 
 ["Adjust points (hold Ctrl for temporary adjustment)"]
 en = "Adjust points (hold Ctrl for temporary adjustment)"
@@ -1469,6 +1573,7 @@ ja = "ポイントを調整（Ctrlを押している間だけ一時調整）"
 pt = "Ajustar pontos (segure Ctrl para ajuste temporário)"
 it = "Regola i punti (tieni premuto Ctrl per la regolazione temporanea)"
 id = "Sesuaikan titik (tahan Ctrl untuk penyesuaian sementara)"
+pl = "Dostosuj punkty (przytrzymaj Ctrl, aby tymczasowo dostosować)"
 
 ["Pen width scale"]
 en = "Pen width scale"
@@ -1483,6 +1588,7 @@ ja = "ペン幅の倍率"
 pt = "Escala da largura da caneta"
 it = "Scala spessore penna"
 id = "Skala lebar pena"
+pl = "Skala szerokości pióra"
 
 ["Eraser width scale"]
 en = "Eraser width scale"
@@ -1497,6 +1603,7 @@ ja = "消しゴム幅の倍率"
 pt = "Escala da largura da borracha"
 it = "Scala spessore gomma"
 id = "Skala lebar penghapus"
+pl = "Skala szerokości gumki"
 
 ["Fill gap tolerance"]
 en = "Fill gap tolerance"
@@ -1511,6 +1618,7 @@ ja = "塗りつぶしの隙間許容値"
 pt = "Tolerância de abertura do preenchimento"
 it = "Tolleranza di riempimento dei vuoti"
 id = "Toleransi celah pengisian"
+pl = "Tolerancja szczeliny wypełnienia"
 
 ["Previous drawing onion skin"]
 en = "Previous drawing onion skin"
@@ -1525,6 +1633,7 @@ ja = "前の描画のオニオンスキン"
 pt = "Papel vegetal do desenho anterior"
 it = "Onion skin del disegno precedente"
 id = "Onion skin gambar sebelumnya"
+pl = "Nakładka onion poprzedniego rysunku"
 
 ["Next drawing onion skin"]
 en = "Next drawing onion skin"
@@ -1539,6 +1648,7 @@ ja = "次の描画のオニオンスキン"
 pt = "Papel vegetal do próximo desenho"
 it = "Onion skin del disegno successivo"
 id = "Onion skin gambar berikutnya"
+pl = "Nakładka onion następnego rysunku"
 
 ["Paint texture %{number}"]
 en = "Paint texture %{number}"
@@ -1553,6 +1663,7 @@ ja = "ペイントテクスチャ%{number}"
 pt = "Textura de pintura %{number}"
 it = "Texture pittura %{number}"
 id = "Tekstur lukisan %{number}"
+pl = "Tekstura farby %{number}"
 
 ["Video Player"]
 en = "Video Player"
@@ -1567,6 +1678,7 @@ ja = "動画プレーヤー"
 pt = "Reprodutor de vídeo"
 it = "Player video"
 id = "Pemutar Video"
+pl = "Odtwarzacz wideo"
 
 ["Copy Preview Image"]
 en = "Copy Preview Image"
@@ -1581,6 +1693,7 @@ ja = "プレビュー画像をコピー"
 pt = "Copiar imagem da pré-visualização"
 it = "Copia immagine anteprima"
 id = "Salin Gambar Pratinjau"
+pl = "Kopiuj obraz podglądu"
 
 ["Save Preview Image…"]
 en = "Save Preview Image…"
@@ -1595,6 +1708,7 @@ ja = "プレビュー画像を保存…"
 pt = "Salvar imagem da pré-visualização…"
 it = "Salva immagine anteprima…"
 id = "Simpan Gambar Pratinjau…"
+pl = "Zapisz obraz podglądu…"
 
 ["Save Preview Image"]
 en = "Save Preview Image"
@@ -1609,6 +1723,7 @@ ja = "プレビュー画像を保存"
 pt = "Salvar imagem da pré-visualização"
 it = "Salva immagine anteprima"
 id = "Simpan Gambar Pratinjau"
+pl = "Zapisz obraz podglądu"
 
 ["PNG image"]
 en = "PNG image"
@@ -1623,6 +1738,7 @@ ja = "PNG画像"
 pt = "Imagem PNG"
 it = "Immagine PNG"
 id = "Gambar PNG"
+pl = "Obraz PNG"
 
 ["Magnet"]
 en = "Magnet"
@@ -1637,6 +1753,7 @@ ja = "マグネット"
 pt = "Ímã"
 it = "Magnete"
 id = "Magnet"
+pl = "Magnes"
 
 ["Beat Grid"]
 en = "Beat Grid"
@@ -1651,6 +1768,7 @@ ja = "ビートグリッド"
 pt = "Grade de batidas"
 it = "Griglia dei beat"
 id = "Beat Grid"
+pl = "Siatka rytmu"
 
 ["Analyzing beats…"]
 en = "Analyzing beats…"
@@ -1665,6 +1783,7 @@ ja = "ビートを解析しています…"
 pt = "Analisando batidas…"
 it = "Analisi dei beat…"
 id = "Menganalisis ketukan…"
+pl = "Analizowanie rytmu…"
 
 ["No reliable beat detected"]
 en = "No reliable beat detected"
@@ -1679,6 +1798,7 @@ ja = "信頼できるビートを検出できませんでした"
 pt = "Nenhuma batida confiável detectada"
 it = "Nessun beat affidabile rilevato"
 id = "Tidak ada ketukan tepercaya yang terdeteksi"
+pl = "Nie znaleziono wiarygodnego rytmu"
 
 ["Pointer"]
 en = "Pointer"
@@ -1693,6 +1813,7 @@ ja = "ポインター"
 pt = "Ponteiro"
 it = "Puntatore"
 id = "Penunjuk"
+pl = "Wskaźnik"
 
 ["Cut"]
 en = "Cut"
@@ -1707,6 +1828,7 @@ ja = "カット"
 pt = "Cortar"
 it = "Taglia"
 id = "Potong"
+pl = "Cięcie"
 
 ["Overwrite/Insert"]
 en = "Overwrite/Insert"
@@ -1721,6 +1843,7 @@ ja = "上書き/挿入"
 pt = "Sobrescrever/Inserir"
 it = "Sovrascrivi/Inserisci"
 id = "Timpa/Sisipkan"
+pl = "Nadpisz/Wstaw"
 
 ["Block"]
 en = "Block"
@@ -1735,6 +1858,7 @@ ja = "ブロック"
 pt = "Bloquear"
 it = "Blocca"
 id = "Blok"
+pl = "Blok"
 
 ["Import Captions…"]
 en = "Import Captions…"
@@ -1749,6 +1873,7 @@ ja = "字幕を読み込む…"
 pt = "Importar legendas…"
 it = "Importa sottotitoli…"
 id = "Impor Subtitel…"
+pl = "Importuj napisy…"
 
 ["Import Media…"]
 en = "Import Media…"
@@ -1763,6 +1888,7 @@ ja = "メディアを読み込む…"
 pt = "Importar mídia…"
 it = "Importa media…"
 id = "Impor Media…"
+pl = "Importuj media…"
 
 ["3D Scene"]
 en = "3D Scene"
@@ -1777,6 +1903,7 @@ ja = "3Dシーン"
 pt = "Cena 3D"
 it = "Scena 3D"
 id = "Adegan 3D"
+pl = "Scena 3D"
 
 ["New %{kind}"]
 en = "New %{kind}"
@@ -1791,6 +1918,7 @@ ja = "新規%{kind}"
 pt = "Novo %{kind}"
 it = "Nuovo: %{kind}"
 id = "%{kind} Baru"
+pl = "Nowe: %{kind}"
 
 ["Paste"]
 en = "Paste"
@@ -1805,6 +1933,7 @@ ja = "貼り付け"
 pt = "Colar"
 it = "Incolla"
 id = "Tempel"
+pl = "Wklej"
 
 ["Replace Properties"]
 en = "Replace Properties"
@@ -1819,6 +1948,7 @@ ja = "プロパティを置換"
 pt = "Substituir propriedades"
 it = "Sostituisci proprietà"
 id = "Ganti Properti"
+pl = "Zamień właściwości"
 
 ["Paste Modifiers"]
 en = "Paste Modifiers"
@@ -1833,6 +1963,7 @@ ja = "モディファイアを貼り付け"
 pt = "Colar modificadores"
 it = "Incolla modificatori"
 id = "Tempel Pengubah"
+pl = "Wklej modyfikatory"
 
 ["Fold Sequence"]
 en = "Fold Sequence"
@@ -1847,6 +1978,7 @@ ja = "シーケンスを折りたたむ"
 pt = "Recolher sequência"
 it = "Comprimi sequenza"
 id = "Lipat Sekuens"
+pl = "Złóż sekwencję"
 
 ["Unlink Folder"]
 en = "Unlink Folder"
@@ -1861,6 +1993,7 @@ ja = "フォルダーのリンクを解除"
 pt = "Desvincular pasta"
 it = "Scollega cartella"
 id = "Putuskan Tautan Folder"
+pl = "Odłącz folder"
 
 ["Add Track at Top"]
 en = "Add Track at Top"
@@ -1875,6 +2008,7 @@ ja = "上にトラックを追加"
 pt = "Adicionar faixa no topo"
 it = "Aggiungi traccia in alto"
 id = "Tambah Track di Atas"
+pl = "Dodaj ścieżkę u góry"
 
 ["Add Track at Bottom"]
 en = "Add Track at Bottom"
@@ -1889,6 +2023,7 @@ ja = "下にトラックを追加"
 pt = "Adicionar faixa na base"
 it = "Aggiungi traccia in basso"
 id = "Tambah Track di Bawah"
+pl = "Dodaj ścieżkę na dole"
 
 ["Copy Frame"]
 en = "Copy Frame"
@@ -1903,6 +2038,7 @@ ja = "フレームをコピー"
 pt = "Copiar quadro"
 it = "Copia fotogramma"
 id = "Salin Frame"
+pl = "Kopiuj klatkę"
 
 ["Save Frame…"]
 en = "Save Frame…"
@@ -1917,6 +2053,7 @@ ja = "フレームを保存…"
 pt = "Salvar quadro…"
 it = "Salva fotogramma…"
 id = "Simpan Frame…"
+pl = "Zapisz klatkę…"
 
 ["Frame copied"]
 en = "Frame copied"
@@ -1931,6 +2068,7 @@ ja = "フレームをコピーしました"
 pt = "Quadro copiado"
 it = "Fotogramma copiato"
 id = "Frame disalin"
+pl = "Klatka skopiowana"
 
 ["Save Selected Frame"]
 en = "Save Selected Frame"
@@ -1945,6 +2083,7 @@ ja = "選択したフレームを保存"
 pt = "Salvar quadro selecionado"
 it = "Salva fotogramma selezionato"
 id = "Simpan Frame Terpilih"
+pl = "Zapisz zaznaczoną klatkę"
 
 ["Enable Beat Detection"]
 en = "Enable Beat Detection"
@@ -1959,6 +2098,7 @@ ja = "ビート検出を有効化"
 pt = "Habilitar detecção de batidas"
 it = "Attiva rilevamento dei beat"
 id = "Aktifkan Deteksi Ketukan"
+pl = "Włącz wykrywanie rytmu"
 
 ["Disable Beat Detection"]
 en = "Disable Beat Detection"
@@ -1973,6 +2113,7 @@ ja = "ビート検出を無効化"
 pt = "Desabilitar detecção de batidas"
 it = "Disattiva rilevamento dei beat"
 id = "Nonaktifkan Deteksi Ketukan"
+pl = "Wyłącz wykrywanie rytmu"
 
 ["Export Audio…"]
 en = "Export Audio…"
@@ -1987,6 +2128,7 @@ ja = "音声を書き出す…"
 pt = "Exportar áudio…"
 it = "Esporta audio…"
 id = "Ekspor Audio…"
+pl = "Eksportuj audio…"
 
 ["Transcribe"]
 en = "Transcribe"
@@ -2001,6 +2143,7 @@ ja = "文字起こし"
 pt = "Transcrever"
 it = "Trascrivi"
 id = "Transkripsikan"
+pl = "Transkrybuj"
 
 ["Remove Silences"]
 en = "Remove Silences"
@@ -2015,6 +2158,7 @@ ja = "無音部分を削除"
 pt = "Remover silêncios"
 it = "Rimuovi silenzi"
 id = "Hapus Bagian Hening"
+pl = "Usuń ciszę"
 
 ["Export Selected Audio"]
 en = "Export Selected Audio"
@@ -2029,6 +2173,7 @@ ja = "選択した音声を書き出す"
 pt = "Exportar áudio selecionado"
 it = "Esporta audio selezionato"
 id = "Ekspor Audio Terpilih"
+pl = "Eksportuj zaznaczone audio"
 
 ["Exporting Audio"]
 en = "Exporting Audio"
@@ -2043,6 +2188,7 @@ ja = "音声を書き出しています"
 pt = "Exportando áudio"
 it = "Esportazione audio"
 id = "Mengekspor Audio"
+pl = "Eksportowanie audio"
 
 ["The selected items will be mixed into one audio file."]
 en = "The selected items will be mixed into one audio file."
@@ -2057,6 +2203,7 @@ ja = "選択した項目を1つの音声ファイルにミックスします。"
 pt = "Os itens selecionados serão mixados em um único arquivo de áudio."
 it = "Gli elementi selezionati verranno mixati in un unico file audio."
 id = "Item yang dipilih akan digabungkan ke dalam satu file audio."
+pl = "Zaznaczone elementy zostaną połączone w jeden plik audio."
 
 ["Choose File"]
 en = "Choose File"
@@ -2071,6 +2218,7 @@ ja = "ファイルを選択"
 pt = "Escolher arquivo"
 it = "Scegli file"
 id = "Pilih File"
+pl = "Wybierz plik"
 
 ["Audio exported"]
 en = "Audio exported"
@@ -2085,6 +2233,7 @@ ja = "音声を書き出しました"
 pt = "Áudio exportado"
 it = "Audio esportato"
 id = "Audio diekspor"
+pl = "Audio wyeksportowane"
 
 ["Add Caption Track"]
 en = "Add Caption Track"
@@ -2099,6 +2248,7 @@ ja = "字幕トラックを追加"
 pt = "Adicionar faixa de legendas"
 it = "Aggiungi traccia sottotitoli"
 id = "Tambah Track Subtitel"
+pl = "Dodaj ścieżkę z napisami"
 
 ["Add Video Track"]
 en = "Add Video Track"
@@ -2113,6 +2263,7 @@ ja = "動画トラックを追加"
 pt = "Adicionar faixa de vídeo"
 it = "Aggiungi traccia video"
 id = "Tambah Track Video"
+pl = "Dodaj ścieżkę wideo"
 
 ["Add Audio Track"]
 en = "Add Audio Track"
@@ -2127,6 +2278,7 @@ ja = "音声トラックを追加"
 pt = "Adicionar faixa de áudio"
 it = "Aggiungi traccia audio"
 id = "Tambah Track Audio"
+pl = "Dodaj ścieżkę audio"
 
 ["Gain Offset"]
 en = "Gain Offset"
@@ -2141,6 +2293,7 @@ ja = "ゲインオフセット"
 pt = "Ajuste de ganho"
 it = "Offset gain"
 id = "Offset Gain"
+pl = "Przesunięcie wzmocnienia"
 
 ["Track gain offset in decibels"]
 en = "Track gain offset in decibels"
@@ -2155,6 +2308,7 @@ ja = "トラックのゲインオフセット（デシベル）"
 pt = "Ajuste de ganho da faixa em decibéis"
 it = "Offset gain della traccia in decibel"
 id = "Offset gain trek dalam desibel"
+pl = "Przesunięcie wzmocnienia ścieżki w decybelach"
 
 ["Generate Speech"]
 en = "Generate Speech"
@@ -2169,6 +2323,7 @@ ja = "音声を生成"
 pt = "Gerar fala"
 it = "Genera voce"
 id = "Hasilkan Ucapan"
+pl = "Wygeneruj mowę"
 
 ["Move Out"]
 en = "Move Out"
@@ -2183,6 +2338,7 @@ ja = "外に移動"
 pt = "Mover para fora"
 it = "Sposta fuori"
 id = "Pindahkan Keluar"
+pl = "Przenieś poza"
 
 ["Group"]
 en = "Group"
@@ -2197,6 +2353,7 @@ ja = "グループ化"
 pt = "Agrupar"
 it = "Raggruppa"
 id = "Kelompokkan"
+pl = "Grupuj"
 
 ["Ungroup"]
 en = "Ungroup"
@@ -2211,6 +2368,7 @@ ja = "グループ解除"
 pt = "Desagrupar"
 it = "Annulla raggruppamento"
 id = "Pisahkan Kelompok"
+pl = "Rozdziel"
 
 ["Delete Track"]
 en = "Delete Track"
@@ -2225,6 +2383,7 @@ ja = "トラックを削除"
 pt = "Excluir faixa"
 it = "Elimina traccia"
 id = "Hapus Trek"
+pl = "Usuń ścieżkę"
 
 ["Properties replaced on 1 item"]
 en = "Properties replaced on 1 item"
@@ -2239,6 +2398,7 @@ ja = "1項目のプロパティを置換しました"
 pt = "Propriedades substituídas em 1 item"
 it = "Proprietà sostituite su 1 elemento"
 id = "Properti diganti pada 1 item"
+pl = "Zamieniono właściwości na 1 elemencie"
 
 ["Properties replaced on %{count} items"]
 en = "Properties replaced on %{count} items"
@@ -2253,6 +2413,7 @@ ja = "%{count}項目のプロパティを置換しました"
 pt = "Propriedades substituídas em %{count} itens"
 it = "Proprietà sostituite su %{count} elementi"
 id = "Properti diganti pada %{count} item"
+pl = "Zamieniono właściwości na %{count} elementach"
 
 ["Delete Tracks?"]
 en = "Delete Tracks?"
@@ -2267,6 +2428,7 @@ ja = "トラックを削除しますか？"
 pt = "Excluir faixas?"
 it = "Eliminare le tracce?"
 id = "Hapus Trek?"
+pl = "Usunąć ścieżki?"
 
 ["1 clip is about to be deleted, are you sure?"]
 en = "1 clip is about to be deleted, are you sure?"
@@ -2281,6 +2443,7 @@ ja = "1個のクリップを削除します。よろしいですか？"
 pt = "1 clipe está prestes a ser excluído, tem certeza?"
 it = "1 clip sta per essere eliminata, sei sicuro?"
 id = "1 klip akan dihapus, Anda yakin?"
+pl = "1 klip zostanie usunięty, aby na pewno?"
 
 ["%{count} clips are about to be deleted, are you sure?"]
 en = "%{count} clips are about to be deleted, are you sure?"
@@ -2295,6 +2458,7 @@ ja = "%{count}個のクリップを削除します。よろしいですか？"
 pt = "%{count} clipes estão prestes a ser excluídos, tem certeza?"
 it = "%{count} clip stanno per essere eliminate, sei sicuro?"
 id = "%{count} klip akan dihapus, Anda yakin?"
+pl = "%{count} klipów zostanie usuniętych, aby na pewno?"
 
 ["Silence threshold"]
 en = "Silence threshold"
@@ -2309,6 +2473,7 @@ ja = "無音しきい値"
 pt = "Limiar de silêncio"
 it = "Soglia di silenzio"
 id = "Ambang batas keheningan"
+pl = "Próg ciszy"
 
 ["Minimum silence"]
 en = "Minimum silence"
@@ -2323,6 +2488,7 @@ ja = "最小無音時間"
 pt = "Silêncio mínimo"
 it = "Silenzio minimo"
 id = "Keheningan minimum"
+pl = "Minimalna cisza"
 
 ["Gap tolerance"]
 en = "Gap tolerance"
@@ -2337,6 +2503,7 @@ ja = "隙間の許容値"
 pt = "Tolerância de intervalo"
 it = "Tolleranza vuoti"
 id = "Toleransi celah"
+pl = "Tolerancja przerw"
 
 ["Min chunk"]
 en = "Min chunk"
@@ -2351,6 +2518,7 @@ ja = "最小チャンク"
 pt = "Trecho mínimo"
 it = "Frammento minimo"
 id = "Potongan minimum"
+pl = "Minimalny segment"
 
 ["No Silences Found"]
 en = "No Silences Found"
@@ -2365,6 +2533,7 @@ ja = "無音部分が見つかりません"
 pt = "Nenhum silêncio encontrado"
 it = "Nessun silenzio trovato"
 id = "Tidak Ditemukan Bagian Hening"
+pl = "Nie znaleziono żadnej ciszy"
 
 ["No selected-audio gaps matched the configured threshold and duration."]
 en = "No selected-audio gaps matched the configured threshold and duration."
@@ -2379,6 +2548,7 @@ ja = "選択した音声に、設定したしきい値と長さに一致する�
 pt = "Nenhum intervalo do áudio selecionado correspondeu ao limiar e duração configurados."
 it = "Nessun vuoto dell'audio selezionato corrispondeva alla soglia e alla durata configurate."
 id = "Tidak ada celah audio terpilih yang cocok dengan ambang batas dan durasi yang dikonfigurasi."
+pl = "Żadne przerwy zaznaczonego audio nie pasowały do skonfigurowanego progu oraz czasu trwania."
 
 ["No timeline ranges were removed."]
 en = "No timeline ranges were removed."
@@ -2393,6 +2563,7 @@ ja = "タイムラインの範囲は削除されませんでした。"
 pt = "Nenhum intervalo da linha do tempo foi removido."
 it = "Nessun intervallo della sequenza è stato rimosso."
 id = "Tidak ada rentang timeline yang dihapus."
+pl = "Żadne zakresy osi czasu nie zostały usunięte."
 
 ["Follow cuts"]
 en = "Follow cuts"
@@ -2407,6 +2578,7 @@ ja = "カットに従う"
 pt = "Seguir cortes"
 it = "Segui i tagli"
 id = "Ikuti potongan"
+pl = "Podążaj za cięciami"
 
 ["Snap source"]
 en = "Snap source"
@@ -2421,6 +2593,7 @@ ja = "スナップ元"
 pt = "Origem do encaixe"
 it = "Origine snap"
 id = "Sumber snap"
+pl = "Źródło przyciągania"
 
 ["Snap tolerance"]
 en = "Snap tolerance"
@@ -2435,6 +2608,7 @@ ja = "スナップ許容値"
 pt = "Tolerância do encaixe"
 it = "Tolleranza snap"
 id = "Toleransi snap"
+pl = "Tolerancja przyciągania"
 
 ["Snap generated caption boundaries to nearby cuts within this many seconds."]
 en = "Snap generated caption boundaries to nearby cuts within this many seconds."
@@ -2449,6 +2623,7 @@ ja = "生成した字幕の境界を、この秒数以内にある近くのカ�
 pt = "Encaixar limites das legendas geradas nos cortes próximos dentro desta quantidade de segundos."
 it = "Aggancia i limiti dei sottotitoli generati ai tagli vicini entro questo numero di secondi."
 id = "Rapatkan batas subtitel yang dihasilkan ke potongan terdekat dalam rentang detik ini."
+pl = "Przyciągnij granice wygenerowanych napisów do bliskich cięć w ciągu tych kilku sekund."
 
 ["Continue cut threshold"]
 en = "Continue cut threshold"
@@ -2463,6 +2638,7 @@ ja = "カット継続しきい値"
 pt = "Limiar de continuidade de corte"
 it = "Soglia continuità del taglio"
 id = "Ambang batas potongan lanjutan"
+pl = "Próg kontynuowania cięcia"
 
 ["Absorb chunks shorter than this many seconds only when the merged chunk stays under this threshold."]
 en = "Absorb chunks shorter than this many seconds only when the merged chunk stays under this threshold."
@@ -2477,6 +2653,7 @@ ja = "この秒数より短いチャンクを、結合後もこのしきい値�
 pt = "Absorver trechos mais curtos que esta quantidade de segundos apenas quando o trecho mesclado permanecer abaixo deste limiar."
 it = "Assorbi frammenti più brevi di questo numero di secondi solo se il frammento unito resta sotto questa soglia."
 id = "Gabungkan potongan yang lebih pendek dari sekian detik ini hanya jika potongan gabungan tetap berada di bawah ambang batas ini."
+pl = "Dołączaj fragmenty krótsze od podanej liczby sekund tylko wtedy, gdy po połączeniu ich długość nie przekroczy tego progu."
 
 ["%{count} chunk will be transcribed."]
 en = "%{count} chunk will be transcribed."
@@ -2491,6 +2668,7 @@ ja = "%{count}個のチャンクを文字起こしします。"
 pt = "%{count} trecho será transcrito."
 it = "%{count} frammenti verrà trascritto."
 id = "%{count} potongan akan ditranskripsikan."
+pl = "Transkrypcja obejmie %{count} fragment."
 
 ["%{count} chunks will be transcribed."]
 en = "%{count} chunks will be transcribed."
@@ -2505,6 +2683,7 @@ ja = "%{count}個のチャンクを文字起こしします。"
 pt = "%{count} trechos serão transcritos."
 it = "%{count} frammenti verranno trascritti."
 id = "%{count} potongan akan ditranskripsikan."
+pl = "Transkrypcja obejmie %{count} fragmentów."
 
 ["Transcribing..."]
 en = "Transcribing..."
@@ -2519,6 +2698,7 @@ ja = "文字起こし中..."
 pt = "Transcrevendo..."
 it = "Trascrizione…"
 id = "Mentranskripsikan..."
+pl = "Transkrybowanie..."
 
 ["Audio cuts"]
 en = "Audio cuts"
@@ -2533,6 +2713,7 @@ ja = "音声カット"
 pt = "Cortes de áudio"
 it = "Tagli audio"
 id = "Potongan audio"
+pl = "Cięcia audio"
 
 ["Video cuts"]
 en = "Video cuts"
@@ -2547,6 +2728,7 @@ ja = "動画カット"
 pt = "Cortes de vídeo"
 it = "Tagli video"
 id = "Potongan video"
+pl = "Cięcia wideo"
 
 ["Audio and video cuts"]
 en = "Audio and video cuts"
@@ -2561,6 +2743,7 @@ ja = "音声と動画のカット"
 pt = "Cortes de áudio e vídeo"
 it = "Tagli audio e video"
 id = "Potongan audio dan video"
+pl = "Cięcia audio i wideo"
 
 ["%{current}/%{total} · %{message}"]
 en = "%{current}/%{total} · %{message}"
@@ -2575,6 +2758,7 @@ ja = "%{current}/%{total} · %{message}"
 pt = "%{current}/%{total} · %{message}"
 it = "%{current}/%{total} · %{message}"
 id = "%{current}/%{total} · %{message}"
+pl = "%{current}/%{total} · %{message}"
 
 ["%{current}/%{total} · Complete"]
 en = "%{current}/%{total} · Complete"
@@ -2589,6 +2773,7 @@ ja = "%{current}/%{total} · 完了"
 pt = "%{current}/%{total} · Concluído"
 it = "%{current}/%{total} · Completato"
 id = "%{current}/%{total} · Selesai"
+pl = "%{current}/%{total} · Zakończono"
 
 ["%{count} caption chunk will be generated with each caption's exact duration."]
 en = "%{count} caption chunk will be generated with each caption's exact duration."
@@ -2603,6 +2788,7 @@ ja = "字幕の正確な長さで%{count}個の字幕チャンクを生成しま
 pt = "%{count} trecho de legenda será gerado com a duração exata de cada legenda."
 it = "Verrà generato %{count} frammento di sottotitoli con la durata esatta di ciascun sottotitolo."
 id = "%{count} potongan subtitel akan dihasilkan dengan durasi tepat dari masing-masing subtitel."
+pl = "Zostanie wygenerowany %{count} fragment napisów z dokładnym czasem trwania każdego napisu."
 
 ["%{count} caption chunks will be generated with each caption's exact duration."]
 en = "%{count} caption chunks will be generated with each caption's exact duration."
@@ -2617,6 +2803,7 @@ ja = "各字幕の正確な長さで%{count}個の字幕チャンクを生成し
 pt = "%{count} trechos de legendas serão gerados com a duração exata de cada legenda."
 it = "Verranno generati %{count} frammenti di sottotitoli con la durata esatta di ciascun sottotitolo."
 id = "%{count} potongan subtitel akan dihasilkan dengan durasi tepat dari masing-masing subtitel."
+pl = "Zostaną wygenerowane %{count} fragmenty napisów z dokładnym czasem trwania każdego napisu."
 
 ["%{count} empty or invalid chunk will be skipped."]
 en = "%{count} empty or invalid chunk will be skipped."
@@ -2631,6 +2818,7 @@ ja = "%{count}個の空または無効なチャンクをスキップします。
 pt = "%{count} trecho vazio ou inválido será ignorado."
 it = "%{count} frammento vuoto o non valido verrà saltato."
 id = "%{count} potongan kosong atau tidak valid akan dilewati."
+pl = "Pusty lub nieprawidłowy fragment %{count} zostanie pominięty."
 
 ["%{count} empty or invalid chunks will be skipped."]
 en = "%{count} empty or invalid chunks will be skipped."
@@ -2645,6 +2833,7 @@ ja = "%{count}個の空または無効なチャンクをスキップします。
 pt = "%{count} trechos vazios ou inválidos serão ignorados."
 it = "%{count} frammenti vuoti o non validi verranno saltati."
 id = "%{count} potongan kosong atau tidak valid akan dilewati."
+pl = "Puste lub nieprawidłowe fragmenty (%{count}) zostaną pominięte."
 
 ["Chunk %{current}/%{total}"]
 en = "Chunk %{current}/%{total}"
@@ -2659,6 +2848,7 @@ ja = "チャンク%{current}/%{total}"
 pt = "Trecho %{current}/%{total}"
 it = "Frammento %{current}/%{total}"
 id = "Potongan %{current}/%{total}"
+pl = "Fragment %{current}/%{total}"
 
 ["Generating Speech…"]
 en = "Generating Speech…"
@@ -2673,6 +2863,7 @@ ja = "音声を生成しています…"
 pt = "Gerando fala…"
 it = "Generazione voce…"
 id = "Menghasilkan Ucapan…"
+pl = "Generowanie mowy…"
 
 ["Match Project to Video?"]
 en = "Match Project to Video?"
@@ -2687,6 +2878,7 @@ ja = "プロジェクトを動画に合わせますか？"
 pt = "Ajustar projeto ao vídeo?"
 it = "Adattare il progetto al video?"
 id = "Sesuaikan Proyek dengan Video?"
+pl = "Dostosować projekt do wideo?"
 
 ["This is the first video in the project. Match the project to its %{width}×%{height} resolution and %{fps} FPS?"]
 en = "This is the first video in the project. Match the project to its %{width}×%{height} resolution and %{fps} FPS?"
@@ -2701,6 +2893,7 @@ ja = "プロジェクトで最初の動画です。プロジェクトを%{width}
 pt = "Este é o primeiro vídeo do projeto. Deseja ajustar o projeto para sua resolução de %{width}×%{height} e %{fps} FPS?"
 it = "Questo è il primo video del progetto. Adatta il progetto alla sua risoluzione di %{width}×%{height} e %{fps} FPS?"
 id = "Ini adalah video pertama dalam proyek. Sesuaikan proyek dengan resolusi %{width}×%{height} dan %{fps} FPS?"
+pl = "To jest pierwsze wideo tego projektu. Czy dostosować projekt do jego rozdzielczości %{width}×%{height} i %{fps} FPS?"
 
 ["This is the first video in the project. Match the project to its %{width}×%{height} resolution?"]
 en = "This is the first video in the project. Match the project to its %{width}×%{height} resolution?"
@@ -2715,6 +2908,7 @@ ja = "プロジェクトで最初の動画です。プロジェクトを%{width}
 pt = "Este é o primeiro vídeo do projeto. Deseja ajustar o projeto para sua resolução de %{width}×%{height}?"
 it = "Questo è il primo video del progetto. Adatta il progetto alla sua risoluzione di %{width}×%{height}?"
 id = "Ini adalah video pertama dalam proyek. Sesuaikan proyek dengan resolusi %{width}×%{height}?"
+pl = "To jest pierwsze wideo tego projektu. Czy dostosować projekt do jego rozdzielczości %{width}×%{height}?"
 
 ["This is the first video in the project. Match the project to its %{fps} FPS?"]
 en = "This is the first video in the project. Match the project to its %{fps} FPS?"
@@ -2729,6 +2923,7 @@ ja = "プロジェクトで最初の動画です。プロジェクトを%{fps} F
 pt = "Este é o primeiro vídeo do projeto. Deseja ajustar o projeto para %{fps} FPS?"
 it = "Questo è il primo video del progetto. Adatta il progetto ai suoi %{fps} FPS?"
 id = "Ini adalah video pertama dalam proyek. Sesuaikan proyek dengan %{fps} FPS?"
+pl = "To jest pierwsze wideo tego projektu. Czy dostosować projekt do jego %{fps} FPS?"
 
 ["Keep Project Settings"]
 en = "Keep Project Settings"
@@ -2743,6 +2938,7 @@ ja = "プロジェクト設定を維持"
 pt = "Manter configurações do projeto"
 it = "Mantieni impostazioni progetto"
 id = "Pertahankan Pengaturan Proyek"
+pl = "Zachowaj ustawienia projektu"
 
 ["Match Video"]
 en = "Match Video"
@@ -2757,6 +2953,7 @@ ja = "動画に合わせる"
 pt = "Ajustar ao vídeo"
 it = "Adatta al video"
 id = "Sesuaikan Video"
+pl = "Dopasuj do wideo"
 
 ["Import to Track"]
 en = "Import to Track"
@@ -2771,6 +2968,7 @@ ja = "トラックに読み込む"
 pt = "Importar para a faixa"
 it = "Importa nella traccia"
 id = "Impor ke Trek"
+pl = "Importuj do ścieżki"
 
 ["Remux MKV/WebM to MP4?"]
 en = "Remux MKV/WebM to MP4?"
@@ -2785,6 +2983,7 @@ ja = "MKV/WebMをMP4に再多重化しますか？"
 pt = "Remuxar MKV/WebM para MP4?"
 it = "Eseguire remux MKV/WebM in MP4?"
 id = "Remux MKV/WebM ke MP4?"
+pl = "Remuksować MKV/WebM do MP4?"
 
 ["MP4 is the supported timeline import format. The file can be remuxed losslessly first."]
 en = "MP4 is the supported timeline import format. The file can be remuxed losslessly first."
@@ -2799,6 +2998,7 @@ ja = "タイムラインへの読み込みはMP4に対応しています。先�
 pt = "MP4 é o formato suportado para importação na linha do tempo. O arquivo pode ser remuxado sem perdas primeiro."
 it = "MP4 è il formato supportato per l'import nella timeline. È possibile eseguire prima un remux senza perdita di qualità."
 id = "MP4 adalah format impor timeline yang didukung. File dapat di-remux secara lossless terlebih dahulu."
+pl = "MP4 jest obsługiwanym formatem importowania do osi czasu. Plik można najpierw bezstratnie zremuksować."
 
 ["Remux"]
 en = "Remux"
@@ -2813,6 +3013,7 @@ ja = "再多重化"
 pt = "Remuxar"
 it = "Remux"
 id = "Remux"
+pl = "Remuksuj"
 
 ["Delete original file?"]
 en = "Delete original file?"
@@ -2827,6 +3028,7 @@ ja = "元のファイルを削除しますか？"
 pt = "Excluir arquivo original?"
 it = "Eliminare il file originale?"
 id = "Hapus file asli?"
+pl = "Usunąć oryginalny plik?"
 
 ["The file was remuxed. Delete the original to keep only the MP4 copy?"]
 en = "The file was remuxed. Delete the original to keep only the MP4 copy?"
@@ -2841,6 +3043,7 @@ ja = "ファイルを再多重化しました。元のファイルを削除し�
 pt = "O arquivo foi remuxado. Deseja excluir o original para manter apenas a cópia em MP4?"
 it = "Remux sul file completato. Eliminare l'originale per conservare solo la copia in MP4?"
 id = "File telah di-remux. Hapus file asli untuk hanya menyimpan salinan MP4?"
+pl = "Plik został zremuksowany. Czy usunąć oryginał, w celu zachowania tylko kopii MP4?"
 
 ["Keep"]
 en = "Keep"
@@ -2855,6 +3058,7 @@ ja = "残す"
 pt = "Manter"
 it = "Mantieni"
 id = "Pertahankan"
+pl = "Zachowaj"
 
 ["Starting Blender…"]
 en = "Starting Blender…"
@@ -2869,6 +3073,7 @@ ja = "Blenderを起動しています…"
 pt = "Iniciando o Blender…"
 it = "Avvio di Blender…"
 id = "Memulai Blender…"
+pl = "Uruchamianie Blender…"
 
 ["Starting Manim…"]
 en = "Starting Manim…"
@@ -2883,6 +3088,7 @@ ja = "Manimを起動しています…"
 pt = "Iniciando o Manim…"
 it = "Avvio di Manim…"
 id = "Memulai Manim…"
+pl = "Uruchamianie Manim…"
 
 ["Loading scene…"]
 en = "Loading scene…"
@@ -2897,6 +3103,7 @@ ja = "シーンを読み込んでいます…"
 pt = "Carregando cena…"
 it = "Caricamento della scena…"
 id = "Memuat adegan…"
+pl = "Ładowanie sceny…"
 
 ["Frame %{completed}"]
 en = "Frame %{completed}"
@@ -2911,6 +3118,7 @@ ja = "フレーム%{completed}"
 pt = "Quadro %{completed}"
 it = "Fotogrammi %{completed}"
 id = "Frame %{completed}"
+pl = "Klatka %{completed}"
 
 ["Frame %{completed} / %{total}"]
 en = "Frame %{completed} / %{total}"
@@ -2925,3 +3133,4 @@ ja = "フレーム%{completed} / %{total}"
 pt = "Quadro %{completed} / %{total}"
 it = "Fotogrammi %{completed} / %{total}"
 id = "Frame %{completed} / %{total}"
+pl = "Klatka %{completed} / %{total}"

--- a/crates/ui/i18n-core/src/lib.rs
+++ b/crates/ui/i18n-core/src/lib.rs
@@ -4,8 +4,8 @@ use std::borrow::Cow;
 rust_i18n::i18n!("locales", fallback = "en");
 
 const DEFAULT_LOCALE: &str = "en";
-const SUPPORTED_LOCALES: [&str; 13] = [
-    "en", "es", "fr", "de", "ja", "zh-CN", "zh-TW", "ko", "pt", "ru", "tr", "it", "id",
+const SUPPORTED_LOCALES: [&str; 14] = [
+    "en", "es", "fr", "de", "ja", "zh-CN", "zh-TW", "ko", "pt", "ru", "tr", "it", "id", "pl",
 ];
 
 pub fn init_system_locale() {


### PR DESCRIPTION
This PR adds the polish (pl) language translations for app.toml, common.toml, inspector.toml and media.toml.
Similar to other PRs, I've added "pl" to the array in ./crates/ui/i18n-core/src/lib.rs

I'm a native polish speaker. My translations use gender-neutral adjectives when applicable (I did check the rust code when unsure), and don't assume the user's gender. AI had been used to double-check for any errors and better wording opportunities. While I'm a native, I'm also not an expert, but these translations should be usable, and of course could be improved on in the future by more people.

Let me know if there are any problems or questions.
The last PR had merge conflicts once the Indonesian translation was merged, this PR has the same changes as my older PR.