### PR TITLE
Support Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN make deps-fedora DNF="dnf -y"
 
 
 RUN rpm -q gtk4-devel && pkg-config --exists gtk4 \
-    && echo "gtk4-devel OK: $(pkg-config --modversion gtk4)"
+    && echo "gtk4-devel OK: $(pkg-config --modversion gtk4)" \
     && make qt-native-deps
 
 # Add CUDA from Nvidia source

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN make deps-fedora DNF="dnf -y"
 
 RUN rpm -q gtk4-devel && pkg-config --exists gtk4 \
     && echo "gtk4-devel OK: $(pkg-config --modversion gtk4)"
+    && make qt-native-deps
 
 # Add CUDA from Nvidia source
 RUN . /etc/os-release && \
@@ -54,12 +55,12 @@ ENV CUDA_TOOLKIT_PATH=/usr/local/cuda
 RUN ln -sf libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
 
-RUN make release
-RUN make install DESTDIR=/stage PREFIX=/usr
+RUN make release qt-release
+RUN make install install-qt DESTDIR=/stage PREFIX=/usr
 
 # --- Bundle the runtime libraries
 RUN mkdir -p /stage/usr/lib/shrimply && \
-    for bin in shrimply shrimply-editor shrimply-mcp; do \
+    for bin in shrimply shrimply-editor shrimply-mcp shrimply-qt shrimply-editor-qt; do \
         ldd "/stage/usr/bin/$bin" | awk '{print $3}' | grep '^/'; \
     done | sort -u \
       | grep -Ev '/(ld-linux[^/]*|libc|libm|libdl|libpthread|librt|libresolv)\.so' \
@@ -91,6 +92,25 @@ RUN mkdir -p /stage/usr/lib/shrimply/flexiblas && \
         patchelf --set-rpath '$ORIGIN:$ORIGIN/..' "$lib"; \
     done
 
+# QT's Platform Libs including all the QML Imports
+RUN mkdir -p /stage/usr/lib/shrimply/qt6/plugins /stage/usr/lib/shrimply/qt6/qml && \
+    cp -aL /usr/lib64/qt6/plugins/. /stage/usr/lib/shrimply/qt6/plugins/ && \
+    cp -aL /usr/lib64/qt6/qml/. /stage/usr/lib/shrimply/qt6/qml/ && \
+    find /stage/usr/lib/shrimply/qt6 -name '*.so*' -exec ldd {} \; \
+      | awk '{print $3}' | grep '^/' | sort -u \
+      | grep -Ev '/(ld-linux[^/]*|libc|libm|libdl|libpthread|librt|libresolv)\.so' \
+      | grep -Ev '/lib(GL|EGL|GLX|GLdispatch|drm|gbm)\.so' \
+      | grep -Ev '/libcuda\.so|/libnvidia-' \
+      | xargs -r -I{} cp -Ln --remove-destination {} /stage/usr/lib/shrimply/ && \
+    for lib in /stage/usr/lib/shrimply/*.so*; do \
+        patchelf --set-rpath '$ORIGIN' "$lib"; \
+    done && \
+    find /stage/usr/lib/shrimply/qt6 -name '*.so*' | while read -r lib; do \
+        depth="$(dirname "$lib" | sed 's|^/stage/usr/lib/shrimply/||' | awk -F/ '{print NF}')"; \
+        uprel="$(printf '../%.0s' $(seq 1 "$depth"))"; \
+        patchelf --set-rpath "\$ORIGIN:\$ORIGIN/$uprel" "$lib"; \
+    done
+
 # GI typelibs, compiled GSettings schemas, and icon themes: non-.so runtime data ldd can't see, but GTK4/libadwaita needs at runtime.
 # NOTE: Claude helped troubleshooting this one as well
 RUN mkdir -p /stage/usr/lib/shrimply/girepository-1.0 /stage/usr/share/glib-2.0/schemas /stage/usr/share/icons && \
@@ -100,13 +120,16 @@ RUN mkdir -p /stage/usr/lib/shrimply/girepository-1.0 /stage/usr/share/glib-2.0/
     cp -a /usr/share/icons/hicolor /stage/usr/share/icons/
 
 # Bundle all previous fixes into Shrimply and shrimply-editor binaries
-RUN for bin in shrimply shrimply-editor; do \
+RUN for bin in shrimply shrimply-editor shrimply-qt shrimply-editor-qt; do \
         patchelf --set-rpath '$ORIGIN/../lib/shrimply' "/stage/usr/bin/$bin"; \
         mv "/stage/usr/bin/$bin" "/stage/usr/bin/$bin.bin"; \
-        printf '#!/bin/sh\nhere="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexport GI_TYPELIB_PATH="$here/../lib/shrimply/girepository-1.0"\nexport GSETTINGS_SCHEMA_DIR="$here/../share/glib-2.0/schemas"\nexport XDG_DATA_DIRS="$here/../share:$XDG_DATA_DIRS"\nexport FLEXIBLASRC="$here/../lib/shrimply/flexiblasrc"\nexport FLEXIBLAS_LIBRARY_PATH="$here/../lib/shrimply/flexiblas"\nexec "$here/%s.bin" "$@"\n' "$bin" > "/stage/usr/bin/$bin"; \
+        printf '#!/bin/sh\nhere="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexport GI_TYPELIB_PATH="$here/../lib/shrimply/girepository-1.0"\nexport GSETTINGS_SCHEMA_DIR="$here/../share/glib-2.0/schemas"\nexport XDG_DATA_DIRS="$here/../share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"\nexport FLEXIBLASRC="$here/../lib/shrimply/flexiblasrc"\nexport FLEXIBLAS_LIBRARY_PATH="$here/../lib/shrimply/flexiblas"\nexec "$here/%s.bin" "$@"\n' "$bin" > "/stage/usr/bin/$bin"; \
         chmod 0755 "/stage/usr/bin/$bin"; \
     done
 RUN patchelf --set-rpath '$ORIGIN/../lib/shrimply' /stage/usr/bin/shrimply-mcp
+
+RUN printf '[Paths]\nPrefix = ../lib/shrimply/qt6\nPlugins = plugins\nImports = qml\nQml2Imports = qml\n' \
+    > /stage/usr/bin/qt.conf
 
 FROM scratch AS export
 COPY --from=builder /stage /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,112 @@
+FROM fedora:44 AS builder
+WORKDIR /src
+
+RUN dnf install -y curl git make patchelf rustup && dnf clean all
+
+RUN rustup-init -y --default-toolchain none --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# ffmepg from RPMFusion
+RUN dnf install -y \
+        "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+        "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" \
+    && dnf clean all
+
+COPY Makefile ./
+RUN make deps-fedora DNF="dnf -y"
+
+
+RUN rpm -q gtk4-devel && pkg-config --exists gtk4 \
+    && echo "gtk4-devel OK: $(pkg-config --modversion gtk4)"
+
+# Add CUDA from Nvidia source
+RUN . /etc/os-release && \
+    curl -fsSL -o /etc/yum.repos.d/cuda-fedora.repo \
+        "https://developer.download.nvidia.com/compute/cuda/repos/fedora${VERSION_ID}/x86_64/cuda-fedora${VERSION_ID}.repo" && \
+    dnf install -y cuda-toolkit && \
+    dnf clean all
+
+COPY . .
+
+
+RUN rustup show
+
+# Git submodules might be missing or outdated before the build. Happened on Arch, not sure if it happens on Fedora
+RUN test -e external/cuda-oxide/crates/cargo-oxide/Cargo.toml || { \
+        echo "Git submodules are missing from the build context." >&2; \
+        echo "Run 'git submodule update --init --recursive' before 'docker build'." >&2; \
+        exit 1; \
+    }
+
+# This is something that happens on fresh installs of CUDA-Oxide due to cargo trying to build it from Shrimply's workspace (where there is no library target)
+# We build directly againts the submodule that is pinned with the nightly version
+RUN rustup run nightly-2026-04-03 cargo install --path external/cuda-oxide/crates/cargo-oxide --locked
+RUN cd external/cuda-oxide/crates/rustc-codegen-cuda && \
+    SYSROOT="$(rustup run nightly-2026-04-03 rustc --print sysroot)" && \
+    LIBRARY_PATH="$SYSROOT/lib" LD_LIBRARY_PATH="$SYSROOT/lib" \
+        rustup run nightly-2026-04-03 cargo build --lib --target host-tuple --target-dir target
+
+ENV CUDA_OXIDE_BACKEND=/src/external/cuda-oxide/crates/rustc-codegen-cuda/target/x86_64-unknown-linux-gnu/debug/librustc_codegen_cuda.so
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_TOOLKIT_PATH=/usr/local/cuda
+
+# We have to do this to compile since Docker doesnt have a nvidia driver. 
+RUN ln -sf libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+
+RUN make release
+RUN make install DESTDIR=/stage PREFIX=/usr
+
+# --- Bundle the runtime libraries
+RUN mkdir -p /stage/usr/lib/shrimply && \
+    for bin in shrimply shrimply-editor shrimply-mcp; do \
+        ldd "/stage/usr/bin/$bin" | awk '{print $3}' | grep '^/'; \
+    done | sort -u \
+      | grep -Ev '/(ld-linux[^/]*|libc|libm|libdl|libpthread|librt|libresolv)\.so' \
+      | grep -Ev '/lib(GL|EGL|GLX|GLdispatch|drm|gbm)\.so' \
+      | grep -Ev '/libcuda\.so|/libnvidia-' \
+      | xargs -r -I{} cp -Ln --remove-destination {} /stage/usr/lib/shrimply/
+
+# Fixes issue shrimply-editor.bin: error while loading shared libraries: libxml2.so.2: cannot open shared object file: No such file or directory
+# Adds the dependencies of dependencies to the ORIGIN
+RUN for lib in /stage/usr/lib/shrimply/*.so*; do \
+        patchelf --set-rpath '$ORIGIN' "$lib"; \
+    done
+
+# Fixes issue: flexiblas Failed to load the BLAS fallback library. Abort!.
+# NOTE: Claude helped troubleshooting this one
+# This is related to FlexiBLAS linking to any real BLAS Implementation
+RUN mkdir -p /stage/usr/lib/shrimply/flexiblas && \
+    cp -aL /usr/lib64/flexiblas/. /stage/usr/lib/shrimply/flexiblas/ && \
+    cp -a /etc/flexiblasrc /stage/usr/lib/shrimply/flexiblasrc && \
+    ldd /stage/usr/lib/shrimply/flexiblas/*.so* | awk '{print $3}' | grep '^/' | sort -u \
+      | grep -Ev '/(ld-linux[^/]*|libc|libm|libdl|libpthread|librt|libresolv)\.so' \
+      | grep -Ev '/lib(GL|EGL|GLX|GLdispatch|drm|gbm)\.so' \
+      | grep -Ev '/libcuda\.so|/libnvidia-' \
+      | xargs -r -I{} cp -Ln --remove-destination {} /stage/usr/lib/shrimply/ && \
+    for lib in /stage/usr/lib/shrimply/*.so*; do \
+        patchelf --set-rpath '$ORIGIN' "$lib"; \
+    done && \
+    for lib in /stage/usr/lib/shrimply/flexiblas/*.so*; do \
+        patchelf --set-rpath '$ORIGIN:$ORIGIN/..' "$lib"; \
+    done
+
+# GI typelibs, compiled GSettings schemas, and icon themes: non-.so runtime data ldd can't see, but GTK4/libadwaita needs at runtime.
+# NOTE: Claude helped troubleshooting this one as well
+RUN mkdir -p /stage/usr/lib/shrimply/girepository-1.0 /stage/usr/share/glib-2.0/schemas /stage/usr/share/icons && \
+    cp -a /usr/lib64/girepository-1.0/. /stage/usr/lib/shrimply/girepository-1.0/ && \
+    cp -a /usr/share/glib-2.0/schemas/. /stage/usr/share/glib-2.0/schemas/ && \
+    cp -a /usr/share/icons/Adwaita /stage/usr/share/icons/ && \
+    cp -a /usr/share/icons/hicolor /stage/usr/share/icons/
+
+# Bundle all previous fixes into Shrimply and shrimply-editor binaries
+RUN for bin in shrimply shrimply-editor; do \
+        patchelf --set-rpath '$ORIGIN/../lib/shrimply' "/stage/usr/bin/$bin"; \
+        mv "/stage/usr/bin/$bin" "/stage/usr/bin/$bin.bin"; \
+        printf '#!/bin/sh\nhere="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"\nexport GI_TYPELIB_PATH="$here/../lib/shrimply/girepository-1.0"\nexport GSETTINGS_SCHEMA_DIR="$here/../share/glib-2.0/schemas"\nexport XDG_DATA_DIRS="$here/../share:$XDG_DATA_DIRS"\nexport FLEXIBLASRC="$here/../lib/shrimply/flexiblasrc"\nexport FLEXIBLAS_LIBRARY_PATH="$here/../lib/shrimply/flexiblas"\nexec "$here/%s.bin" "$@"\n' "$bin" > "/stage/usr/bin/$bin"; \
+        chmod 0755 "/stage/usr/bin/$bin"; \
+    done
+RUN patchelf --set-rpath '$ORIGIN/../lib/shrimply' /stage/usr/bin/shrimply-mcp
+
+FROM scratch AS export
+COPY --from=builder /stage /

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,11 @@ FEDORA_PACKAGES := \
 	gtksourceview5-devel \
 	vte291-gtk4-devel \
 	poppler-glib-devel \
-	freetype-devel
+	freetype-devel \
+	qt6-qtbase-devel \
+	qt6-qtdeclarative-devel
 
-.PHONY: native-deps qt-native-deps qt-desktop-file cuda-target-check cuda-artifacts dev qt-build dev-qt dev-server docs docs-check run run-qt build release check components-check gtk-components-showcase qt-components-showcase server-python-check manim manim-python-check manim-parameter-check cargo-check fmt fmt-check lint test frame-rate-test video-lifecycle-test transparent-fill-frame-range-test transparent-fill-decoder-test transparent-fill-kernel-test transparent-fill-compositor-test transparent-fill-playback-test transparent-fill-e2e-fixture transparent-fill-e2e-test decode-ahead-benchmark paint-interpolation-test crash-report oxide-doctor oxide-setup clean-dev clean deps-fedora install install-codex-mcp-dev install-agy-mcp-dev uninstall
-
+.PHONY: native-deps qt-native-deps qt-desktop-file cuda-target-check cuda-artifacts dev qt-build dev-qt dev-server docs docs-check run run-qt build release check components-check gtk-components-showcase qt-components-showcase server-python-check manim manim-python-check manim-parameter-check cargo-check fmt fmt-check lint test frame-rate-test video-lifecycle-test transparent-fill-frame-range-test transparent-fill-decoder-test transparent-fill-kernel-test transparent-fill-compositor-test transparent-fill-playback-test transparent-fill-e2e-fixture transparent-fill-e2e-test decode-ahead-benchmark paint-interpolation-test crash-report oxide-doctor oxide-setup clean-dev clean deps-fedora deps-fedora-qt qt-release install install-qt install-codex-mcp-dev install-agy-mcp-dev uninstall uninstall-qt dist-image dist
 native-deps:
 	@$(PKG_CONFIG) --exists rubberband || { echo "Missing Rubber Band development files (pkg-config: rubberband)" >&2; exit 1; }
 	@$(PKG_CONFIG) --exists libpipewire-0.3 || { echo "Missing PipeWire development files (pkg-config: libpipewire-0.3)" >&2; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,9 @@ clean:
 deps-fedora:
 	$(DNF) install $(FEDORA_PACKAGES)
 
+qt-release: native-deps qt-native-deps cuda-artifacts
+	$(DEV_BUILD_ENV) QMAKE=$(QT_QMAKE) CARGO_TERM_COLOR=always $(CARGO) build --release -p $(QT_EDITOR_PACKAGE) -p $(QT_LAUNCHER_PACKAGE)
+
 install: release
 	$(INSTALL) -Dm755 target/release/$(BIN_NAME) "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
 	$(INSTALL) -Dm755 target/release/$(EDITOR_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(EDITOR_BIN_NAME)"
@@ -403,6 +406,15 @@ install: release
 		command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -f -t "$(DATADIR)/icons/hicolor" >/dev/null || true; \
 	fi
 	@echo "Installed $(APP_NAME) under $(DESTDIR)$(PREFIX)"
+
+install-qt: qt-release
+	$(INSTALL) -Dm755 target/release/$(QT_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(QT_BIN_NAME)"
+	$(INSTALL) -Dm755 target/release/$(QT_EDITOR_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(QT_EDITOR_BIN_NAME)"
+	sed -e 's|^Exec=.*|Exec=$(BINDIR)/$(QT_BIN_NAME) %f|' -e 's|^TryExec=.*|TryExec=$(BINDIR)/$(QT_BIN_NAME)|' $(QT_DESKTOP_FILE) | $(INSTALL) -Dm644 /dev/stdin "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.Qt.desktop"
+	@if test -z "$(DESTDIR)"; then \
+		command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$(APPLICATIONSDIR)" >/dev/null || true; \
+	fi
+	@echo "Installed Qt launcher/editor under $(DESTDIR)$(PREFIX)"
 
 install-codex-mcp-dev:
 	@test -x "$(CURDIR)/target/debug/$(MCP_BIN_NAME)" || { echo "Run make dev first to build target/debug/$(MCP_BIN_NAME)" >&2; exit 2; }
@@ -423,9 +435,16 @@ uninstall:
 	rm -rf "$(DESTDIR)$(DATADIR)/shrimply/rhubarb"
 	rm -rf "$(DESTDIR)$(ICONS_RESOURCE_DIR)"
 	rm -f "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.desktop"
-	rm -f "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.Qt.desktop"
 	rm -f "$(DESTDIR)$(ICONDIR)/dev.shrimply.Shrimply.svg"
 	@if test -z "$(DESTDIR)"; then \
 		command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$(APPLICATIONSDIR)" >/dev/null || true; \
 		command -v gtk-update-icon-cache >/dev/null 2>&1 && gtk-update-icon-cache -f -t "$(DATADIR)/icons/hicolor" >/dev/null || true; \
+	fi
+
+uninstall-qt:
+	rm -f "$(DESTDIR)$(BINDIR)/$(QT_BIN_NAME)"
+	rm -f "$(DESTDIR)$(BINDIR)/$(QT_EDITOR_BIN_NAME)"
+	rm -f "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.Qt.desktop"
+	@if test -z "$(DESTDIR)"; then \
+		command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$(APPLICATIONSDIR)" >/dev/null || true; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ QT_COMPONENTS_PACKAGE := shrimply-qt-components
 GTK_COMPONENTS_DEMO_PACKAGE := shrimply-gtk-components-demo
 QT_COMPONENTS_DEMO_PACKAGE := shrimply-qt-components-demo
 QT_BIN_NAME := shrimply-qt
+QT_EDITOR_BIN_NAME := shrimply-editor-qt
 MCP_PACKAGE := shrimply-mcp
 MCP_BIN_NAME := shrimply-mcp
 MCP_SERVER_NAME ?= shrimply

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ install: release
 	$(INSTALL) -d "$(DESTDIR)$(RHUBARB_RESOURCE_DIR)/acoustic-model"
 	cp -a $(RHUBARB_ACOUSTIC_MODEL_SOURCE)/. "$(DESTDIR)$(RHUBARB_RESOURCE_DIR)/acoustic-model/"
 	$(INSTALL) -d "$(DESTDIR)$(ICONS_RESOURCE_DIR)"
-+   cp -a assets/icons/. "$(DESTDIR)$(ICONS_RESOURCE_DIR)/"
+    cp -a assets/icons/. "$(DESTDIR)$(ICONS_RESOURCE_DIR)/"
 	sed -e 's|^Exec=.*|Exec=$(BINDIR)/$(BIN_NAME) %f|' -e 's|^TryExec=.*|TryExec=$(BINDIR)/$(BIN_NAME)|' $(DESKTOP_FILE) | $(INSTALL) -Dm644 /dev/stdin "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.desktop"
 	$(INSTALL) -Dm644 $(APP_ICON) "$(DESTDIR)$(ICONDIR)/dev.shrimply.Shrimply.svg"
 	@if test -z "$(DESTDIR)"; then \

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ RHUBARB_LIBRARY := target/release/libshrimply-rhubarb.so
 RHUBARB_MODEL_SOURCE := external/rhubarb-lip-sync/rhubarb/lib/pocketsphinx-rev13216/model/en-us
 RHUBARB_ACOUSTIC_MODEL_SOURCE := external/rhubarb-lip-sync/rhubarb/lib/cmusphinx-en-us-5.2
 RHUBARB_RESOURCE_DIR := $(DATADIR)/shrimply/rhubarb/sphinx
+ICONS_RESOURCE_DIR := $(DATADIR)/shrimply/icons
 
 FEDORA_PACKAGES := \
 	rust \
@@ -416,6 +417,7 @@ uninstall:
 	rm -f "$(DESTDIR)$(BINDIR)/$(MCP_BIN_NAME)"
 	rm -f "$(DESTDIR)$(BINDIR)/libshrimply-rhubarb.so"
 	rm -rf "$(DESTDIR)$(DATADIR)/shrimply/rhubarb"
+	rm -rf "$(DESTDIR)$(ICONS_RESOURCE_DIR)"
 	rm -f "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.desktop"
 	rm -f "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.Qt.desktop"
 	rm -f "$(DESTDIR)$(ICONDIR)/dev.shrimply.Shrimply.svg"

--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,8 @@ install: release
 	cp -a $(RHUBARB_MODEL_SOURCE)/. "$(DESTDIR)$(RHUBARB_RESOURCE_DIR)/"
 	$(INSTALL) -d "$(DESTDIR)$(RHUBARB_RESOURCE_DIR)/acoustic-model"
 	cp -a $(RHUBARB_ACOUSTIC_MODEL_SOURCE)/. "$(DESTDIR)$(RHUBARB_RESOURCE_DIR)/acoustic-model/"
+	$(INSTALL) -d "$(DESTDIR)$(ICONS_RESOURCE_DIR)"
++   cp -a assets/icons/. "$(DESTDIR)$(ICONS_RESOURCE_DIR)/"
 	sed -e 's|^Exec=.*|Exec=$(BINDIR)/$(BIN_NAME) %f|' -e 's|^TryExec=.*|TryExec=$(BINDIR)/$(BIN_NAME)|' $(DESKTOP_FILE) | $(INSTALL) -Dm644 /dev/stdin "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.desktop"
 	$(INSTALL) -Dm644 $(APP_ICON) "$(DESTDIR)$(ICONDIR)/dev.shrimply.Shrimply.svg"
 	@if test -z "$(DESTDIR)"; then \

--- a/crates/ui/gtk-components/src/icons.rs
+++ b/crates/ui/gtk-components/src/icons.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub fn register_bundled() {
     let Some(display) = gtk::gdk::Display::default() else {
@@ -6,4 +6,16 @@ pub fn register_bundled() {
     };
     gtk::IconTheme::for_display(&display)
         .add_search_path(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../assets/icons"));
+}
+
+fn bundled_icons_dir() -> PathBuf {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(bin_dir) = exe.parent() {
+            let installed = bin_dir.join("../share/shrimply/icons");
+            if installed.is_dir() {
+                return installed;
+            }
+        }
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../assets/icons")
 }


### PR DESCRIPTION
This tries to address the issue #37 by building Shrimply via docker, trying to achieve a distro agnostic build environment. 

Build Command used
```bash
docker buildx build --target export --output type=local,dest=dist/stage .
```

> [!NOTE]
> At the moment of testing, I'm missing some icons that were present on the native build, for that reason I'm leaving this PR in draft while I troubleshoot the icon issue.

