### PR TITLE
Flatpak build

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,178 @@
+name: Flatpak build
+
+# See TODO.md ("Flatpak packaging") for the milestone plan this follows and
+# packaging/flatpak/README.md for the manual rebuild recipe. This workflow
+# runs `make dist` (build the manifest, export a single-file .flatpak bundle
+# -- TODO.md's chosen distribution model, not Flathub) and uploads the result
+# as a workflow artifact, plus four caches that make repeat runs fast:
+#
+# - ~/.local/share/flatpak: the user-installation OSTree repo holding the
+#   SDK/runtime pair (org.gnome.Platform//50 + org.gnome.Sdk//50) and the two
+#   Sdk extensions (rust-nightly, llvm22) -- together a multi-GB download.
+#   flatpak-builder --user reads its base runtimes from here, so caching it
+#   turns the `make dist` install steps (flatpak-sdk/-rust-sdk/-llvm-sdk)
+#   into near-instant no-ops. Key pins the runtime major (50) and extension
+#   branch (25.08) literally -- bump them here when Makefile's
+#   FLATPAK_RUNTIME_VERSION / FLATPAK_SDK_EXTENSION_BRANCH change.
+# - .flatpak-builder: flatpak-builder's own per-module cache. Once the M6
+#   dependency modules (rubberband/ffmpeg/poppler/vte/openblas/opencv/slang)
+#   have built successfully once, this lets every later run skip them
+#   entirely as long as the manifest doesn't change -- see TODO.md's M7
+#   section for how this was discovered (module cache keys are invalidated
+#   by ANY change to global build-options, so keep manifest edits scoped to
+#   module-level build-options where possible to avoid needless rebuilds).
+# - ~/.cache/shrimply-flatpak-cargo-cache: the shrimply app module's own
+#   source is always a fresh `dir` checkout of the live repo, so it can
+#   never get a flatpak-builder cache hit -- this is a separate bind-mounted
+#   cargo registry + target dir (see the manifest's shrimply module) that
+#   persists cargo's downloaded crates and compiled build artifacts across
+#   runs instead.
+# - crates/render-cuda/prebuilt: the M4 CUDA cubins (see
+#   packaging/flatpak/README.md) are gitignored, not committed, so they don't
+#   exist in a fresh checkout. `make dist` depends on `flatpak-cuda-vendor`,
+#   which only runs the (Docker + full CUDA toolkit) rebuild when this
+#   directory is empty -- restoring it here before `make dist` turns that
+#   into a no-op on a cache hit. Keyed on the shader sources, build.rs, and
+#   the cuda-artifacts Dockerfile: any of those changing means the cubins
+#   need regenerating.
+#
+# Cache keys are STATIC (input hash only, no per-run component). The warm set
+# is already ~8-12 GB and GitHub Free evicts at 10 GB/repo across all
+# branches, so a rolling `<hash>-<run_id>` key -- which keeps a second
+# generation live until eviction -- would thrash the cache and make repeat
+# runs slower, not faster. The tradeoff: actions/cache never re-saves once the
+# primary key hits exactly (and it saves on job failure too), so if the first
+# cold build times out partway (240 min limit), the partial target/ / module
+# set it saved is frozen under that key and later identical-input runs won't
+# add to it. Escape hatch: bump the `-vN` suffix in the affected key below
+# (or delete that one entry in the repo's Actions > Caches UI) to force a
+# fresh save. In normal use Cargo.lock / the manifest change every few PRs,
+# which rotates the keys often enough on its own. The CUDA cubin cache keeps a
+# single exact key with no restore-keys on purpose: any change to its keyed
+# inputs means the cubins genuinely must be regenerated.
+#
+# None of the caches is required for correctness -- a cold cache just means a
+# slower (multi-hour) first build, same as a fresh clone on a new machine.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+    branches: [main, feature/flatpak]
+    paths:
+      - "packaging/flatpak/**"
+      - "packaging/docker/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "assets/**"
+      - "Makefile"
+      - ".github/workflows/flatpak.yml"
+  pull_request:
+    paths:
+      - "packaging/flatpak/**"
+      - "packaging/docker/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/**"
+      - "assets/**"
+      - "Makefile"
+
+# Least-privilege GITHUB_TOKEN: artifact upload/download is governed by the
+# `contents` scope (not `actions`, which is for workflow-run operations like
+# cancellation), and write includes the read access checkout needs. Without
+# this, org/repo settings that default GITHUB_TOKEN to read-only would make
+# the artifact upload step fail.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # M6+M7 modules together are a genuinely long build cold (FFmpeg, OpenCV
+    # and the full Rust workspace all compile from source) -- see TODO.md.
+    timeout-minutes: 240
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        # Submodules are initialized by `make flatpak-submodules` below
+        # (only the 3 actually needed: slang, optix-dev, vtracer -- NOT
+        # external/manim, which is explicitly out of scope, see TODO.md).
+
+      - name: Install flatpak, flatpak-builder, and make dist's other tool deps
+        # Docker is already preinstalled on ubuntu-latest runners (needed by
+        # flatpak-cuda-vendor, now that the .cubin files aren't committed --
+        # see packaging/flatpak/README.md). appstream/desktop-file-utils
+        # provide appstreamcli/desktop-file-validate, which `make dist`
+        # requires via metainfo-check/desktop-file-check. Installing all of
+        # these via apt-get here means the Makefile's own install-if-missing
+        # fallbacks (pacman-based, see Makefile's PACMAN comment) never
+        # trigger in CI -- they're gated on `command -v`, which succeeds
+        # once these are already on PATH.
+        #
+        # The flathub remote and all SDK/runtime/extension installs are
+        # user-scoped (--user): a system-wide `flatpak install` on the runner
+        # goes through polkit, which denies "Deploy" non-interactively
+        # ("Flatpak system operation Deploy not allowed for user"). The
+        # `make dist` step below passes FLATPAK/FLATPAK_BUILDER overrides so
+        # the Makefile's own install steps and flatpak-builder match.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder appstream desktop-file-utils
+          flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Cache flatpak SDK/runtime/extensions (user installation)
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/share/flatpak
+          # Runtime major (50) and extension branch (25.08) pinned literally:
+          # keep in sync with Makefile's FLATPAK_RUNTIME_VERSION and
+          # FLATPAK_SDK_EXTENSION_BRANCH. The manifest hash covers the rest
+          # (e.g. an added sdk-extension). Bump -v1 to force a fresh save.
+          key: flatpak-sdk-v1-gnome50-ext25.08-${{ hashFiles('packaging/flatpak/dev.shrimply.Shrimply.yaml') }}
+          restore-keys: |
+            flatpak-sdk-v1-gnome50-ext25.08-
+
+      - name: Cache flatpak-builder module cache
+        uses: actions/cache@v4
+        with:
+          # Bump -v1 if a timed-out cold build freezes a partial module set.
+          path: .flatpak-builder
+          key: flatpak-builder-v1-${{ hashFiles('packaging/flatpak/dev.shrimply.Shrimply.yaml') }}
+          restore-keys: |
+            flatpak-builder-v1-
+
+      - name: Cache cargo cache (registry + target, mounted into the sandbox)
+        uses: actions/cache@v4
+        with:
+          # Bump -v1 if a timed-out cold build freezes a partial target/ dir.
+          path: ~/.cache/shrimply-flatpak-cargo-cache
+          key: shrimply-cargo-v1-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            shrimply-cargo-v1-
+
+      - name: Restore vendored CUDA cubins (see packaging/flatpak/README.md)
+        uses: actions/cache@v4
+        with:
+          path: crates/render-cuda/prebuilt
+          key: cuda-cubins-${{ hashFiles('crates/render-core/shaders/**', 'crates/render-cuda/build.rs', 'packaging/docker/cuda-artifacts.Dockerfile') }}
+
+      - name: Build flatpak bundle (installs SDK/runtime/extensions, submodules, builds manifest, exports a .flatpak)
+        run: make dist
+        env:
+          # Force user-scoped flatpak: see the remote-add step above. Both
+          # vars are `?=` overrides in the Makefile (FLATPAK, FLATPAK_BUILDER).
+          FLATPAK: flatpak --user
+          FLATPAK_BUILDER: flatpak-builder --user
+
+      - name: Upload flatpak bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev.shrimply.Shrimply
+          path: dev.shrimply.Shrimply.flatpak
+          if-no-files-found: error
+
+      - name: Remove app/repo output before caching (keep only the caches above)
+        if: always()
+        run: rm -rf build repo

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,68 +1,17 @@
 name: Flatpak build
 
-# See TODO.md ("Flatpak packaging") for the milestone plan this follows and
-# packaging/flatpak/README.md for the manual rebuild recipe. This workflow
-# runs `make dist` (build the manifest, export a single-file .flatpak bundle
-# -- TODO.md's chosen distribution model, not Flathub) and uploads the result
-# as a workflow artifact, plus four caches that make repeat runs fast:
+# Runs `make dist` (builds the manifest, exports a single-file .flatpak bundle)
+# and uploads it as a workflow artifact. See packaging/flatpak/README.md for the
+# manual recipe and TODO.md ("Flatpak packaging") for the milestone plan.
 #
-# - ~/.local/share/flatpak: the user-installation OSTree repo holding the
-#   SDK/runtime pair (org.gnome.Platform//50 + org.gnome.Sdk//50) and the two
-#   Sdk extensions (rust-nightly, llvm22) -- together a multi-GB download.
-#   flatpak-builder --user reads its base runtimes from here, so caching it
-#   turns the `make dist` install steps (flatpak-sdk/-rust-sdk/-llvm-sdk)
-#   into near-instant no-ops. Key pins the runtime major (50) and extension
-#   branch (25.08) literally -- bump them here when Makefile's
-#   FLATPAK_RUNTIME_VERSION / FLATPAK_SDK_EXTENSION_BRANCH change.
-# - .flatpak-builder: flatpak-builder's own per-module cache. Once the M6
-#   dependency modules (rubberband/ffmpeg/poppler/vte/openblas/opencv/slang)
-#   have built successfully once, this lets every later run skip them
-#   entirely as long as the manifest doesn't change -- see TODO.md's M7
-#   section for how this was discovered (module cache keys are invalidated
-#   by ANY change to global build-options, so keep manifest edits scoped to
-#   module-level build-options where possible to avoid needless rebuilds).
-# - ~/.cache/shrimply-flatpak-cargo-cache: the shrimply app module's own
-#   source is always a fresh `dir` checkout of the live repo, so it can
-#   never get a flatpak-builder cache hit -- this is a separate bind-mounted
-#   cargo registry + target dir (see the manifest's shrimply module) that
-#   persists cargo's downloaded crates and compiled build artifacts across
-#   runs instead.
-# - crates/render-cuda/prebuilt: the M4 CUDA cubins (see
-#   packaging/flatpak/README.md) are gitignored, not committed, so they don't
-#   exist in a fresh checkout. `make dist` depends on `flatpak-cuda-vendor`,
-#   which only runs the (Docker + full CUDA toolkit) rebuild when this
-#   directory is empty -- restoring it here before `make dist` turns that
-#   into a no-op on a cache hit. Keyed on the shader sources, build.rs, and
-#   the cuda-artifacts Dockerfile: any of those changing means the cubins
-#   need regenerating.
-#
-# Each cache is a restore step (actions/cache/restore, before the build) plus a
-# guarded save step (actions/cache/save, if: always()) after it, rather than
-# the one-shot actions/cache. Two reasons:
-#  - the one-shot action does NOT save when the job fails, so a build that dies
-#    partway (a manifest bug caught only once the M6/M7 modules compile, say)
-#    would persist nothing and the next attempt starts fully cold -- SDK
-#    re-download, the ~15 min CUDA Docker rebuild, every module from scratch.
-#    The always() save keeps whatever stages completed (flatpak-builder commits
-#    each module to its cache as it finishes; a partial target/ is fine for
-#    cargo to resume from).
-#  - it never re-saves once the primary key hits exactly. The save steps are
-#    guarded on `cache-hit != 'true'` -- save only when the key rotated or
-#    missed -- so an unchanged-input run is a no-op and a changed-input run
-#    always writes a fresh entry.
-#
-# Keys are STATIC (input hash only, no run id). The warm set is ~8-12 GB and
-# GitHub Free evicts at 10 GB/repo across all branches, so a rolling
-# `<hash>-<run_id>` key would keep a second generation live until eviction and
-# thrash. During development Cargo.lock and the manifest change often enough to
-# rotate the keys on their own, and the restore-keys prefix still warm-starts
-# from the previous entry. Escape hatch if a key gets stuck on a bad partial:
-# bump its `-vN` suffix, or delete the entry in Actions > Caches. The CUDA
-# cubin cache has no restore-keys on purpose -- any change to its keyed inputs
-# means the cubins must be regenerated.
-#
-# None of the caches is required for correctness -- a cold cache just means a
-# slower (multi-hour) first build, same as a fresh clone on a new machine.
+# Each of the four caches is a restore step before the build plus a save step
+# after it (actions/cache/save, if: always()), not the one-shot actions/cache:
+# that saves nothing when the job fails, so every failed attempt would start
+# fully cold (SDK re-download, ~15 min CUDA Docker rebuild, all modules). The
+# save is guarded on cache-hit != 'true' so an unchanged-input run is a no-op.
+# Keys are static -- a rolling key would blow GitHub Free's 10 GB/repo limit.
+# If a key gets stuck on a bad partial, bump its `-vN` suffix or delete the
+# entry in Actions > Caches. A cold cache only costs time.
 
 on:
   workflow_dispatch:
@@ -89,44 +38,26 @@ on:
       - "assets/**"
       - "Makefile"
 
-# Least-privilege GITHUB_TOKEN: artifact upload/download is governed by the
-# `contents` scope (not `actions`, which is for workflow-run operations like
-# cancellation), and write includes the read access checkout needs. Without
-# this, org/repo settings that default GITHUB_TOKEN to read-only would make
-# the artifact upload step fail.
+# upload-artifact needs contents: write where the repo/org defaults
+# GITHUB_TOKEN to read-only.
 permissions:
   contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    # M6+M7 modules together are a genuinely long build cold (FFmpeg, OpenCV
-    # and the full Rust workspace all compile from source) -- see TODO.md.
+    # Cold builds compile FFmpeg, OpenCV and the full Rust workspace from source.
     timeout-minutes: 240
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
         # Submodules are initialized by `make flatpak-submodules` below
-        # (only the 3 actually needed: slang, optix-dev, vtracer -- NOT
-        # external/manim, which is explicitly out of scope, see TODO.md).
+        # (slang, optix-dev, vtracer -- not external/manim, out of scope).
+        uses: actions/checkout@v4
 
-      - name: Install flatpak, flatpak-builder, and make dist's other tool deps
-        # Docker is already preinstalled on ubuntu-latest runners (needed by
-        # flatpak-cuda-vendor, now that the .cubin files aren't committed --
-        # see packaging/flatpak/README.md). appstream/desktop-file-utils
-        # provide appstreamcli/desktop-file-validate, which `make dist`
-        # requires via metainfo-check/desktop-file-check. Installing all of
-        # these via apt-get here means the Makefile's own install-if-missing
-        # fallbacks (pacman-based, see Makefile's PACMAN comment) never
-        # trigger in CI -- they're gated on `command -v`, which succeeds
-        # once these are already on PATH.
-        #
-        # The flathub remote and all SDK/runtime/extension installs are
-        # user-scoped (--user): a system-wide `flatpak install` on the runner
-        # goes through polkit, which denies "Deploy" non-interactively
-        # ("Flatpak system operation Deploy not allowed for user"). The
-        # `make dist` step below passes FLATPAK/FLATPAK_BUILDER overrides so
-        # the Makefile's own install steps and flatpak-builder match.
+      - name: Install flatpak-builder and make dist's other tool deps
+        # --user everywhere: a system-wide `flatpak install` on the runner is
+        # denied by polkit non-interactively ("Deploy not allowed for user").
+        # `make dist` gets matching FLATPAK/FLATPAK_BUILDER overrides below.
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder appstream desktop-file-utils
@@ -137,10 +68,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.local/share/flatpak
-          # Runtime major (50) and extension branch (25.08) pinned literally:
-          # keep in sync with Makefile's FLATPAK_RUNTIME_VERSION and
-          # FLATPAK_SDK_EXTENSION_BRANCH. The manifest hash covers the rest
-          # (e.g. an added sdk-extension). Bump -v1 to force a fresh save.
+          # Bump the runtime major / extension branch here when Makefile's
+          # FLATPAK_RUNTIME_VERSION / FLATPAK_SDK_EXTENSION_BRANCH change.
           key: flatpak-sdk-v1-gnome50-ext25.08-${{ hashFiles('packaging/flatpak/dev.shrimply.Shrimply.yaml') }}
           restore-keys: |
             flatpak-sdk-v1-gnome50-ext25.08-
@@ -149,7 +78,6 @@ jobs:
         id: cache-flatpak-builder
         uses: actions/cache/restore@v4
         with:
-          # Bump -v1 if a key gets stuck on a partial module set.
           path: .flatpak-builder
           key: flatpak-builder-v1-${{ hashFiles('packaging/flatpak/dev.shrimply.Shrimply.yaml') }}
           restore-keys: |
@@ -159,7 +87,6 @@ jobs:
         id: cache-cargo
         uses: actions/cache/restore@v4
         with:
-          # Bump -v1 if a key gets stuck on a partial target/ dir.
           path: ~/.cache/shrimply-flatpak-cargo-cache
           key: shrimply-cargo-v1-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
@@ -169,25 +96,21 @@ jobs:
         id: cache-cuda
         uses: actions/cache/restore@v4
         with:
+          # No restore-keys: a shader/build.rs/Dockerfile change must regenerate.
           path: crates/render-cuda/prebuilt
           key: cuda-cubins-${{ hashFiles('crates/render-core/shaders/**', 'crates/render-cuda/build.rs', 'packaging/docker/cuda-artifacts.Dockerfile') }}
 
       - name: Build flatpak bundle (installs SDK/runtime/extensions, submodules, builds manifest, exports a .flatpak)
         run: make dist
         env:
-          # Force user-scoped flatpak: see the remote-add step above. Both
-          # vars are `?=` overrides in the Makefile (FLATPAK, FLATPAK_BUILDER).
+          # ?= overrides in the Makefile; see the install step above.
           FLATPAK: flatpak --user
           FLATPAK_BUILDER: flatpak-builder --user
 
-      - name: Remove app/repo output before caching (not in any cache path, just tidy)
+      - name: Remove build/ and repo/ (free disk before the cache saves)
         if: always()
         run: rm -rf build repo
 
-      # Save steps run even when the build failed (if: always()), so a run that
-      # dies in a late module still persists the earlier work. Guarded on
-      # cache-hit != 'true' so an exact-key hit (nothing changed) is a no-op
-      # instead of a "cache already exists" warning.
       - name: Save flatpak SDK/runtime/extensions cache
         if: always() && steps.cache-flatpak-sdk.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -36,20 +36,30 @@ name: Flatpak build
 #   the cuda-artifacts Dockerfile: any of those changing means the cubins
 #   need regenerating.
 #
-# Cache keys are STATIC (input hash only, no per-run component). The warm set
-# is already ~8-12 GB and GitHub Free evicts at 10 GB/repo across all
-# branches, so a rolling `<hash>-<run_id>` key -- which keeps a second
-# generation live until eviction -- would thrash the cache and make repeat
-# runs slower, not faster. The tradeoff: actions/cache never re-saves once the
-# primary key hits exactly (and it saves on job failure too), so if the first
-# cold build times out partway (240 min limit), the partial target/ / module
-# set it saved is frozen under that key and later identical-input runs won't
-# add to it. Escape hatch: bump the `-vN` suffix in the affected key below
-# (or delete that one entry in the repo's Actions > Caches UI) to force a
-# fresh save. In normal use Cargo.lock / the manifest change every few PRs,
-# which rotates the keys often enough on its own. The CUDA cubin cache keeps a
-# single exact key with no restore-keys on purpose: any change to its keyed
-# inputs means the cubins genuinely must be regenerated.
+# Each cache is a restore step (actions/cache/restore, before the build) plus a
+# guarded save step (actions/cache/save, if: always()) after it, rather than
+# the one-shot actions/cache. Two reasons:
+#  - the one-shot action does NOT save when the job fails, so a build that dies
+#    partway (a manifest bug caught only once the M6/M7 modules compile, say)
+#    would persist nothing and the next attempt starts fully cold -- SDK
+#    re-download, the ~15 min CUDA Docker rebuild, every module from scratch.
+#    The always() save keeps whatever stages completed (flatpak-builder commits
+#    each module to its cache as it finishes; a partial target/ is fine for
+#    cargo to resume from).
+#  - it never re-saves once the primary key hits exactly. The save steps are
+#    guarded on `cache-hit != 'true'` -- save only when the key rotated or
+#    missed -- so an unchanged-input run is a no-op and a changed-input run
+#    always writes a fresh entry.
+#
+# Keys are STATIC (input hash only, no run id). The warm set is ~8-12 GB and
+# GitHub Free evicts at 10 GB/repo across all branches, so a rolling
+# `<hash>-<run_id>` key would keep a second generation live until eviction and
+# thrash. During development Cargo.lock and the manifest change often enough to
+# rotate the keys on their own, and the restore-keys prefix still warm-starts
+# from the previous entry. Escape hatch if a key gets stuck on a bad partial:
+# bump its `-vN` suffix, or delete the entry in Actions > Caches. The CUDA
+# cubin cache has no restore-keys on purpose -- any change to its keyed inputs
+# means the cubins must be regenerated.
 #
 # None of the caches is required for correctness -- a cold cache just means a
 # slower (multi-hour) first build, same as a fresh clone on a new machine.
@@ -122,8 +132,9 @@ jobs:
           sudo apt-get install -y flatpak flatpak-builder appstream desktop-file-utils
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
-      - name: Cache flatpak SDK/runtime/extensions (user installation)
-        uses: actions/cache@v4
+      - name: Restore flatpak SDK/runtime/extensions (user installation)
+        id: cache-flatpak-sdk
+        uses: actions/cache/restore@v4
         with:
           path: ~/.local/share/flatpak
           # Runtime major (50) and extension branch (25.08) pinned literally:
@@ -134,26 +145,29 @@ jobs:
           restore-keys: |
             flatpak-sdk-v1-gnome50-ext25.08-
 
-      - name: Cache flatpak-builder module cache
-        uses: actions/cache@v4
+      - name: Restore flatpak-builder module cache
+        id: cache-flatpak-builder
+        uses: actions/cache/restore@v4
         with:
-          # Bump -v1 if a timed-out cold build freezes a partial module set.
+          # Bump -v1 if a key gets stuck on a partial module set.
           path: .flatpak-builder
           key: flatpak-builder-v1-${{ hashFiles('packaging/flatpak/dev.shrimply.Shrimply.yaml') }}
           restore-keys: |
             flatpak-builder-v1-
 
-      - name: Cache cargo cache (registry + target, mounted into the sandbox)
-        uses: actions/cache@v4
+      - name: Restore cargo cache (registry + target, mounted into the sandbox)
+        id: cache-cargo
+        uses: actions/cache/restore@v4
         with:
-          # Bump -v1 if a timed-out cold build freezes a partial target/ dir.
+          # Bump -v1 if a key gets stuck on a partial target/ dir.
           path: ~/.cache/shrimply-flatpak-cargo-cache
           key: shrimply-cargo-v1-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             shrimply-cargo-v1-
 
       - name: Restore vendored CUDA cubins (see packaging/flatpak/README.md)
-        uses: actions/cache@v4
+        id: cache-cuda
+        uses: actions/cache/restore@v4
         with:
           path: crates/render-cuda/prebuilt
           key: cuda-cubins-${{ hashFiles('crates/render-core/shaders/**', 'crates/render-cuda/build.rs', 'packaging/docker/cuda-artifacts.Dockerfile') }}
@@ -166,13 +180,45 @@ jobs:
           FLATPAK: flatpak --user
           FLATPAK_BUILDER: flatpak-builder --user
 
+      - name: Remove app/repo output before caching (not in any cache path, just tidy)
+        if: always()
+        run: rm -rf build repo
+
+      # Save steps run even when the build failed (if: always()), so a run that
+      # dies in a late module still persists the earlier work. Guarded on
+      # cache-hit != 'true' so an exact-key hit (nothing changed) is a no-op
+      # instead of a "cache already exists" warning.
+      - name: Save flatpak SDK/runtime/extensions cache
+        if: always() && steps.cache-flatpak-sdk.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.local/share/flatpak
+          key: ${{ steps.cache-flatpak-sdk.outputs.cache-primary-key }}
+
+      - name: Save flatpak-builder module cache
+        if: always() && steps.cache-flatpak-builder.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .flatpak-builder
+          key: ${{ steps.cache-flatpak-builder.outputs.cache-primary-key }}
+
+      - name: Save cargo cache
+        if: always() && steps.cache-cargo.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/shrimply-flatpak-cargo-cache
+          key: ${{ steps.cache-cargo.outputs.cache-primary-key }}
+
+      - name: Save vendored CUDA cubins cache
+        if: always() && steps.cache-cuda.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: crates/render-cuda/prebuilt
+          key: ${{ steps.cache-cuda.outputs.cache-primary-key }}
+
       - name: Upload flatpak bundle
         uses: actions/upload-artifact@v4
         with:
           name: dev.shrimply.Shrimply
           path: dev.shrimply.Shrimply.flatpak
           if-no-files-found: error
-
-      - name: Remove app/repo output before caching (keep only the caches above)
-        if: always()
-        run: rm -rf build repo

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
 target/
+/.flatpak-builder
+/build
+/repo
+/*.flatpak
+packaging/flatpak/.flatpak-builder
+packaging/flatpak/build
 /assets/icons/dev.shrimply.Shrimply.png
 .qmlls.ini
 /.slang-artifacts
+# M4 flatpak CUDA cubins: built by `make cuda-artifacts-image`/`flatpak-cuda-vendor`
+# (see packaging/flatpak/README.md), not committed -- CI regenerates and caches them.
+crates/render-cuda/prebuilt/*/*.cubin
 /video-generation-cache
 
 # Python bytecode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ objc2-core-media = "0.3.2"
 objc2-screen-capture-kit = { version = "0.3.2", default-features = false }
 objc2-vision = "0.3.2"
 oklab = "1"
-opencv = { version = "0.100", default-features = false, features = ["calib3d", "clang-runtime", "imgproc", "video", "videoio"] }
+opencv = { version = "0.100", default-features = false, features = ["clang-runtime", "features", "geometry", "imgproc", "video", "videoio"] }
 pango = "0.22"
 pangocairo = "0.22"
 pest = "2.9"

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ APPKIT_ICON_SIZE := 512
 RSVG_CONVERT ?= rsvg-convert
 LIP_SYNC_MODEL := target/release/res/lip-sync/pocketsphinx-ci.model
 LIP_SYNC_RESOURCE_DIR := $(DATADIR)/shrimply/lip-sync
-LIP_SYNC_LICENSE_DIR := $(DATADIR)/licenses/shrimply
+LICENSE_DIR := $(DATADIR)/licenses/shrimply
 ICONS_RESOURCE_DIR := $(DATADIR)/shrimply/icons
 
 FEDORA_PACKAGES := \
@@ -445,10 +445,11 @@ install: release desktop-icon
 	$(INSTALL) -Dm755 target/release/$(BIN_NAME) "$(DESTDIR)$(BINDIR)/$(BIN_NAME)"
 	$(INSTALL) -Dm755 target/release/$(EDITOR_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(EDITOR_BIN_NAME)"
 	$(INSTALL) -Dm755 target/release/$(MCP_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(MCP_BIN_NAME)"
+	$(INSTALL) -Dm644 LICENSE "$(DESTDIR)$(LICENSE_DIR)/Shrimply.txt"
 	$(INSTALL) -Dm644 $(LIP_SYNC_MODEL) "$(DESTDIR)$(LIP_SYNC_RESOURCE_DIR)/pocketsphinx-ci.model"
-	$(INSTALL) -Dm644 vendor/pocketsphinx/LICENSE "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/PocketSphinx-code.txt"
-	$(INSTALL) -Dm644 vendor/pocketsphinx/MODEL-LICENSE "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/PocketSphinx-model.txt"
-	$(INSTALL) -Dm644 vendor/rhubarb-lip-sync/LICENSE "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/Rhubarb-Lip-Sync.txt"
+	$(INSTALL) -Dm644 vendor/pocketsphinx/LICENSE "$(DESTDIR)$(LICENSE_DIR)/PocketSphinx-code.txt"
+	$(INSTALL) -Dm644 vendor/pocketsphinx/MODEL-LICENSE "$(DESTDIR)$(LICENSE_DIR)/PocketSphinx-model.txt"
+	$(INSTALL) -Dm644 vendor/rhubarb-lip-sync/LICENSE "$(DESTDIR)$(LICENSE_DIR)/Rhubarb-Lip-Sync.txt"
 	$(INSTALL) -d "$(DESTDIR)$(ICONS_RESOURCE_DIR)"
 	cp -a assets/icons/. "$(DESTDIR)$(ICONS_RESOURCE_DIR)/"
 	sed -e 's|^Exec=.*|Exec=$(BINDIR)/$(BIN_NAME) %f|' -e 's|^TryExec=.*|TryExec=$(BINDIR)/$(BIN_NAME)|' $(DESKTOP_FILE) | $(INSTALL) -Dm644 /dev/stdin "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.desktop"
@@ -460,10 +461,11 @@ install: release desktop-icon
 install-qt: qt-release desktop-icon
 	$(INSTALL) -Dm755 target/release/$(QT_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(QT_BIN_NAME)"
 	$(INSTALL) -Dm755 target/release/$(QT_EDITOR_BIN_NAME) "$(DESTDIR)$(BINDIR)/$(QT_EDITOR_BIN_NAME)"
+	$(INSTALL) -Dm644 LICENSE "$(DESTDIR)$(LICENSE_DIR)/Shrimply.txt"
 	$(INSTALL) -Dm644 $(LIP_SYNC_MODEL) "$(DESTDIR)$(LIP_SYNC_RESOURCE_DIR)/pocketsphinx-ci.model"
-	$(INSTALL) -Dm644 vendor/pocketsphinx/LICENSE "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/PocketSphinx-code.txt"
-	$(INSTALL) -Dm644 vendor/pocketsphinx/MODEL-LICENSE "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/PocketSphinx-model.txt"
-	$(INSTALL) -Dm644 vendor/rhubarb-lip-sync/LICENSE "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/Rhubarb-Lip-Sync.txt"
+	$(INSTALL) -Dm644 vendor/pocketsphinx/LICENSE "$(DESTDIR)$(LICENSE_DIR)/PocketSphinx-code.txt"
+	$(INSTALL) -Dm644 vendor/pocketsphinx/MODEL-LICENSE "$(DESTDIR)$(LICENSE_DIR)/PocketSphinx-model.txt"
+	$(INSTALL) -Dm644 vendor/rhubarb-lip-sync/LICENSE "$(DESTDIR)$(LICENSE_DIR)/Rhubarb-Lip-Sync.txt"
 	sed -e 's|^Exec=.*|Exec=$(BINDIR)/$(QT_BIN_NAME) %f|' -e 's|^TryExec=.*|TryExec=$(BINDIR)/$(QT_BIN_NAME)|' $(QT_DESKTOP_FILE) | $(INSTALL) -Dm644 /dev/stdin "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.Qt.desktop"
 	@if test -z "$(DESTDIR)"; then \
 		command -v update-desktop-database >/dev/null 2>&1 && update-desktop-database "$(APPLICATIONSDIR)" >/dev/null || true; \
@@ -486,9 +488,10 @@ uninstall:
 	rm -f "$(DESTDIR)$(BINDIR)/$(EDITOR_BIN_NAME)"
 	rm -f "$(DESTDIR)$(BINDIR)/$(MCP_BIN_NAME)"
 	rm -rf "$(DESTDIR)$(LIP_SYNC_RESOURCE_DIR)"
-	rm -f "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/PocketSphinx-code.txt"
-	rm -f "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/PocketSphinx-model.txt"
-	rm -f "$(DESTDIR)$(LIP_SYNC_LICENSE_DIR)/Rhubarb-Lip-Sync.txt"
+	rm -f "$(DESTDIR)$(LICENSE_DIR)/Shrimply.txt"
+	rm -f "$(DESTDIR)$(LICENSE_DIR)/PocketSphinx-code.txt"
+	rm -f "$(DESTDIR)$(LICENSE_DIR)/PocketSphinx-model.txt"
+	rm -f "$(DESTDIR)$(LICENSE_DIR)/Rhubarb-Lip-Sync.txt"
 	rm -rf "$(DESTDIR)$(ICONS_RESOURCE_DIR)"
 	rm -f "$(DESTDIR)$(APPLICATIONSDIR)/dev.shrimply.Shrimply.desktop"
 	rm -f "$(DESTDIR)$(ICONDIR)/dev.shrimply.Shrimply.svg"

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,9 @@ FLATPAK_REPO_DIR ?= repo
 FLATPAK_BUNDLE ?= $(FLATPAK_APP_ID).flatpak
 dist: flatpak-sdk flatpak-rust-sdk flatpak-llvm-sdk flatpak-cuda-vendor metainfo-check desktop-file-check
 	$(FLATPAK_BUILDER) --repo=$(FLATPAK_REPO_DIR) --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
-	$(FLATPAK) build-bundle $(FLATPAK_REPO_DIR) $(FLATPAK_BUNDLE) $(FLATPAK_APP_ID)
+	# build-bundle acts on a repo dir, not an installation, and rejects the
+	# --user/--system flags the install steps need -- firstword drops them.
+	$(firstword $(FLATPAK)) build-bundle $(FLATPAK_REPO_DIR) $(FLATPAK_BUNDLE) $(FLATPAK_APP_ID)
 	@echo "Flatpak bundle: $(FLATPAK_BUNDLE)"
 
 dev: SHELL := /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,7 @@ FLATPAK_BUILDER ?= flatpak-builder
 FLATPAK_RUNTIME_VERSION ?= 50
 FLATPAK_MANIFEST ?= packaging/flatpak/dev.shrimply.Shrimply.yaml
 FLATPAK_BUILD_DIR ?= build
-# Matches org.gnome.Sdk//50's own base (confirmed via
-# `flatpak info --show-metadata org.gnome.Sdk//50`: its GL/GStreamer/etc
-# extension points are all pinned to 25.08) -- the rust-nightly extension has
-# no "50" branch of its own, see TODO.md M5.
+# org.gnome.Sdk//50's base; the Sdk extensions have no "50" branch of their own.
 FLATPAK_SDK_EXTENSION_BRANCH ?= 25.08
 PKG_CONFIG ?= /usr/bin/pkg-config
 PKG_CONFIG_PATH ?= /usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
@@ -148,14 +145,10 @@ cuda-target-check:
 cuda-artifacts: cuda-target-check slang-compiler
 	$(BUILD_ENV) CUDA_TARGET=$(CUDA_TARGET) CUDA_HOST_CXX=$(CUDA_HOST_CXX) $(CARGO) build -p shrimply-render-cuda
 
-# Occasional, heavy, explicit-only: builds the prebuilt .cubin files vendored
-# for the flatpak sandbox (M4 — see TODO.md), where nvcc never runs. Not a
-# dependency of `check`/`dev`/`cuda-artifacts` itself. Runs `make
-# cuda-artifacts` inside a Docker image that has nvcc (this machine has no
-# GPU driver in the container, same as the top-level Dockerfile), then copies
-# the resulting cubins out to crates/render-cuda/prebuilt/$(CUDA_TARGET)/,
-# which build.rs picks up automatically on the next `cargo build -p
-# shrimply-render-cuda` (in-sandbox or not).
+# Builds the prebuilt .cubin files vendored for the flatpak sandbox (where nvcc
+# never runs) by running `make cuda-artifacts` in a Docker image that has nvcc,
+# then copying the cubins to $(CUDA_ARTIFACTS_PREBUILT_DIR)/ where build.rs
+# picks them up. Heavy and explicit-only -- not a dependency of check/dev.
 cuda-artifacts-image:
 	@command -v $(DOCKER) >/dev/null 2>&1 || { echo "Installing docker..."; $(PACMAN) -S --noconfirm docker; sudo systemctl enable --now docker; }
 	$(DOCKER) build -f $(CUDA_ARTIFACTS_DOCKERFILE) -t $(CUDA_ARTIFACTS_IMAGE) .
@@ -167,11 +160,9 @@ cuda-artifacts-image:
 	-chown -R "$$(id -u):$$(id -g)" $(CUDA_ARTIFACTS_PREBUILT_DIR) 2>/dev/null
 	$(DOCKER) rm -f $(CUDA_ARTIFACTS_CONTAINER) >/dev/null 2>&1
 
-# Idempotent: installs flatpak, flatpak-builder, the flathub remote, and the
-# org.gnome Platform/Sdk pair if missing, skips anything already present.
-# Package names are assumed to be pacman's (this repo's target machine is
-# CachyOS/Arch per CLAUDE.md) -- override PACMAN if that's wrong for your
-# host.
+# Idempotent installs of flatpak, flatpak-builder, the flathub remote and the
+# org.gnome Platform/Sdk pair. Package names assume pacman (the target machine
+# is Arch, per CLAUDE.md) -- override PACMAN otherwise.
 PACMAN ?= sudo pacman
 flatpak-sdk:
 	@command -v $(FLATPAK) >/dev/null 2>&1 || { echo "Installing flatpak..."; $(PACMAN) -S --noconfirm flatpak; }
@@ -180,20 +171,16 @@ flatpak-sdk:
 	@$(FLATPAK) info org.gnome.Platform//$(FLATPAK_RUNTIME_VERSION) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.gnome.Platform//$(FLATPAK_RUNTIME_VERSION)
 	@$(FLATPAK) info org.gnome.Sdk//$(FLATPAK_RUNTIME_VERSION) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.gnome.Sdk//$(FLATPAK_RUNTIME_VERSION)
 
-# Only the submodules the flatpak build path actually needs (slang for
-# cuda-artifacts and the M6 slang module, optix-dev/vtracer as
-# shrimply-render-cuda/-video-core path deps). external/manim is out of
-# scope -- see TODO.md. slang needs --recursive: its own build (glslang,
-# spirv-tools, etc., see M6) pulls in nested submodules under
-# external/slang/external/ that a plain (non-recursive) init leaves empty.
+# Only the submodules the flatpak build needs. slang needs --recursive: its
+# build pulls in nested submodules under external/slang/external/ that a plain
+# init leaves empty.
 flatpak-submodules:
 	@test -e external/slang/external/glslang/CMakeLists.txt || git submodule update --init --recursive external/slang
 	@test -e external/optix-dev/README.md || git submodule update --init external/optix-dev
 	@test -e external/vtracer/Cargo.toml || git submodule update --init external/vtracer
 
-# Skips the (heavy, Docker-based) rebuild if cubins are already vendored --
-# see M4 in TODO.md. Delete crates/render-cuda/prebuilt/$(CUDA_TARGET)/ first
-# to force regeneration (e.g. after a shader change).
+# Skips the Docker rebuild if cubins are already vendored. Delete
+# $(CUDA_ARTIFACTS_PREBUILT_DIR)/ to force regeneration (e.g. after a shader change).
 flatpak-cuda-vendor: flatpak-submodules
 	@if [ -z "$$(ls -A $(CUDA_ARTIFACTS_PREBUILT_DIR) 2>/dev/null)" ]; then \
 		$(MAKE) cuda-artifacts-image; \
@@ -204,53 +191,33 @@ flatpak-cuda-vendor: flatpak-submodules
 flatpak-skeleton: flatpak-sdk metainfo-check desktop-file-check
 	$(FLATPAK_BUILDER) --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
 
-# M5 (see TODO.md): installs the Rust nightly Sdk extension the flatpak build
-# uses for its toolchain. Idempotent like flatpak-sdk.
+# Rust nightly Sdk extension: the flatpak build's toolchain.
 flatpak-rust-sdk:
 	@$(FLATPAK) info org.freedesktop.Sdk.Extension.rust-nightly//$(FLATPAK_SDK_EXTENSION_BRANCH) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.freedesktop.Sdk.Extension.rust-nightly//$(FLATPAK_SDK_EXTENSION_BRANCH)
 
-# M7: installs the LLVM Sdk extension (bindgen/opencv-binding-generator need
-# libclang.so + the clang binary, org.gnome.Sdk//50 has neither). Idempotent.
+# LLVM Sdk extension: bindgen / opencv-binding-generator need libclang + clang,
+# which org.gnome.Sdk doesn't ship.
 flatpak-llvm-sdk:
 	@$(FLATPAK) info org.freedesktop.Sdk.Extension.llvm22//$(FLATPAK_SDK_EXTENSION_BRANCH) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.freedesktop.Sdk.Extension.llvm22//$(FLATPAK_SDK_EXTENSION_BRANCH)
 
-# In-sandbox only -- has no business running on the host, which has no
-# `/usr/lib/sdk/rust-nightly` and normally drives cargo through rustup
-# instead (see CARGO's definition above). A manifest build-command sources
-# the extension's enable.sh for PATH, then invokes this with `CARGO=cargo` to
-# override the rustup-wrapped default, e.g.:
+# In-sandbox smoke test -- run with CARGO=cargo after sourcing the extension's
+# enable.sh, e.g.:
 #   source /usr/lib/sdk/rust-nightly/enable.sh && make flatpak-rust-check CARGO=cargo
-# Checks a single leaf crate (shrimply-math-core: no native deps, nothing
-# else in the workspace depends on it) rather than the whole workspace --
-# M6's native deps (ffmpeg/poppler/opencv/...) don't exist in the sandbox
-# yet, see TODO.md M5.
+# Checks one leaf crate (no native deps) rather than the whole workspace.
 flatpak-rust-check:
 	rustc --version
 	$(CARGO) --version
 	$(CARGO) check -p shrimply-math-core
 
-# Reproduces the flatpak packaging work done through M6 (see TODO.md) from a
-# fresh clone in one command: installs flatpak-builder + the SDK/runtime pair
-# + the rust-nightly and llvm22 Sdk extensions, initializes the submodules
-# the build needs, vendors the CUDA cubins if not already present (needs
-# Docker), then runs flatpak-skeleton -- which, now that M6's 6 dependency
-# modules and M7's app module are in the manifest, is no longer a quick
-# metadata-only build: it's a real, possibly hour-plus build of
-# rubberband/ffmpeg/poppler/vte/opencv/slang/shrimply from source.
-# `--share=network` is still on, so this also needs network access for the
-# module sources. See TODO.md's M7 section for the ~/.cache/
-# shrimply-flatpak-cargo-cache CI caching notes.
+# Full flatpak build from a fresh clone in one command: SDK/runtime, both Sdk
+# extensions, submodules, vendored cubins, then the manifest build (a real
+# hour-plus compile of all the dependency modules from source). Needs Docker
+# and network access.
 flatpak-bootstrap: flatpak-sdk flatpak-rust-sdk flatpak-llvm-sdk flatpak-cuda-vendor flatpak-skeleton
-	@echo "Flatpak packaging reproduced through M7."
+	@echo "Flatpak packaging reproduced."
 
-# M7: `dist` was deliberately left unimplemented (listed in .PHONY with no
-# recipe) until a real app module landed -- see TODO.md's "Decided" section.
-# It has now, so this is real: produces a single-file .flatpak bundle, the
-# distribution model TODO.md's Target section actually calls for (self-hosted
-# repo or single-file bundle, NOT Flathub -- blocked by the NVIDIA
-# redistributables and the pinned Rust nightly). `dist-image` was the other
-# historical option floated for this and is deleted, not implemented, per
-# that same note.
+# Produces a single-file .flatpak bundle (the distribution model, not Flathub --
+# blocked by the NVIDIA redistributables and the pinned Rust nightly).
 FLATPAK_APP_ID ?= dev.shrimply.Shrimply
 FLATPAK_REPO_DIR ?= repo
 FLATPAK_BUNDLE ?= $(FLATPAK_APP_ID).flatpak

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,26 @@ SLANG_BUILD_DIR ?= $(SLANG_SOURCE_DIR)/build
 OPTIX_ROOT ?= $(CURDIR)/external/optix-dev
 DNF ?= sudo dnf
 INSTALL ?= install
+DOCKER ?= docker
+CUDA_ARTIFACTS_DOCKERFILE ?= packaging/docker/cuda-artifacts.Dockerfile
+CUDA_ARTIFACTS_IMAGE ?= shrimply-cuda-artifacts
+CUDA_ARTIFACTS_CONTAINER ?= shrimply-cuda-artifacts-run
+CUDA_ARTIFACTS_PREBUILT_DIR ?= crates/render-cuda/prebuilt/$(CUDA_TARGET)
+FLATPAK ?= flatpak
+FLATPAK_BUILDER ?= flatpak-builder
+FLATPAK_RUNTIME_VERSION ?= 50
+FLATPAK_MANIFEST ?= packaging/flatpak/dev.shrimply.Shrimply.yaml
+FLATPAK_BUILD_DIR ?= build
+# Matches org.gnome.Sdk//50's own base (confirmed via
+# `flatpak info --show-metadata org.gnome.Sdk//50`: its GL/GStreamer/etc
+# extension points are all pinned to 25.08) -- the rust-nightly extension has
+# no "50" branch of its own, see TODO.md M5.
+FLATPAK_SDK_EXTENSION_BRANCH ?= 25.08
 PKG_CONFIG ?= /usr/bin/pkg-config
 PKG_CONFIG_PATH ?= /usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig
 QT_QMAKE ?= qmake6
+APPSTREAMCLI ?= appstreamcli
+DESKTOP_FILE_VALIDATE ?= desktop-file-validate
 SLANG_LIBRARY_ENV = LD_LIBRARY_PATH="$(SLANG_BUILD_DIR)/Release/lib:$${LD_LIBRARY_PATH}" DYLD_LIBRARY_PATH="$(SLANG_BUILD_DIR)/Release/lib:$${DYLD_LIBRARY_PATH}"
 BUILD_ENV := CUDA_HOME=$(CUDA_HOME) CUDA_TOOLKIT_PATH=$(CUDA_TOOLKIT_PATH) PATH=$(CUDA_HOME)/bin:$(PATH) PKG_CONFIG=$(PKG_CONFIG) PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) SLANG_SOURCE_DIR=$(SLANG_SOURCE_DIR) SLANG_BUILD_DIR=$(SLANG_BUILD_DIR) OPTIX_ROOT=$(OPTIX_ROOT)
 BUILD_ENV += $(SLANG_LIBRARY_ENV)
@@ -103,7 +120,7 @@ FEDORA_PACKAGES := \
 	qt6-qtbase-devel \
 	qt6-qtdeclarative-devel
 
-.PHONY: native-deps qt-native-deps desktop-icon qt-desktop-file cuda-target-check cuda-artifacts dev dev-mac qt-build dev-qt dev-server docs docs-check run run-qt build release check components-check gtk-components-showcase qt-components-showcase server-python-check manim manim-python-check manim-parameter-check cargo-check fmt fmt-check lint test frame-rate-test video-lifecycle-test transparent-fill-frame-range-test transparent-fill-decoder-test transparent-fill-kernel-test transparent-fill-compositor-test transparent-fill-playback-test transparent-fill-e2e-fixture transparent-fill-e2e-test decode-ahead-benchmark paint-interpolation-test crash-report clean-dev clean deps-fedora deps-fedora-qt qt-release install install-qt install-codex-mcp-dev install-agy-mcp-dev uninstall uninstall-qt dist-image dist
+.PHONY: native-deps qt-native-deps desktop-icon qt-desktop-file cuda-target-check cuda-artifacts cuda-artifacts-image flatpak-sdk flatpak-submodules flatpak-cuda-vendor flatpak-skeleton flatpak-bootstrap flatpak-rust-sdk flatpak-llvm-sdk flatpak-rust-check dev dev-mac qt-build dev-qt dev-server docs docs-check run run-qt build release check components-check gtk-components-showcase qt-components-showcase server-python-check manim manim-python-check manim-parameter-check metainfo-check desktop-file-check cargo-check fmt fmt-check lint test frame-rate-test video-lifecycle-test transparent-fill-frame-range-test transparent-fill-decoder-test transparent-fill-kernel-test transparent-fill-compositor-test transparent-fill-playback-test transparent-fill-e2e-fixture transparent-fill-e2e-test decode-ahead-benchmark paint-interpolation-test crash-report clean-dev clean deps-fedora deps-fedora-qt qt-release install install-qt install-codex-mcp-dev install-agy-mcp-dev uninstall uninstall-qt dist
 native-deps:
 	@$(PKG_CONFIG) --exists rubberband || { echo "Missing Rubber Band development files (pkg-config: rubberband)" >&2; exit 1; }
 	@$(PKG_CONFIG) --exists libpipewire-0.3 || { echo "Missing PipeWire development files (pkg-config: libpipewire-0.3)" >&2; exit 1; }
@@ -130,6 +147,117 @@ cuda-target-check:
 
 cuda-artifacts: cuda-target-check slang-compiler
 	$(BUILD_ENV) CUDA_TARGET=$(CUDA_TARGET) CUDA_HOST_CXX=$(CUDA_HOST_CXX) $(CARGO) build -p shrimply-render-cuda
+
+# Occasional, heavy, explicit-only: builds the prebuilt .cubin files vendored
+# for the flatpak sandbox (M4 — see TODO.md), where nvcc never runs. Not a
+# dependency of `check`/`dev`/`cuda-artifacts` itself. Runs `make
+# cuda-artifacts` inside a Docker image that has nvcc (this machine has no
+# GPU driver in the container, same as the top-level Dockerfile), then copies
+# the resulting cubins out to crates/render-cuda/prebuilt/$(CUDA_TARGET)/,
+# which build.rs picks up automatically on the next `cargo build -p
+# shrimply-render-cuda` (in-sandbox or not).
+cuda-artifacts-image:
+	@command -v $(DOCKER) >/dev/null 2>&1 || { echo "Installing docker..."; $(PACMAN) -S --noconfirm docker; sudo systemctl enable --now docker; }
+	$(DOCKER) build -f $(CUDA_ARTIFACTS_DOCKERFILE) -t $(CUDA_ARTIFACTS_IMAGE) .
+	-$(DOCKER) rm -f $(CUDA_ARTIFACTS_CONTAINER) >/dev/null 2>&1
+	$(DOCKER) run --name $(CUDA_ARTIFACTS_CONTAINER) $(CUDA_ARTIFACTS_IMAGE)
+	mkdir -p $(CUDA_ARTIFACTS_PREBUILT_DIR)
+	$(DOCKER) cp $(CUDA_ARTIFACTS_CONTAINER):/src/.slang-artifacts/cuda/$(CUDA_TARGET)/. $(CUDA_ARTIFACTS_PREBUILT_DIR)/
+	find $(CUDA_ARTIFACTS_PREBUILT_DIR) -maxdepth 1 -type f ! -name '*.cubin' -delete
+	-chown -R "$$(id -u):$$(id -g)" $(CUDA_ARTIFACTS_PREBUILT_DIR) 2>/dev/null
+	$(DOCKER) rm -f $(CUDA_ARTIFACTS_CONTAINER) >/dev/null 2>&1
+
+# Idempotent: installs flatpak, flatpak-builder, the flathub remote, and the
+# org.gnome Platform/Sdk pair if missing, skips anything already present.
+# Package names are assumed to be pacman's (this repo's target machine is
+# CachyOS/Arch per CLAUDE.md) -- override PACMAN if that's wrong for your
+# host.
+PACMAN ?= sudo pacman
+flatpak-sdk:
+	@command -v $(FLATPAK) >/dev/null 2>&1 || { echo "Installing flatpak..."; $(PACMAN) -S --noconfirm flatpak; }
+	@command -v $(FLATPAK_BUILDER) >/dev/null 2>&1 || { echo "Installing flatpak-builder..."; $(PACMAN) -S --noconfirm flatpak-builder; }
+	@$(FLATPAK) remote-list | grep -q '^flathub' || $(FLATPAK) remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+	@$(FLATPAK) info org.gnome.Platform//$(FLATPAK_RUNTIME_VERSION) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.gnome.Platform//$(FLATPAK_RUNTIME_VERSION)
+	@$(FLATPAK) info org.gnome.Sdk//$(FLATPAK_RUNTIME_VERSION) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.gnome.Sdk//$(FLATPAK_RUNTIME_VERSION)
+
+# Only the submodules the flatpak build path actually needs (slang for
+# cuda-artifacts and the M6 slang module, optix-dev/vtracer as
+# shrimply-render-cuda/-video-core path deps). external/manim is out of
+# scope -- see TODO.md. slang needs --recursive: its own build (glslang,
+# spirv-tools, etc., see M6) pulls in nested submodules under
+# external/slang/external/ that a plain (non-recursive) init leaves empty.
+flatpak-submodules:
+	@test -e external/slang/external/glslang/CMakeLists.txt || git submodule update --init --recursive external/slang
+	@test -e external/optix-dev/README.md || git submodule update --init external/optix-dev
+	@test -e external/vtracer/Cargo.toml || git submodule update --init external/vtracer
+
+# Skips the (heavy, Docker-based) rebuild if cubins are already vendored --
+# see M4 in TODO.md. Delete crates/render-cuda/prebuilt/$(CUDA_TARGET)/ first
+# to force regeneration (e.g. after a shader change).
+flatpak-cuda-vendor: flatpak-submodules
+	@if [ -z "$$(ls -A $(CUDA_ARTIFACTS_PREBUILT_DIR) 2>/dev/null)" ]; then \
+		$(MAKE) cuda-artifacts-image; \
+	else \
+		echo "CUDA cubins already vendored at $(CUDA_ARTIFACTS_PREBUILT_DIR)/, skipping"; \
+	fi
+
+flatpak-skeleton: flatpak-sdk metainfo-check desktop-file-check
+	$(FLATPAK_BUILDER) --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+
+# M5 (see TODO.md): installs the Rust nightly Sdk extension the flatpak build
+# uses for its toolchain. Idempotent like flatpak-sdk.
+flatpak-rust-sdk:
+	@$(FLATPAK) info org.freedesktop.Sdk.Extension.rust-nightly//$(FLATPAK_SDK_EXTENSION_BRANCH) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.freedesktop.Sdk.Extension.rust-nightly//$(FLATPAK_SDK_EXTENSION_BRANCH)
+
+# M7: installs the LLVM Sdk extension (bindgen/opencv-binding-generator need
+# libclang.so + the clang binary, org.gnome.Sdk//50 has neither). Idempotent.
+flatpak-llvm-sdk:
+	@$(FLATPAK) info org.freedesktop.Sdk.Extension.llvm22//$(FLATPAK_SDK_EXTENSION_BRANCH) >/dev/null 2>&1 || $(FLATPAK) install -y flathub org.freedesktop.Sdk.Extension.llvm22//$(FLATPAK_SDK_EXTENSION_BRANCH)
+
+# In-sandbox only -- has no business running on the host, which has no
+# `/usr/lib/sdk/rust-nightly` and normally drives cargo through rustup
+# instead (see CARGO's definition above). A manifest build-command sources
+# the extension's enable.sh for PATH, then invokes this with `CARGO=cargo` to
+# override the rustup-wrapped default, e.g.:
+#   source /usr/lib/sdk/rust-nightly/enable.sh && make flatpak-rust-check CARGO=cargo
+# Checks a single leaf crate (shrimply-math-core: no native deps, nothing
+# else in the workspace depends on it) rather than the whole workspace --
+# M6's native deps (ffmpeg/poppler/opencv/...) don't exist in the sandbox
+# yet, see TODO.md M5.
+flatpak-rust-check:
+	rustc --version
+	$(CARGO) --version
+	$(CARGO) check -p shrimply-math-core
+
+# Reproduces the flatpak packaging work done through M6 (see TODO.md) from a
+# fresh clone in one command: installs flatpak-builder + the SDK/runtime pair
+# + the rust-nightly and llvm22 Sdk extensions, initializes the submodules
+# the build needs, vendors the CUDA cubins if not already present (needs
+# Docker), then runs flatpak-skeleton -- which, now that M6's 6 dependency
+# modules and M7's app module are in the manifest, is no longer a quick
+# metadata-only build: it's a real, possibly hour-plus build of
+# rubberband/ffmpeg/poppler/vte/opencv/slang/shrimply from source.
+# `--share=network` is still on, so this also needs network access for the
+# module sources. See TODO.md's M7 section for the ~/.cache/
+# shrimply-flatpak-cargo-cache CI caching notes.
+flatpak-bootstrap: flatpak-sdk flatpak-rust-sdk flatpak-llvm-sdk flatpak-cuda-vendor flatpak-skeleton
+	@echo "Flatpak packaging reproduced through M7."
+
+# M7: `dist` was deliberately left unimplemented (listed in .PHONY with no
+# recipe) until a real app module landed -- see TODO.md's "Decided" section.
+# It has now, so this is real: produces a single-file .flatpak bundle, the
+# distribution model TODO.md's Target section actually calls for (self-hosted
+# repo or single-file bundle, NOT Flathub -- blocked by the NVIDIA
+# redistributables and the pinned Rust nightly). `dist-image` was the other
+# historical option floated for this and is deleted, not implemented, per
+# that same note.
+FLATPAK_APP_ID ?= dev.shrimply.Shrimply
+FLATPAK_REPO_DIR ?= repo
+FLATPAK_BUNDLE ?= $(FLATPAK_APP_ID).flatpak
+dist: flatpak-sdk flatpak-rust-sdk flatpak-llvm-sdk flatpak-cuda-vendor metainfo-check desktop-file-check
+	$(FLATPAK_BUILDER) --repo=$(FLATPAK_REPO_DIR) --force-clean $(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+	$(FLATPAK) build-bundle $(FLATPAK_REPO_DIR) $(FLATPAK_BUNDLE) $(FLATPAK_APP_ID)
+	@echo "Flatpak bundle: $(FLATPAK_BUNDLE)"
 
 dev: SHELL := /bin/bash
 desktop-icon:
@@ -219,7 +347,7 @@ build: native-deps cuda-artifacts
 release: native-deps cuda-artifacts
 	$(BUILD_ENV) $(CARGO) build --release -p $(EDITOR_PACKAGE) -p $(LAUNCHER_PACKAGE) -p $(MCP_PACKAGE) --bins
 
-check: native-deps qt-native-deps cuda-artifacts fmt source-size-check cargo-check lint server-python-check manim-python-check docs-check
+check: native-deps qt-native-deps cuda-artifacts fmt source-size-check cargo-check lint server-python-check manim-python-check docs-check metainfo-check desktop-file-check
 
 components-check: native-deps qt-native-deps
 	$(DEV_BUILD_ENV) QMAKE=$(QT_QMAKE) $(CARGO) check -p $(FRAMEGRAPH_CORE_PACKAGE) -p $(GTK_COMPONENTS_PACKAGE) -p $(QT_COMPONENTS_PACKAGE) -p $(GTK_COMPONENTS_DEMO_PACKAGE) -p $(QT_COMPONENTS_DEMO_PACKAGE) --all-targets
@@ -255,6 +383,14 @@ manim-visual-check: native-deps
 
 manim-parameter-check: native-deps
 	$(DEV_BUILD_ENV) $(CARGO) test -p shrimply-manim-parser --test two_pass_parameters -- --ignored --nocapture
+
+metainfo-check:
+	@command -v $(APPSTREAMCLI) >/dev/null 2>&1 || { echo "Installing appstream..."; $(PACMAN) -S --noconfirm appstream; }
+	$(APPSTREAMCLI) validate assets/dev.shrimply.Shrimply.metainfo.xml
+
+desktop-file-check:
+	@command -v $(DESKTOP_FILE_VALIDATE) >/dev/null 2>&1 || { echo "Installing desktop-file-utils..."; $(PACMAN) -S --noconfirm desktop-file-utils; }
+	$(DESKTOP_FILE_VALIDATE) assets/dev.shrimply.Shrimply.desktop
 
 cargo-check: native-deps qt-native-deps slang-compiler
 	$(DEV_BUILD_ENV) QMAKE=$(QT_QMAKE) $(CARGO) check -p $(EDITOR_PACKAGE) -p $(QT_EDITOR_PACKAGE) -p $(LAUNCHER_PACKAGE) -p $(QT_LAUNCHER_PACKAGE) -p $(MCP_PACKAGE) --bins

--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ Shrimply's main application is written in Rust and uses these technologies:
 - **Media**: FFmpeg and PipeWire
 - **Compute server**: Python
 
+### Building a Flatpak
+
+```
+make dist
+```
+
+This installs flatpak, flatpak-builder, the GNOME runtime/SDK, and required
+SDK extensions; initializes the submodules the build needs; regenerates the
+vendored CUDA cubins if missing (needs Docker); and builds
+`packaging/flatpak/dev.shrimply.Shrimply.yaml` from scratch into a
+single-file `dev.shrimply.Shrimply.flatpak` bundle. It's a long build
+(FFmpeg, OpenCV, and the whole Rust workspace all compile from source) — see
+`packaging/flatpak/README.md` for details, caching notes, and the manual
+step-by-step equivalent.
+
 ### Finding Things to Work On
 
 Browse the [open issues](https://github.com/soirihiroka/shrimply/issues) for

--- a/assets/dev.shrimply.Shrimply.metainfo.xml
+++ b/assets/dev.shrimply.Shrimply.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>dev.shrimply.Shrimply</id>
+  <name>Shrimply</name>
+  <summary>Video editor for creating videos from start to finish</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <developer id="dev.shrimply">
+    <name>Shrimply contributors</name>
+  </developer>
+  <description>
+    <p>
+      Shrimply is a free and open-source video editor for creating videos
+      from start to finish, whether you are making a quick edit or something
+      fancy.
+    </p>
+    <p>
+      Shrimply is currently pre-alpha software and should be expected to be
+      unstable.
+    </p>
+  </description>
+  <launchable type="desktop-id">dev.shrimply.Shrimply.desktop</launchable>
+  <url type="homepage">https://shrimply.pages.dev</url>
+  <url type="vcs-browser">https://github.com/soirihiroka/shrimply</url>
+  <url type="bugtracker">https://github.com/soirihiroka/shrimply/issues</url>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.1.0" date="2026-09-07">
+      <description>
+        <p>Pre-alpha development snapshot.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/crates/cuda/bridge/bridge.c
+++ b/crates/cuda/bridge/bridge.c
@@ -130,7 +130,7 @@ CUresult shrimply_cuda_mem_alloc_managed(uint64_t *pointer, size_t bytes,
 CUresult shrimply_cuda_mem_get_info(size_t *free_bytes, size_t *total_bytes) {
   return cuMemGetInfo(free_bytes, total_bytes);
 }
-#if CUDA_VERSION >= 13020
+#if CUDA_VERSION >= 13000
 CUresult shrimply_cuda_mem_advise_v2(uint64_t pointer, size_t bytes,
                                      unsigned advice, CUmemLocation location) {
   return cuMemAdvise((CUdeviceptr)pointer, bytes, (CUmem_advise)advice,

--- a/crates/export/export-core/src/video.rs
+++ b/crates/export/export-core/src/video.rs
@@ -82,7 +82,6 @@ pub enum ExportProfile {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExportAudioEncoder {
-    FdkAac,
     Aac,
     Opus,
 }
@@ -621,7 +620,6 @@ fn open_audio_encoder(
     global_header: bool,
 ) -> Result<ffmpeg::codec::encoder::audio::Encoder, String> {
     let encoder_name = match settings.audio_encoder {
-        ExportAudioEncoder::FdkAac => "libfdk_aac",
         ExportAudioEncoder::Aac => "aac",
         ExportAudioEncoder::Opus => "libopus",
     };
@@ -1142,9 +1140,6 @@ fn sample_i16(sample: f32) -> i16 {
 
 fn audio_sample_format(encoder: ExportAudioEncoder) -> ffmpeg::format::Sample {
     match encoder {
-        ExportAudioEncoder::FdkAac => {
-            ffmpeg::format::Sample::I16(ffmpeg::format::sample::Type::Packed)
-        }
         ExportAudioEncoder::Aac => {
             ffmpeg::format::Sample::F32(ffmpeg::format::sample::Type::Planar)
         }

--- a/crates/export/export-gtk/src/lib.rs
+++ b/crates/export/export-gtk/src/lib.rs
@@ -419,11 +419,10 @@ fn open_export_page(
     let audio_encoder_row = TypedComboRow::new(
         "Audio Encoder",
         [
-            (video::ExportAudioEncoder::FdkAac, "FDK AAC"),
             (video::ExportAudioEncoder::Aac, "AAC"),
             (video::ExportAudioEncoder::Opus, "Opus"),
         ],
-        video::ExportAudioEncoder::FdkAac,
+        video::ExportAudioEncoder::Aac,
     );
 
     let audio_sample_rate_row = TypedComboRow::new(

--- a/crates/export/export-qt/qml/ExportWindow.qml
+++ b/crates/export/export-qt/qml/ExportWindow.qml
@@ -314,7 +314,7 @@ Item {
                             ControlRow {
                                 label: exportBackend.translate("Audio Encoder")
                                 ComboBox {
-                                    model: ["FDK AAC", "AAC", "Opus"]
+                                    model: ["AAC", "Opus"]
                                     currentIndex: exportBackend.audioEncoder
                                     onActivated: exportBackend.audioEncoder = currentIndex
                                 }

--- a/crates/export/export-qt/src/backend.rs
+++ b/crates/export/export-qt/src/backend.rs
@@ -719,9 +719,8 @@ fn profile(index: i32) -> video::ExportProfile {
 
 fn audio_encoder(index: i32) -> video::ExportAudioEncoder {
     match index {
-        0 => video::ExportAudioEncoder::FdkAac,
-        1 => video::ExportAudioEncoder::Aac,
-        2 => video::ExportAudioEncoder::Opus,
+        0 => video::ExportAudioEncoder::Aac,
+        1 => video::ExportAudioEncoder::Opus,
         value => panic!("unknown audio encoder index {value}"),
     }
 }

--- a/crates/render-cuda/build.rs
+++ b/crates/render-cuda/build.rs
@@ -36,24 +36,43 @@ fn main() {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/usr/local/cuda"));
     let host = env::var("CUDA_HOST_CXX").unwrap_or_else(|_| "g++-15".to_owned());
+    // Flatpak M4: nvcc doesn't run inside the org.gnome.Sdk sandbox, so cubins
+    // for that build are prebuilt outside it (see Dockerfile /
+    // `make cuda-artifacts-image`) and vendored on disk here -- gitignored,
+    // not committed (see packaging/flatpak/README.md); `make
+    // flatpak-cuda-vendor` regenerates them when missing and CI caches the
+    // result. If a module's cubin is already present at
+    // `prebuilt/<CUDA_TARGET>/<module>.cubin`, skip slangc+nvcc for that
+    // module entirely and just copy the vendored file to the expected output
+    // path — this applies to every build, sandboxed or not, since the
+    // vendored files are just part of the source tree. Editing a shader and
+    // expecting a normal `make cuda-artifacts` to pick it up requires
+    // deleting the corresponding file under `prebuilt/` first.
+    let prebuilt = manifest.join("prebuilt").join(CUDA_TARGET);
     let mut bindings = String::new();
     for module in MODULES.lines() {
-        let source = shaders.join(format!("{module}.slang"));
-        let artifact = compiler.compile(&source, Target::Cuda, &[]);
         let image = output.join(format!("{module}.cubin"));
-        let status = Command::new(toolkit.join("bin/nvcc"))
-            .arg(format!("--compiler-bindir={host}"))
-            .args(["--cubin", "-O2", "-w"])
-            .arg(format!("--gpu-architecture={CUDA_TARGET}"))
-            .arg(output.join(artifact.filename))
-            .arg("-o")
-            .arg(&image)
-            .status()
-            .expect("compile generated CUDA source with NVCC");
-        assert!(
-            status.success(),
-            "compile CUDA kernel module {module}: {status}"
-        );
+        let vendored = prebuilt.join(format!("{module}.cubin"));
+        if vendored.exists() {
+            fs::copy(&vendored, &image)
+                .unwrap_or_else(|error| panic!("copy vendored cubin for {module}: {error}"));
+        } else {
+            let source = shaders.join(format!("{module}.slang"));
+            let artifact = compiler.compile(&source, Target::Cuda, &[]);
+            let status = Command::new(toolkit.join("bin/nvcc"))
+                .arg(format!("--compiler-bindir={host}"))
+                .args(["--cubin", "-O2", "-w", "-allow-unsupported-compiler"])
+                .arg(format!("--gpu-architecture={CUDA_TARGET}"))
+                .arg(output.join(artifact.filename))
+                .arg("-o")
+                .arg(&image)
+                .status()
+                .expect("compile generated CUDA source with NVCC");
+            assert!(
+                status.success(),
+                "compile CUDA kernel module {module}: {status}"
+            );
+        }
         bindings.push_str(&format!(
             "pub const {}: &[u8] = include_bytes!({:?});\n",
             module.to_uppercase(),

--- a/crates/render-cuda/build.rs
+++ b/crates/render-cuda/build.rs
@@ -36,18 +36,11 @@ fn main() {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/usr/local/cuda"));
     let host = env::var("CUDA_HOST_CXX").unwrap_or_else(|_| "g++-15".to_owned());
-    // Flatpak M4: nvcc doesn't run inside the org.gnome.Sdk sandbox, so cubins
-    // for that build are prebuilt outside it (see Dockerfile /
-    // `make cuda-artifacts-image`) and vendored on disk here -- gitignored,
-    // not committed (see packaging/flatpak/README.md); `make
-    // flatpak-cuda-vendor` regenerates them when missing and CI caches the
-    // result. If a module's cubin is already present at
-    // `prebuilt/<CUDA_TARGET>/<module>.cubin`, skip slangc+nvcc for that
-    // module entirely and just copy the vendored file to the expected output
-    // path — this applies to every build, sandboxed or not, since the
-    // vendored files are just part of the source tree. Editing a shader and
-    // expecting a normal `make cuda-artifacts` to pick it up requires
-    // deleting the corresponding file under `prebuilt/` first.
+    // nvcc doesn't run inside the flatpak sandbox, so cubins can be prebuilt
+    // outside it and vendored at `prebuilt/<CUDA_TARGET>/<module>.cubin`
+    // (gitignored; `make flatpak-cuda-vendor` regenerates them). When a
+    // vendored cubin is present, copy it instead of running slangc+nvcc --
+    // delete it to force a rebuild after editing that shader.
     let prebuilt = manifest.join("prebuilt").join(CUDA_TARGET);
     let mut bindings = String::new();
     for module in MODULES.lines() {

--- a/crates/stabilization/affine-l1-stabilization/src/lib.rs
+++ b/crates/stabilization/affine-l1-stabilization/src/lib.rs
@@ -11,7 +11,7 @@ use opencv::core::{
 };
 use opencv::prelude::MatTraitConstManual;
 use opencv::prelude::*;
-use opencv::{calib3d, imgproc, video, videoio};
+use opencv::{features, geometry, imgproc, video, videoio};
 use shrimply_cuda::{CudaContext, CudaStream};
 use shrimply_gpu_memory::GpuBuffer as DeviceBuffer;
 use shrimply_math_core::{Time, fraction_as_u32_ratio, frame_rate_from_f64};
@@ -256,7 +256,7 @@ pub fn estimate_affine(previous: &Mat, current: &Mat) -> Result<Mat3, String> {
         .map_err(|error| error.to_string())?;
 
     let mut previous_points = Vector::<Point2f>::new();
-    imgproc::good_features_to_track(
+    features::good_features_to_track(
         &previous_gray,
         &mut previous_points,
         MAXIMUM_FEATURES,
@@ -329,11 +329,11 @@ fn estimate_affine_from_points(
     previous: &Vector<Point2f>,
 ) -> Result<Mat3, String> {
     let mut inliers = Mat::default();
-    let affine = calib3d::estimate_affine_2d(
+    let affine = geometry::estimate_affine_2d(
         current,
         previous,
         &mut inliers,
-        calib3d::RANSAC,
+        geometry::RANSAC,
         RANSAC_REPROJECTION_THRESHOLD,
         RANSAC_MAXIMUM_ITERATIONS,
         RANSAC_CONFIDENCE,

--- a/crates/video/gpu-memory/build.rs
+++ b/crates/video/gpu-memory/build.rs
@@ -23,7 +23,7 @@ fn main() {
                 .flatten()
         })
         .unwrap_or_else(|| panic!("CUDA_VERSION is missing from {}", header.display()));
-    if version >= 13_020 {
+    if version >= 13_000 {
         println!("cargo:rustc-cfg=cuda_uses_mem_location");
     }
 }

--- a/packaging/docker/cuda-artifacts.Dockerfile
+++ b/packaging/docker/cuda-artifacts.Dockerfile
@@ -1,16 +1,7 @@
-# Leaner image for producing prebuilt CUDA cubins outside the flatpak sandbox
-# (M4, see TODO.md). Mirrors the toolchain setup in the top-level Dockerfile
-# (rustup, CUDA toolkit from NVIDIA's repo) but stops there: it does NOT run
-# `make release qt-release` or any of the runtime-bundling steps below it in
-# the top-level Dockerfile — this image only needs to run `make
-# cuda-artifacts`, which builds `shrimply-render-cuda` (slangc + nvcc) and
-# nothing else.
-#
-# Built and run via `make cuda-artifacts-image` (see Makefile). Kept as a
-# separate file rather than folded into the top-level Dockerfile as a build
-# stage: the two images serve different, occasional purposes and touching the
-# working top-level Dockerfile to add staging risks breaking it for no
-# benefit here.
+# Builds the prebuilt CUDA cubins for the flatpak sandbox: just the toolchain
+# (rustup + CUDA from NVIDIA's repo) needed to run `make cuda-artifacts`, none
+# of the top-level Dockerfile's runtime-bundling. Built via
+# `make cuda-artifacts-image`.
 FROM fedora:44
 WORKDIR /src
 
@@ -19,8 +10,7 @@ RUN dnf install -y curl git make patchelf rustup && dnf clean all
 RUN rustup-init -y --default-toolchain none --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# deps-fedora expects the RPMFusion repos to exist even though cuda-artifacts
-# itself never touches ffmpeg/rubberband/opencv etc.
+# deps-fedora expects the RPMFusion repos to exist.
 RUN dnf install -y \
         "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
         "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" \
@@ -50,17 +40,10 @@ RUN test -e external/slang/CMakeLists.txt || { \
 ENV CUDA_HOME=/usr/local/cuda
 ENV CUDA_TOOLKIT_PATH=/usr/local/cuda
 
-# No NVIDIA driver in the build container; stub libcuda.so.1 so nvcc's link
-# step resolves (same trick as the top-level Dockerfile).
+# No NVIDIA driver in the container; stub libcuda.so.1 so nvcc's link resolves.
 RUN ln -sf libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
 
-# `make cuda-artifacts` builds slang (slangc/slang-glslang) itself via the
-# slang-compiler Makefile target, then compiles the kernels with nvcc.
-#
-# CUDA_HOST_CXX override: the Makefile's default (g++-15) assumes a
-# version-suffixed binary that doesn't exist on this Fedora 44 image (or on
-# this host either) — only plain `g++` (GCC 16) is installed. Overridden here
-# rather than in the Makefile default since that default is a separate,
-# pre-existing concern unrelated to this packaging work.
+# CUDA_HOST_CXX=g++: the Makefile default (g++-15) isn't installed here, only
+# plain g++.
 CMD ["make", "cuda-artifacts", "CUDA_HOST_CXX=g++"]

--- a/packaging/docker/cuda-artifacts.Dockerfile
+++ b/packaging/docker/cuda-artifacts.Dockerfile
@@ -1,0 +1,66 @@
+# Leaner image for producing prebuilt CUDA cubins outside the flatpak sandbox
+# (M4, see TODO.md). Mirrors the toolchain setup in the top-level Dockerfile
+# (rustup, CUDA toolkit from NVIDIA's repo) but stops there: it does NOT run
+# `make release qt-release` or any of the runtime-bundling steps below it in
+# the top-level Dockerfile — this image only needs to run `make
+# cuda-artifacts`, which builds `shrimply-render-cuda` (slangc + nvcc) and
+# nothing else.
+#
+# Built and run via `make cuda-artifacts-image` (see Makefile). Kept as a
+# separate file rather than folded into the top-level Dockerfile as a build
+# stage: the two images serve different, occasional purposes and touching the
+# working top-level Dockerfile to add staging risks breaking it for no
+# benefit here.
+FROM fedora:44
+WORKDIR /src
+
+RUN dnf install -y curl git make patchelf rustup && dnf clean all
+
+RUN rustup-init -y --default-toolchain none --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# deps-fedora expects the RPMFusion repos to exist even though cuda-artifacts
+# itself never touches ffmpeg/rubberband/opencv etc.
+RUN dnf install -y \
+        "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm" \
+        "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm" \
+    && dnf clean all
+
+COPY Makefile ./
+RUN make deps-fedora DNF="dnf -y"
+
+# CUDA toolkit from NVIDIA's own repo (Fedora's repos don't ship it)
+RUN . /etc/os-release && \
+    curl -fsSL -o /etc/yum.repos.d/cuda-fedora.repo \
+        "https://developer.download.nvidia.com/compute/cuda/repos/fedora${VERSION_ID}/x86_64/cuda-fedora${VERSION_ID}.repo" && \
+    dnf install -y cuda-toolkit && \
+    dnf clean all
+
+COPY . .
+
+RUN rustup show
+
+# Git submodules (slang) might be missing from the build context.
+RUN test -e external/slang/CMakeLists.txt || { \
+        echo "Git submodules are missing from the build context." >&2; \
+        echo "Run 'git submodule update --init --recursive' before 'docker build'." >&2; \
+        exit 1; \
+    }
+
+ENV CUDA_HOME=/usr/local/cuda
+ENV CUDA_TOOLKIT_PATH=/usr/local/cuda
+
+# No NVIDIA driver in the build container; stub libcuda.so.1 so nvcc's link
+# step resolves (same trick as the top-level Dockerfile).
+RUN ln -sf libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+
+# `make cuda-artifacts` builds slang (slangc/slang-glslang) itself via the
+# slang-compiler Makefile target, then compiles the kernels with nvcc.
+#
+# CUDA_HOST_CXX override: the Makefile's default (g++-15) assumes a
+# version-suffixed binary that doesn't exist on this Fedora 44 image (or on
+# this host either) — only plain `g++` (GCC 16) is installed. Overridden here
+# rather than in the Makefile default since that default is a separate,
+# pre-existing concern unrelated to this packaging work.
+CMD ["make", "cuda-artifacts", "CUDA_HOST_CXX=g++"]

--- a/packaging/flatpak/NOTICE
+++ b/packaging/flatpak/NOTICE
@@ -1,0 +1,65 @@
+Shrimply — third-party components bundled in the Flatpak
+========================================================
+
+Shrimply itself is licensed under GPL-3.0-or-later (see the accompanying
+Shrimply.txt / the LICENSE file in the source tree). The Flatpak bundle links
+the libraries below, built from the exact upstream releases listed here. The
+combined work is distributed under the GNU GPL version 3.
+
+Corresponding source
+--------------------
+The complete corresponding source is:
+  - the upstream release archives identified by URL and SHA-256 below, and
+  - Shrimply's own source together with the Flatpak build manifest
+    (packaging/flatpak/dev.shrimply.Shrimply.yaml), which records every
+    source URL, revision and build option used.
+Shrimply's repository: https://github.com/soirihiroka/shrimply
+
+Bundled libraries
+-----------------
+Rubber Band Library 4.0.0        GPL-2.0-or-later
+  https://breakfastquay.com/files/releases/rubberband-4.0.0.tar.bz2
+
+x264 (b35605ace3ddf7c1a5d67a2eb553f034aef41d55)   GPL-2.0-or-later
+  https://code.videolan.org/videolan/x264.git
+
+LAME 3.100 (libmp3lame only)     LGPL-2.0-or-later
+  https://sourceforge.net/projects/lame/files/lame/3.100/
+
+FFmpeg 9.0.1                     LGPL-2.1-or-later, with GPL parts enabled
+  (--enable-gpl; effectively GPL-2.0-or-later)
+  https://ffmpeg.org/releases/ffmpeg-9.0.1.tar.xz
+
+poppler 26.09.0                  GPL-2.0-or-later
+  https://poppler.freedesktop.org/poppler-26.09.0.tar.xz
+
+VTE 0.84.1                       LGPL-3.0-or-later
+  https://download.gnome.org/sources/vte/0.84/vte-0.84.1.tar.xz
+
+OpenBLAS 0.3.34                  BSD-3-Clause
+  https://github.com/OpenMathLib/OpenBLAS/releases/tag/v0.3.34
+
+OpenCV 5.0.0                     Apache-2.0
+  https://github.com/opencv/opencv/archive/refs/tags/5.0.0.tar.gz
+
+Slang (961e4e59ee0181ad645825c5db3a677d5a829a9f)  Apache-2.0 WITH LLVM-exception
+  https://github.com/shader-slang/slang
+
+Compiled into the Shrimply binaries
+-----------------------------------
+PocketSphinx                     BSD-2-Clause (see PocketSphinx-code.txt)
+PocketSphinx acoustic model      BSD-style (see PocketSphinx-model.txt)
+Rhubarb Lip Sync                 MIT (see Rhubarb-Lip-Sync.txt)
+CUDA kernels (*.cubin)           Shrimply's own shader source, compiled to
+                                 GPU code with the NVIDIA CUDA toolchain
+                                 (NVIDIA CUDA EULA governs the toolchain).
+
+Provided by the runtime, not bundled here
+-----------------------------------------
+org.gnome.Platform // 50 and its libraries (GTK, cairo, pango, gnutls, ICU,
+libvorbis, libopus, …) are supplied by the Flatpak runtime under their own
+licenses. libcuda.so is supplied at runtime by
+org.freedesktop.Platform.GL.nvidia-*.
+
+Full license texts: GPL-3.0 in Shrimply.txt. GPL-2.0, LGPL-2.0/2.1, LGPL-3.0
+and Apache-2.0 texts accompany each upstream release archive above.

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,24 +1,19 @@
-# CUDA cubins in the flatpak (M4)
+# CUDA cubins in the flatpak
 
-`org.gnome.Sdk//50` has no `nvcc`, so `crates/render-cuda/build.rs` never
-compiles CUDA kernels inside the flatpak sandbox. Instead the `.cubin` files
-are built outside the sandbox and vendored as pinned sources — this is the
-decided M4 plan (see `TODO.md`), not a stopgap.
+`org.gnome.Sdk//50` has no `nvcc`, so the CUDA kernels can't be compiled inside
+the flatpak sandbox. Instead the `.cubin` files are built outside it and
+vendored on disk.
 
 ## How it works
 
 - `crates/render-cuda/build.rs` checks
   `crates/render-cuda/prebuilt/<CUDA_TARGET>/<module>.cubin` before running
-  slangc/nvcc for that module. If the file exists it's copied straight to the
-  expected build output path and nvcc is never invoked for that module. This
-  applies both inside and outside the sandbox — it's a plain file-existence
-  check, not flatpak-specific.
-- Outside the sandbox, cubins are produced with the Fedora/CUDA-toolkit image
-  the top-level `Dockerfile` already uses for the full app build, but via a
-  leaner, separate image: `packaging/docker/cuda-artifacts.Dockerfile`. That
-  image stops right after the CUDA toolkit + slang toolchain are installed —
-  it never runs the full `make release qt-release` or the runtime-bundling
-  steps in the top-level Dockerfile.
+  slangc/nvcc. If it exists, it's copied to the build output and nvcc is
+  skipped. Plain file-existence check, not flatpak-specific — it applies to
+  every build.
+- The cubins are produced by `packaging/docker/cuda-artifacts.Dockerfile`, a
+  lean image with just the CUDA + slang toolchain (none of the top-level
+  Dockerfile's app build / runtime bundling).
 
 ## Rebuild recipe
 
@@ -26,44 +21,25 @@ decided M4 plan (see `TODO.md`), not a stopgap.
 make flatpak-cuda-vendor
 ```
 
-Don't call `cuda-artifacts-image` directly on a fresh clone — it has no
-`flatpak-submodules` prerequisite of its own, and the Docker build's `COPY .
-.` step will hard-fail with a "Git submodules are missing" error if
-`external/slang` hasn't been initialized yet. `flatpak-cuda-vendor` inits the
-submodules it needs first, then only actually runs `cuda-artifacts-image` if
-`crates/render-cuda/prebuilt/$(CUDA_TARGET)/` is empty — see "Status" below.
-It builds the image, runs `make cuda-artifacts` inside a container, and
-copies `.slang-artifacts/cuda/sm_86/*.cubin` out to
-`crates/render-cuda/prebuilt/sm_86/`. It's deliberately not part of `make
-check`/`make dev`/`make cuda-artifacts` — it needs Docker, a full CUDA
-toolkit download, and a full slang compile, so it's an explicit, occasional
-operation for regenerating the vendored cubins (e.g. after a kernel or slang
-change; delete `crates/render-cuda/prebuilt/sm_86/` first to force it). Two
-host-environment fixes were needed to get real nvcc output out of this
-image, both in the code/Docker layer, not just this one build:
-- `packaging/docker/cuda-artifacts.Dockerfile`'s `CMD` overrides
-  `CUDA_HOST_CXX=g++`: the Makefile's own default (`g++-15`) doesn't exist as
-  a binary on Fedora 44 (or on this host) — only unversioned `g++` (GCC 16) is
-  installed.
-- `crates/render-cuda/build.rs`'s nvcc invocation now always passes
-  `-allow-unsupported-compiler`, since CUDA 13.3 refuses GCC >15 without it.
-  This affects every nvcc invocation, not just the flatpak/Docker path.
+Inits the submodules it needs, then runs the Docker build only if
+`crates/render-cuda/prebuilt/$(CUDA_TARGET)/` is empty. Don't call
+`make cuda-artifacts-image` directly on a fresh clone — it has no submodule
+prerequisite and the Docker `COPY . .` fails if `external/slang` isn't
+initialized.
 
-## Status: not committed, regenerated and cached in CI
+Needs Docker, a CUDA toolkit download and a full slang compile, so it's not
+part of `make check` / `make dev`.
 
-Real cubins are produced by the recipe above and land at
-`crates/render-cuda/prebuilt/sm_86/*.cubin` (~4.7MB total), gitignored
-rather than committed to git or pinned as separate flatpak `sources:` —
-`build.rs`'s existence check picks up whatever's on disk and treats it like
-any other source file, no dedicated CUDA module or sha256 pinning needed, so
-this works whether the files were vendored by hand or restored from a cache.
-`.github/workflows/flatpak.yml` restores `crates/render-cuda/prebuilt` from
-an `actions/cache` entry (keyed on the shader sources, `build.rs`, and the
-cuda-artifacts Dockerfile) before `make dist` runs; on a cache miss,
-`flatpak-cuda-vendor`'s empty-directory check triggers the Docker rebuild
-same as a fresh local clone would. The tradeoff: `build.rs`'s existence
-check is unconditional (in-sandbox or not), so a normal host `make
-cuda-artifacts` will silently reuse whatever's vendored on disk too. If you
-change a `.slang` shader, delete the corresponding
-`crates/render-cuda/prebuilt/sm_86/<module>.cubin` before rebuilding, or
-nvcc never runs and you get stale output.
+## Caveats
+
+- The cubins are **gitignored**, not committed. `.github/workflows/flatpak.yml`
+  caches `crates/render-cuda/prebuilt` (keyed on the shader sources, `build.rs`
+  and the Dockerfile); on a cache miss the Docker rebuild runs as on a fresh
+  clone.
+- `build.rs`'s existence check is unconditional, so a plain host `make
+  cuda-artifacts` also reuses whatever's vendored. **After editing a `.slang`
+  shader, delete the corresponding `prebuilt/sm_86/<module>.cubin`** or nvcc
+  never re-runs and you get stale output.
+- `build.rs` always passes `nvcc -allow-unsupported-compiler` (CUDA 13.3
+  refuses GCC >15 otherwise); the Dockerfile's `CMD` sets `CUDA_HOST_CXX=g++`
+  because the Makefile default `g++-15` isn't installed on Fedora 44.

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,69 @@
+# CUDA cubins in the flatpak (M4)
+
+`org.gnome.Sdk//50` has no `nvcc`, so `crates/render-cuda/build.rs` never
+compiles CUDA kernels inside the flatpak sandbox. Instead the `.cubin` files
+are built outside the sandbox and vendored as pinned sources — this is the
+decided M4 plan (see `TODO.md`), not a stopgap.
+
+## How it works
+
+- `crates/render-cuda/build.rs` checks
+  `crates/render-cuda/prebuilt/<CUDA_TARGET>/<module>.cubin` before running
+  slangc/nvcc for that module. If the file exists it's copied straight to the
+  expected build output path and nvcc is never invoked for that module. This
+  applies both inside and outside the sandbox — it's a plain file-existence
+  check, not flatpak-specific.
+- Outside the sandbox, cubins are produced with the Fedora/CUDA-toolkit image
+  the top-level `Dockerfile` already uses for the full app build, but via a
+  leaner, separate image: `packaging/docker/cuda-artifacts.Dockerfile`. That
+  image stops right after the CUDA toolkit + slang toolchain are installed —
+  it never runs the full `make release qt-release` or the runtime-bundling
+  steps in the top-level Dockerfile.
+
+## Rebuild recipe
+
+```
+make flatpak-cuda-vendor
+```
+
+Don't call `cuda-artifacts-image` directly on a fresh clone — it has no
+`flatpak-submodules` prerequisite of its own, and the Docker build's `COPY .
+.` step will hard-fail with a "Git submodules are missing" error if
+`external/slang` hasn't been initialized yet. `flatpak-cuda-vendor` inits the
+submodules it needs first, then only actually runs `cuda-artifacts-image` if
+`crates/render-cuda/prebuilt/$(CUDA_TARGET)/` is empty — see "Status" below.
+It builds the image, runs `make cuda-artifacts` inside a container, and
+copies `.slang-artifacts/cuda/sm_86/*.cubin` out to
+`crates/render-cuda/prebuilt/sm_86/`. It's deliberately not part of `make
+check`/`make dev`/`make cuda-artifacts` — it needs Docker, a full CUDA
+toolkit download, and a full slang compile, so it's an explicit, occasional
+operation for regenerating the vendored cubins (e.g. after a kernel or slang
+change; delete `crates/render-cuda/prebuilt/sm_86/` first to force it). Two
+host-environment fixes were needed to get real nvcc output out of this
+image, both in the code/Docker layer, not just this one build:
+- `packaging/docker/cuda-artifacts.Dockerfile`'s `CMD` overrides
+  `CUDA_HOST_CXX=g++`: the Makefile's own default (`g++-15`) doesn't exist as
+  a binary on Fedora 44 (or on this host) — only unversioned `g++` (GCC 16) is
+  installed.
+- `crates/render-cuda/build.rs`'s nvcc invocation now always passes
+  `-allow-unsupported-compiler`, since CUDA 13.3 refuses GCC >15 without it.
+  This affects every nvcc invocation, not just the flatpak/Docker path.
+
+## Status: not committed, regenerated and cached in CI
+
+Real cubins are produced by the recipe above and land at
+`crates/render-cuda/prebuilt/sm_86/*.cubin` (~4.7MB total), gitignored
+rather than committed to git or pinned as separate flatpak `sources:` —
+`build.rs`'s existence check picks up whatever's on disk and treats it like
+any other source file, no dedicated CUDA module or sha256 pinning needed, so
+this works whether the files were vendored by hand or restored from a cache.
+`.github/workflows/flatpak.yml` restores `crates/render-cuda/prebuilt` from
+an `actions/cache` entry (keyed on the shader sources, `build.rs`, and the
+cuda-artifacts Dockerfile) before `make dist` runs; on a cache miss,
+`flatpak-cuda-vendor`'s empty-directory check triggers the Docker rebuild
+same as a fresh local clone would. The tradeoff: `build.rs`'s existence
+check is unconditional (in-sandbox or not), so a normal host `make
+cuda-artifacts` will silently reuse whatever's vendored on disk too. If you
+change a `.slang` shader, delete the corresponding
+`crates/render-cuda/prebuilt/sm_86/<module>.cubin` before rebuilding, or
+nvcc never runs and you get stale output.

--- a/packaging/flatpak/dev.shrimply.Shrimply.yaml
+++ b/packaging/flatpak/dev.shrimply.Shrimply.yaml
@@ -1,68 +1,38 @@
-# M4 CUDA note (see TODO.md's M4 plan): no separate CUDA module here. nvcc
-# never runs inside org.gnome.Sdk//50, so cubins are prebuilt outside the
-# sandbox with `make cuda-artifacts-image` (packaging/docker/
-# cuda-artifacts.Dockerfile) and committed directly into git at
-# crates/render-cuda/prebuilt/sm_86/*.cubin. Since they're just part of the
-# source tree, the M7 app module's normal build picks them up like any other
-# source file — no pinned sources or dedicated module needed. See
-# packaging/flatpak/README.md for the full rebuild recipe and the host-dev
-# staleness caveat this creates.
+# No CUDA module: nvcc never runs inside org.gnome.Sdk//50, so cubins are
+# prebuilt outside the sandbox (`make cuda-artifacts-image`) and vendored at
+# crates/render-cuda/prebuilt/sm_86/*.cubin (gitignored). The shrimply module's
+# build picks them up like any other source file. See packaging/flatpak/README.md.
 id: dev.shrimply.Shrimply
 runtime: org.gnome.Platform
 runtime-version: '50'
 sdk: org.gnome.Sdk
-# M7: uncommented now that the shrimply module below actually installs a real
-# /app/bin/shrimply (shrimply-launcher-gtk's binary, see the module's
-# build-commands). Was commented out from M3 through M6 because
-# flatpak-builder's "Finishing app" stage validates this against /app/bin,
-# and no module installed that binary yet -- see TODO.md's M3 correction note
-# for the history.
+# The shrimply module installs /app/bin/shrimply; flatpak-builder validates
+# `command` against /app/bin at the "Finishing app" stage.
 command: shrimply
 
-# M5 (see TODO.md): the pinned nightly-2026-04-03 toolchain (rust-toolchain.toml)
-# is provided by this Sdk extension rather than vendored. It has no branch
-# matching a specific date -- 25.08 is the branch that matches this runtime's
-# own base (confirmed via org.gnome.Sdk//50's own extension points, all
-# pinned to 25.08) and tracks whatever nightly Flathub last built for it
-# (verified 2026-09-07: rustc 1.99.0-nightly (2026-08-08), ~4 months newer
-# than the pin). Acceptable because nothing in this workspace uses
-# rustc_driver/rustc_interface (rustc-dev's unstable-API surface) — see
-# TODO.md M5 status for the full reasoning.
+# Provides the pinned nightly toolchain (rust-toolchain.toml). The extension has
+# no date-specific branch; 25.08 matches this runtime's base and tracks whatever
+# nightly Flathub last built. OK because nothing here uses the rustc-dev
+# unstable-API surface.
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-nightly
-  # M7: ffmpeg-sys-next and opencv's "clang-runtime" feature both run
-  # bindgen at build time, which needs libclang.so -- org.gnome.Sdk//50 has
-  # no system libclang. 25.08 matches the runtime's own extension branch
-  # (same reasoning as the rust-nightly extension above); llvm22 is
-  # flathub's current stable LLVM extension on that branch.
+  # ffmpeg-sys-next and opencv's clang-runtime feature run bindgen at build
+  # time, which needs libclang -- org.gnome.Sdk has none.
   - org.freedesktop.Sdk.Extension.llvm22
 
-# --share=network is needed by later milestones' module build-commands (cargo/pip
-# fetches, etc). M8 removes this once sources are vendored for an offline build.
+# --share=network: module build-commands fetch sources (cargo, etc).
 build-options:
-  # M5: puts the Sdk extension's rustc/cargo/rustfmt/clippy on PATH, plus the
-  # self-contained lld it bundles under rustlib/<target>/bin/gcc-ld -- this
-  # Sdk has no system lld of its own, but rustc's own copy (shipped by this
-  # same extension) satisfies .cargo/config.toml's `-fuse-ld=lld` without
-  # touching that shared, host-dev-affecting file. Verified inside a real
-  # `flatpak-builder` build, not just `flatpak run`.
-  #
-  # M7's clang/bindgen PATH+env additions live on the `shrimply` module's own
-  # build-options below, NOT here: flatpak-builder's per-module cache key
-  # includes the global build-options, so every edit here invalidates every
-  # module's cache -- rubberband through slang all rebuilt from scratch three
-  # times in a row over one afternoon chasing bindgen env vars before this was
-  # noticed. Module-level build-options only invalidate that one module.
+  # rust-nightly's rustc/cargo, plus the self-contained lld it bundles (this Sdk
+  # has no system lld, and .cargo/config.toml sets -fuse-ld=lld). Keep additions
+  # here minimal -- the per-module cache key includes the global build-options,
+  # so an edit here rebuilds every module. Module-specific env (clang/bindgen)
+  # lives on the shrimply module instead.
   append-path: /usr/lib/sdk/rust-nightly/bin:/usr/lib/sdk/rust-nightly/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld
   build-args:
     - --share=network
 
-# M7 (see TODO.md): exactly the list TODO.md specifies, no speculative
-# extras. wayland+fallback-x11 for the GTK window, ipc for the usual
-# GTK/DBus plumbing, device=dri for GPU (GL) access, pulseaudio for audio
-# output, filesystem=host so the app can open/save project files and media
-# anywhere on disk, and network for the localhost:8787 Python compute server
-# (see the M7 section below -- that server stays external, unbundled).
+# wayland/x11 window, ipc for DBus, dri for GPU, pulseaudio, filesystem=host for
+# project/media files, network for the external localhost:8787 compute server.
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
@@ -73,15 +43,9 @@ finish-args:
   - --share=network
 
 modules:
-  # M6 (see TODO.md): Rubber Band Library. Upstream dropped autotools at v3;
-  # meson is the only build system as of 4.0.0. Non-default features
-  # (vamp/ladspa/lv2/jni/cmdline/tests) are explicitly disabled rather than
-  # left at their "auto" default -- none of their optional deps
-  # (vamp-plugin-sdk, ladspa.h, lv2, jni.h) exist in org.gnome.Sdk//50, so
-  # "auto" would silently no-op the same way, but explicit is clearer about
-  # what's intentionally out of scope. fft/resampler stay at "auto", which
-  # resolves to the builtin implementation (no external FFT/resampler lib
-  # needed) -- confirmed by the module actually linking below.
+  # Rubber Band (meson-only since v3). Optional features disabled explicitly;
+  # fft/resampler use the builtin implementation.
+  #
   # -Dlibdir=lib / -DCMAKE_INSTALL_LIBDIR=lib on every meson/cmake module below:
   # org.gnome.Sdk//50 has a real /usr/lib64, so meson and CMake install
   # libfoo.so + foo.pc under /app/lib64, which nothing searches -- flatpak's
@@ -104,11 +68,7 @@ modules:
         url: https://breakfastquay.com/files/releases/rubberband-4.0.0.tar.bz2
         sha256: af050313ee63bc18b35b2e064e5dce05b276aaf6d1aa2b8a82ced1fe2f8028e9
 
-  # M6: FFmpeg's own codec libs, needed before the ffmpeg module below.
-  # pkg-config --exists checks inside org.gnome.Sdk//50 confirmed vorbis and
-  # opus are already present in the runtime, but x264/fdk-aac/libmp3lame are
-  # not -- same "add the smallest missing module" allowance TODO.md gives
-  # poppler's transitive deps, applied here to ffmpeg's.
+  # FFmpeg codec libs missing from org.gnome.Sdk//50 (vorbis/opus are present).
   - name: x264
     buildsystem: simple
     build-commands:
@@ -136,10 +96,7 @@ modules:
     config-opts:
       - --disable-static
       - --enable-nasm
-      # the lame CLI (frontend) fails to link: it wants termcap symbols
-      # (tgetstr/tgetent/tgetnum) that org.gnome.Sdk//50's libncurses
-      # doesn't expose. Not needed -- only libmp3lame.so is, for
-      # ffmpeg-next's --enable-libmp3lame.
+      # the lame CLI won't link (termcap symbols absent); only libmp3lame.so is needed.
       - --disable-frontend
     sources:
       - type: archive
@@ -147,23 +104,10 @@ modules:
         sha256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
         dest-filename: lame-3.100.tar.gz
 
-  # M6 module 2: FFmpeg 9.x itself. The runtime's libavcodec.so.61 is FFmpeg
-  # 7.1 -- two sonames behind what ffmpeg-sys-next 9.0.0 needs -- so this
-  # must land in /app/lib and be found ahead of the runtime copy via /app's
-  # normal linker precedence, no rpath tricks needed.
-  #
-  # Codec selection is scoped to exactly what the Rust crates call
-  # ffmpeg::codec::encoder::find_by_name with (grepped, not guessed):
-  # libx264 (video/decoder, video-cuda transparent_fill), libfdk_aac,
-  # libmp3lame, libvorbis, libopus (export-core audio/video), plus the
-  # builtin aac/flac/pcm_s16le/gif encoders (need nothing extra) and
-  # h264_nvenc/hevc_nvenc (video-cuda, video-recording, export-core).
-  # ffnvcodec (nv-codec-headers) is already provided by org.gnome.Sdk//50
-  # (confirmed via pkg-config, version 13.1.15.0.1) -- nvenc needs no
-  # separate module, just --enable-nonfree to unlock it.
-  # --enable-gpl is required for libx264; --enable-nonfree for libfdk-aac
-  # and nvenc. --disable-programs skips the ffmpeg/ffplay/ffprobe CLI
-  # tools -- only the libraries matter for the Rust bindings.
+  # FFmpeg 9.x: the runtime ships 7.1, too old for ffmpeg-sys-next 9.0.0. Lands
+  # in /app/lib, found ahead of the runtime copy. Codecs enabled = exactly what
+  # the Rust crates request by name (x264/fdk-aac/mp3lame/vorbis/opus, plus
+  # nvenc via --enable-nonfree; ffnvcodec headers are already in the Sdk).
   - name: ffmpeg
     buildsystem: simple
     build-commands:
@@ -181,23 +125,9 @@ modules:
         url: https://ffmpeg.org/releases/ffmpeg-9.0.1.tar.xz
         sha256: cf38e0e28c7e5605942c4a77755349b0145804a397af37eb1fb4c77cb237f635
 
-  # M6 modules 3: poppler + poppler-glib.
-  #
-  # Correction to TODO.md's plan (written when poppler-glib still shipped as
-  # a separate tarball): current poppler releases are a single unified
-  # CMake project where ENABLE_GLIB=ON builds the glib wrapper as a
-  # subdirectory of the same build, not a second source tree. So this is one
-  # flatpak module, not two -- it still lands both libpoppler.so and
-  # libpoppler-glib.so in /app, which is what mattered.
-  #
-  # Its usual awkward transitive deps (fontconfig, freetype, cairo,
-  # harfbuzz, libjpeg, libtiff, libopenjp2, lcms2, nss, gpgme, libcurl) are
-  # all confirmed present in org.gnome.Sdk//50 via pkg-config -- verified
-  # per-lib rather than assumed. boost is genuinely absent, but it's only
-  # used for Splash backend performance (ENABLE_BOOST), not a hard
-  # requirement -- disabled rather than adding a module for it. Qt5/Qt6
-  # wrappers are disabled: this manifest targets the GTK frontend only, and
-  # there's no qmake in this Sdk anyway (confirmed).
+  # poppler + poppler-glib (one unified CMake project since the glib wrapper
+  # moved in-tree). Transitive deps (fontconfig/freetype/cairo/...) are all in
+  # the Sdk; boost (Splash perf only) and the Qt wrappers are off.
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:
@@ -222,19 +152,9 @@ modules:
         url: https://poppler.freedesktop.org/poppler-26.09.0.tar.xz
         sha256: 8059eadb6805340768f138c465b57f8164c92b4a0773c37ef031ea6c0d987b2e
 
-  # M6 module 4: VTE, built with only the GTK4 widget (-Dgtk3=false
-  # -Dgtk4=true) -- there's no GTK3 in org.gnome.Platform//50 to pair it
-  # with anyway. meson.build's dependency list goes well beyond what
-  # TODO.md's plan anticipated for a "small, unremarkable" module: besides
-  # the expected cairo/pango/pcre2/fribidi/gnutls/icu (all present in
-  # org.gnome.Sdk//50, verified via pkg-config), it also needs liblz4 and
-  # fmt (present too) plus simdutf and fast_float (genuinely absent as
-  # system libs) -- but both of those ship as full vendored sources under
-  # vte's own subprojects/, not just download-stub .wrap files, so meson
-  # builds them from the same tarball with no extra module and no network.
-  # -D_systemd=false (sandboxed build, no systemd socket activation needed),
-  # -Dapp=false/-Dglade=false/-Ddocs=false trim the standalone terminal app,
-  # glade catalog and docs -- nothing here uses them.
+  # VTE, GTK4 widget only (no GTK3 in the runtime). simdutf/fast_float are
+  # absent as system libs but ship vendored in vte's subprojects/, so meson
+  # builds them with no extra module.
   - name: vte
     buildsystem: meson
     config-opts:
@@ -251,14 +171,8 @@ modules:
         url: https://download.gnome.org/sources/vte/0.84/vte-0.84.1.tar.xz
         sha256: aca1caa8478aebcdbb1d67897fb3511eb7601debae6810e16a15b6fa25f31ac8
 
-  # M6 module 5: OpenBLAS, a prerequisite for opencv below, not one of the
-  # six libraries TODO.md's "verified absent" list named -- but the plan
-  # explicitly calls for linking OpenBLAS directly (rather than the
-  # Dockerfile's FlexiBLAS workaround), and pkg-config confirmed
-  # org.gnome.Sdk//50 has no openblas/cblas/lapack at all. Same "add the
-  # smallest missing module" allowance as poppler's/ffmpeg's transitive
-  # deps. gfortran (needed for OpenBLAS's bundled reference LAPACK) is
-  # confirmed present in the Sdk.
+  # OpenBLAS: opencv's LAPACK provider (the Sdk has no blas/lapack). gfortran
+  # for the bundled reference LAPACK is present.
   - name: openblas
     buildsystem: simple
     build-commands:
@@ -269,52 +183,15 @@ modules:
         url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
         sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
 
-  # M6 module 5: OpenCV, trimmed to what `Cargo.toml`'s opencv crate
-  # features actually need plus their transitive module deps per OpenCV's
-  # own module graph. imgcodecs is videoio's optional dep (image-sequence
-  # capture). core is implicit in every module. No python/java/highgui/
-  # apps/tests/docs -- none of those are used, and skipping them avoids
-  # needing GTK/Qt-in-OpenCV or a Python toolchain. WITH_FFMPEG picks up the
-  # ffmpeg module built above (found via its .pc files in
-  # /app/lib/pkgconfig, ahead of anything from the runtime). LAPACK_IMPL=
-  # OpenBLAS points at the OpenBLAS module above directly -- this is what
-  # makes the Dockerfile's FlexiBLAS workaround unnecessary, per TODO.md's
-  # explicit instruction.
-  #
-  # M7 corrections, both found by actually inspecting the built headers
-  # rather than guessing from the Cargo.toml feature list alone:
-  #
-  # 1. `dnn` was missing. It's not one of the Cargo.toml-requested opencv
-  #    crate features, but the `opencv` crate's own Cargo.toml declares
-  #    `video = ["dnn"]` -- Cargo therefore enables the "dnn" Rust feature
-  #    transitively, and opencv-binding-generator needs opencv_dnn's headers
-  #    present to generate the `video` Rust module (and several others
-  #    failed silently alongside it once this was missing). `WITH_PROTOBUF=ON`
-  #    (the opencv default) auto-builds opencv's own bundled protobuf
-  #    snapshot since `org.freedesktop.Sdk`//50 has no system protobuf --
-  #    needs network at cmake-configure time, already available via
-  #    --share=network.
-  #
-  # 2. `calib3d`/`features2d` are OpenCV 4.x module names -- OpenCV 5.0.0
-  #    renamed them to `calib`/`features` on disk (confirmed:
-  #    modules/{calib,features,geometry} exist, modules/calib3d and
-  #    modules/features2d do not) and additionally split camera-geometry
-  #    functions (estimateAffine2D, the RANSAC enum, etc.) out into a new
-  #    `geometry` module -- confirmed by grepping the actual built headers
-  #    (`build/files/include/opencv5/opencv2/geometry/3d.hpp` declares both).
-  #    `BUILD_LIST`'s old `calib3d,features2d` entries were silently
-  #    ignored (unrecognized module names), so neither module -- nor
-  #    `geometry`, nor the Rust bindings depending on any of them -- ever
-  #    built. Cargo.toml and `crates/stabilization/affine-l1-stabilization`
-  #    are updated to match (`geometry`/`features` Cargo features and Rust
-  #    module names, not `calib3d`/`calib`, since nothing in this workspace
-  #    actually calls OpenCV's camera-calibration API, only the
-  #    RANSAC-affine-estimation functions that moved to `geometry`).
+  # OpenCV, trimmed to the modules Cargo.toml's opencv features need + their
+  # deps. dnn is pulled in transitively (the opencv crate's `video = ["dnn"]`);
+  # WITH_PROTOBUF builds opencv's bundled protobuf (needs network at configure).
+  # OpenCV 5.0 renamed calib3d/features2d -> calib/features and split the
+  # RANSAC-affine functions into a new `geometry` module -- the Rust code and
+  # Cargo.toml features track that.
   - name: opencv
     buildsystem: cmake-ninja
-    # opencv's CMakeLists.txt hard-refuses in-source builds (unlike
-    # poppler/fdk-aac above); `builddir: true` makes flatpak-builder build
-    # in a separate directory instead of the source tree.
+    # opencv refuses in-source builds.
     builddir: true
     config-opts:
       - -DCMAKE_INSTALL_LIBDIR=lib  # see rubberband
@@ -353,19 +230,13 @@ modules:
         url: https://github.com/opencv/opencv/archive/refs/tags/5.0.0.tar.gz
         sha256: b0528f5a1d379d59d4701cb28c36e22214cc51cf64594e5b56f2d3e6c0233095
         dest-filename: opencv-5.0.0.tar.gz
-      # Fixes modules/videoio failing to compile against our vendored
-      # FFmpeg 9.x: opencv still reads AVCodec::pix_fmts and
-      # AVCodec::supported_framerates directly, both removed from the
-      # public struct in FFmpeg 8+. No newer opencv tag fixes this (checked
-      # 5.x branch HEAD) -- see TODO.md's M6 section for the full writeup.
+      # opencv's videoio reads AVCodec fields removed in FFmpeg 8+; no opencv
+      # tag fixes this yet.
       - type: patch
         path: patches/opencv-ffmpeg9-avcodec-config.patch
 
-  # M6 module 6: slang, from the external/slang git submodule. Same
-  # SLANG_ENABLE_* flags as the Makefile's slang-compiler target (the
-  # CUDA path from M4), minus -G "Ninja Multi-Config" -- flatpak-builder's
-  # cmake-ninja buildsystem already drives a single-config Ninja build,
-  # which is what we want for a one-shot Release install into /app.
+  # slang, from the external/slang submodule. Same SLANG_ENABLE_* flags as the
+  # Makefile's slang-compiler target.
   - name: slang
     buildsystem: cmake-ninja
     builddir: true
@@ -385,120 +256,44 @@ modules:
       - -DSLANG_ENABLE_REPLAYER=OFF
       - -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
       - -DSLANG_ENABLE_DXIL=OFF
-    # cmake-ninja's default `ninja` (then `ninja install`) isn't enough here:
-    # source/slang-glsl-module/CMakeLists.txt marks the slang-glsl-module
-    # target EXCLUDE_FROM_ALL (so plain `ninja`/`ninja all` skips building
-    # it) but still registers an unconditional install() rule for it once
-    # SLANG_ENABLE_SLANG_GLSLANG=ON, so `ninja install` then fails with
-    # "file INSTALL cannot find .../libslang-glsl-module-0.0.0.so" -- it was
-    # never built. The Makefile's own `cmake --build --target slang
-    # slang-glslang` (M4's CUDA path) never hits this because it never runs
-    # install at all (consumes the build in place via LD_LIBRARY_PATH).
-    # Building slang-glsl-module explicitly alongside slang/slang-glslang
-    # before installing is the fix, not disabling the install rule.
+    # slang-glsl-module is EXCLUDE_FROM_ALL but has an unconditional install()
+    # rule, so it must be built explicitly before `ninja install`.
     build-commands:
       - ninja slang slang-glslang slang-glsl-module
       - ninja install
-    # M7 correction: was `type: dir` pointing at the local ../../external/slang
-    # checkout. flatpak-builder can't compute a stable cache key for a `dir`
-    # source (no commit/checksum), so this module -- and everything after it
-    # -- was a guaranteed cache miss on every single build, forcing a full
-    # rebuild even when nothing here changed.
-    #
-    # Tried enumerating all 18 nested submodules as individual pinned `git`
-    # sources first (matching TODO.md's M8 wording literally) -- that broke:
-    # flatpak-builder's `git` source recursively clones submodules on its own
-    # by default (`disable-submodules` defaults to false), using the exact
-    # commits recorded in the parent commit's gitlinks. Declaring them AGAIN
-    # as separate sources collided with that automatic checkout ("cp: cannot
-    # overwrite non-directory '.../external/glslang/.git' with directory").
-    # A single pinned commit on the top-level repo is sufficient: it
-    # transitively pins every submodule commit already, and gives this
-    # module the same kind of real, stable cache key the M6 dependency
-    # modules have.
+    # A single pinned commit, not `type: dir`: flatpak-builder needs a
+    # commit/checksum for a stable cache key, and it clones submodules
+    # recursively on its own, so they aren't re-declared here.
     sources:
       - type: git
         url: https://github.com/shader-slang/slang.git
         commit: 961e4e59ee0181ad645825c5db3a677d5a829a9f
 
-  # M7: the actual app. `make install DESTDIR=/ PREFIX=/app` (Makefile:442)
-  # already installs the desktop file (sed-rewriting Exec=/TryExec= to the
-  # real install path, then `install -Dm644`) and the icon (via its
-  # `desktop-icon` prerequisite, `install -Dm644` into ICONDIR, plus
-  # `cp -a assets/icons/.` into ICONS_RESOURCE_DIR for in-app icon lookups) --
-  # confirmed by reading the `install:`/`desktop-icon:` recipes directly, not
-  # assumed. Only the metainfo.xml install survives from the old 3-file
-  # `simple` module below; installing the desktop file and icon a second time
-  # via explicit `install -Dm644` commands would just be redundant with what
-  # `make install` already does to the exact same destinations.
-  #
-  # `make install`'s `release` prerequisite (native-deps + cuda-artifacts,
-  # then a real `cargo build --release` of the GTK bins) needs several
-  # sandbox-specific overrides, all passed as `make` command-line variable
-  # assignments (which win over the Makefile's own `?=`/`:=` defaults, same
-  # trick M5's `flatpak-rust-check CARGO=cargo` already uses):
-  #
-  # - CARGO=cargo: the Makefile normally drives cargo via
-  #   `$(RUSTUP) run $(RUST_TOOLCHAIN) cargo`, but the sandbox has no rustup,
-  #   only the raw rust-nightly Sdk extension's `cargo` (already on PATH via
-  #   this manifest's `build-options.append-path`) -- exactly the problem
-  #   M5's `flatpak-rust-check` target already solved, same fix reused here.
-  #
-  # - the slang-compiler stamp files are pre-touched so `make`'s dependency
-  #   check treats `cuda-artifacts`'s `slang-compiler` prerequisite as already
-  #   satisfied, and a real `libslang.so` (copied from what the `slang`
-  #   module above just installed into /app) is staged at the exact path
-  #   `crates/slang-build/build.rs` and `crates/render-cuda/build.rs` expect
-  #   (`external/slang/build/Release/lib/`) via `SLANG_BUILD_DIR`'s default.
-  #   Without this, `slang-compiler`'s recipe would `cmake`+`ninja` build all
-  #   of external/slang a second time from scratch -- the exact "genuinely
-  #   slow/redundant" case TODO.md flagged as worth checking empirically; it
-  #   is, so this skips it the same way M4 skips nvcc when a cubin already
-  #   exists. `shrimply-slang-build`'s `Compiler` still needs the actual
-  #   library loadable at process start (it's a hard ELF NEEDED, not lazy),
-  #   so this stages the real installed .so, not an empty stub.
-  #
-  # - a small NVIDIA `cuda_cudart` redistributable (~1.4MB: just
-  #   `include/cuda.h` and `lib/stubs/libcuda.so`, not the ~4GB toolkit --
-  #   see TODO.md's Established Facts on CUDA build surface) is unpacked to
-  #   `cuda-stub/` and used as `CUDA_HOME`/`CUDA_TOOLKIT_PATH` so
-  #   `crates/cuda/bridge/build.rs` finds `cuda.h` to compile `bridge.c`
-  #   against, with a `libcuda.so.1` symlink added next to the stub (same
-  #   thing the Dockerfile does at `/usr/local/cuda/lib64/stubs`) and
-  #   `LIBRARY_PATH` pointed at it so the final link resolves `-lcuda`. This
-  #   stub is build-only and never installed into /app: the real
-  #   `libcuda.so.1` is supplied at runtime by
-  #   `org.freedesktop.Platform.GL.nvidia-*`, and shipping a fake one would
-  #   shadow it.
-  #
-  # cuda-artifacts itself needs no nvcc/CUDA_HOST_CXX handling beyond this:
-  # all 9 `.cubin` modules are vendored under
-  # `crates/render-cuda/prebuilt/sm_86/` (M4), so `render-cuda`'s build.rs
-  # copies them instead of invoking nvcc at all -- confirmed by the build log
-  # rather than assumed.
+  # The app. `make install` (Makefile) installs the binary, desktop file, icon
+  # and metainfo; only the metainfo also has an explicit install below (it's a
+  # separate source). `make install`'s `release` prereq runs a real
+  # `cargo build --release`, which needs sandbox overrides, passed as `make`
+  # variable assignments:
+  #  - CARGO=cargo: no rustup in the sandbox, just the rust-nightly extension's cargo
+  #  - slang stamp files pre-touched + the real libslang.so staged where
+  #    slang-build/build.rs and render-cuda/build.rs expect it, so slang isn't
+  #    rebuilt from scratch (it's a hard ELF NEEDED, so a real .so, not a stub)
+  #  - a ~1.4 MB cuda_cudart redist unpacked to cuda-stub/ for cuda.h (bridge.c)
+  #    and the -lcuda link stub. Build-only, never installed -- the real
+  #    libcuda comes from org.freedesktop.Platform.GL.nvidia-* at runtime.
+  # No nvcc handling needed: the vendored cubins are just copied.
   - name: shrimply
     buildsystem: simple
-    # M7: scoped to this module only (not the top-level build-options) so
-    # iterating on these doesn't invalidate every earlier module's cache --
-    # see the note on the top-level build-options above.
+    # Module-scoped so iterating on bindgen env doesn't rebuild earlier modules.
     build-options:
       append-path: /usr/lib/sdk/llvm22/bin
       env:
         LIBCLANG_PATH: /usr/lib/sdk/llvm22/lib
         BINDGEN_EXTRA_CLANG_ARGS: -resource-dir=/usr/lib/sdk/llvm22/lib/clang/22
-      # CI caching (GitHub Actions runners): this module's own source is
-      # always a fresh `dir` checkout (see below), so unlike the M6
-      # dependency modules it can never get a flatpak-builder cache hit --
-      # every build re-runs the full Rust workspace compile. `~` expands to
-      # the invoking user's home dir (flatpak's own convention, works the
-      # same in build-args as in finish-args) -- mounting a fixed path there
-      # means a CI workflow just needs to restore/save
-      # ~/.cache/shrimply-flatpak-cargo-cache between runs (e.g. actions/
-      # cache) to get cargo's downloaded crates AND compiled target/ dir
-      # back, without this manifest needing to know it's running in CI.
-      # Harmless locally too: bwrap creates it empty on first use if it
-      # doesn't exist (":create"), and an empty cache just means a cold
-      # first build, same as today.
+      # A fixed host path bind-mounted into the sandbox: a CI job restores/saves
+      # ~/.cache/shrimply-flatpak-cargo-cache between runs to persist cargo's
+      # registry + target/ (this module's source is a fresh checkout every
+      # build, so it never gets a flatpak-builder cache hit). Empty = cold build.
       build-args:
         - --filesystem=~/.cache/shrimply-flatpak-cargo-cache:create
     build-commands:
@@ -506,23 +301,13 @@ modules:
       - mkdir -p cuda-stub/lib/stubs
       - ln -sf libcuda.so cuda-stub/lib/stubs/libcuda.so.1
       - mkdir -p external/slang/build/Release/lib
-      # `libslang.so` is a symlink to `libslang-compiler.so.0.0.0.0` -- the
-      # narrower `libslang.so*` glob copied only the symlink, not its target
-      # (different filename, doesn't match), leaving it dangling. Broken
-      # symlink -> `Path::is_file()` in crates/slang-build/build.rs returns
-      # false -> it silently rebuilt all of slang via cmake from scratch
-      # every time, ignoring this module's real, already-built libslang.so
-      # entirely. `libslang*` covers the real target file too.
+      # `libslang*`, not `libslang.so*`: libslang.so is a symlink to
+      # libslang-compiler.so.*, and copying only the dangling symlink made
+      # slang-build/build.rs rebuild slang every time.
       - cp -a /app/lib/libslang* external/slang/build/Release/lib/
       - touch external/slang/build/.shrimply-configure external/slang/build/.shrimply-compiler
-      # A symlink, not a CARGO_TARGET_DIR env var: the Makefile's `install`
-      # target hardcodes relative paths like `target/release/shrimply` --
-      # pointing CARGO_TARGET_DIR at the cache dir directly made cargo build
-      # everything there while `make install` kept looking in `./target`,
-      # failing with "cannot stat 'target/release/shrimply'". Symlinking
-      # `target` itself to the cache dir keeps `make install`'s hardcoded
-      # paths working transparently while still caching every compiled
-      # artifact across runs.
+      # Symlink `target` rather than setting CARGO_TARGET_DIR: `make install`
+      # hardcodes relative `target/...` paths.
       - mkdir -p "$HOME/.cache/shrimply-flatpak-cargo-cache/target"
       - ln -sfn "$HOME/.cache/shrimply-flatpak-cargo-cache/target" target
       - >-

--- a/packaging/flatpak/dev.shrimply.Shrimply.yaml
+++ b/packaging/flatpak/dev.shrimply.Shrimply.yaml
@@ -1,0 +1,538 @@
+# M4 CUDA note (see TODO.md's M4 plan): no separate CUDA module here. nvcc
+# never runs inside org.gnome.Sdk//50, so cubins are prebuilt outside the
+# sandbox with `make cuda-artifacts-image` (packaging/docker/
+# cuda-artifacts.Dockerfile) and committed directly into git at
+# crates/render-cuda/prebuilt/sm_86/*.cubin. Since they're just part of the
+# source tree, the M7 app module's normal build picks them up like any other
+# source file — no pinned sources or dedicated module needed. See
+# packaging/flatpak/README.md for the full rebuild recipe and the host-dev
+# staleness caveat this creates.
+id: dev.shrimply.Shrimply
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+# M7: uncommented now that the shrimply module below actually installs a real
+# /app/bin/shrimply (shrimply-launcher-gtk's binary, see the module's
+# build-commands). Was commented out from M3 through M6 because
+# flatpak-builder's "Finishing app" stage validates this against /app/bin,
+# and no module installed that binary yet -- see TODO.md's M3 correction note
+# for the history.
+command: shrimply
+
+# M5 (see TODO.md): the pinned nightly-2026-04-03 toolchain (rust-toolchain.toml)
+# is provided by this Sdk extension rather than vendored. It has no branch
+# matching a specific date -- 25.08 is the branch that matches this runtime's
+# own base (confirmed via org.gnome.Sdk//50's own extension points, all
+# pinned to 25.08) and tracks whatever nightly Flathub last built for it
+# (verified 2026-09-07: rustc 1.99.0-nightly (2026-08-08), ~4 months newer
+# than the pin). Acceptable because nothing in this workspace uses
+# rustc_driver/rustc_interface (rustc-dev's unstable-API surface) — see
+# TODO.md M5 status for the full reasoning.
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-nightly
+  # M7: ffmpeg-sys-next and opencv's "clang-runtime" feature both run
+  # bindgen at build time, which needs libclang.so -- org.gnome.Sdk//50 has
+  # no system libclang. 25.08 matches the runtime's own extension branch
+  # (same reasoning as the rust-nightly extension above); llvm22 is
+  # flathub's current stable LLVM extension on that branch.
+  - org.freedesktop.Sdk.Extension.llvm22
+
+# --share=network is needed by later milestones' module build-commands (cargo/pip
+# fetches, etc). M8 removes this once sources are vendored for an offline build.
+build-options:
+  # M5: puts the Sdk extension's rustc/cargo/rustfmt/clippy on PATH, plus the
+  # self-contained lld it bundles under rustlib/<target>/bin/gcc-ld -- this
+  # Sdk has no system lld of its own, but rustc's own copy (shipped by this
+  # same extension) satisfies .cargo/config.toml's `-fuse-ld=lld` without
+  # touching that shared, host-dev-affecting file. Verified inside a real
+  # `flatpak-builder` build, not just `flatpak run`.
+  #
+  # M7's clang/bindgen PATH+env additions live on the `shrimply` module's own
+  # build-options below, NOT here: flatpak-builder's per-module cache key
+  # includes the global build-options, so every edit here invalidates every
+  # module's cache -- rubberband through slang all rebuilt from scratch three
+  # times in a row over one afternoon chasing bindgen env vars before this was
+  # noticed. Module-level build-options only invalidate that one module.
+  append-path: /usr/lib/sdk/rust-nightly/bin:/usr/lib/sdk/rust-nightly/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld
+  build-args:
+    - --share=network
+
+# M7 (see TODO.md): exactly the list TODO.md specifies, no speculative
+# extras. wayland+fallback-x11 for the GTK window, ipc for the usual
+# GTK/DBus plumbing, device=dri for GPU (GL) access, pulseaudio for audio
+# output, filesystem=host so the app can open/save project files and media
+# anywhere on disk, and network for the localhost:8787 Python compute server
+# (see the M7 section below -- that server stays external, unbundled).
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --socket=pulseaudio
+  - --filesystem=host
+  - --share=network
+
+modules:
+  # M6 (see TODO.md): Rubber Band Library. Upstream dropped autotools at v3;
+  # meson is the only build system as of 4.0.0. Non-default features
+  # (vamp/ladspa/lv2/jni/cmdline/tests) are explicitly disabled rather than
+  # left at their "auto" default -- none of their optional deps
+  # (vamp-plugin-sdk, ladspa.h, lv2, jni.h) exist in org.gnome.Sdk//50, so
+  # "auto" would silently no-op the same way, but explicit is clearer about
+  # what's intentionally out of scope. fft/resampler stay at "auto", which
+  # resolves to the builtin implementation (no external FFT/resampler lib
+  # needed) -- confirmed by the module actually linking below.
+  - name: rubberband
+    buildsystem: meson
+    config-opts:
+      - -Dfft=auto
+      - -Dresampler=auto
+      - -Djni=disabled
+      - -Dladspa=disabled
+      - -Dlv2=disabled
+      - -Dvamp=disabled
+      - -Dcmdline=disabled
+      - -Dtests=disabled
+    sources:
+      - type: archive
+        url: https://breakfastquay.com/files/releases/rubberband-4.0.0.tar.bz2
+        sha256: af050313ee63bc18b35b2e064e5dce05b276aaf6d1aa2b8a82ced1fe2f8028e9
+
+  # M6: FFmpeg's own codec libs, needed before the ffmpeg module below.
+  # pkg-config --exists checks inside org.gnome.Sdk//50 confirmed vorbis and
+  # opus are already present in the runtime, but x264/fdk-aac/libmp3lame are
+  # not -- same "add the smallest missing module" allowance TODO.md gives
+  # poppler's transitive deps, applied here to ffmpeg's.
+  - name: x264
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=/app --enable-shared --disable-static --disable-cli --enable-pic
+      - make -j$(nproc)
+      - make install
+    sources:
+      - type: git
+        url: https://code.videolan.org/videolan/x264.git
+        # pinned commit on the "stable" branch (no tagged releases upstream)
+        commit: b35605ace3ddf7c1a5d67a2eb553f034aef41d55
+
+  - name: fdk-aac
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_SHARED_LIBS=ON
+    sources:
+      - type: archive
+        url: https://github.com/mstorsjo/fdk-aac/archive/refs/tags/v2.0.3.tar.gz
+        sha256: e25671cd96b10bad896aa42ab91a695a9e573395262baed4e4a2ff178d6a3a78
+
+  - name: lame
+    buildsystem: autotools
+    config-opts:
+      - --disable-static
+      - --enable-nasm
+      # the lame CLI (frontend) fails to link: it wants termcap symbols
+      # (tgetstr/tgetent/tgetnum) that org.gnome.Sdk//50's libncurses
+      # doesn't expose. Not needed -- only libmp3lame.so is, for
+      # ffmpeg-next's --enable-libmp3lame.
+      - --disable-frontend
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/lame/files/lame/3.100/lame-3.100.tar.gz/download
+        sha256: ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
+        dest-filename: lame-3.100.tar.gz
+
+  # M6 module 2: FFmpeg 9.x itself. The runtime's libavcodec.so.61 is FFmpeg
+  # 7.1 -- two sonames behind what ffmpeg-sys-next 9.0.0 needs -- so this
+  # must land in /app/lib and be found ahead of the runtime copy via /app's
+  # normal linker precedence, no rpath tricks needed.
+  #
+  # Codec selection is scoped to exactly what the Rust crates call
+  # ffmpeg::codec::encoder::find_by_name with (grepped, not guessed):
+  # libx264 (video/decoder, video-cuda transparent_fill), libfdk_aac,
+  # libmp3lame, libvorbis, libopus (export-core audio/video), plus the
+  # builtin aac/flac/pcm_s16le/gif encoders (need nothing extra) and
+  # h264_nvenc/hevc_nvenc (video-cuda, video-recording, export-core).
+  # ffnvcodec (nv-codec-headers) is already provided by org.gnome.Sdk//50
+  # (confirmed via pkg-config, version 13.1.15.0.1) -- nvenc needs no
+  # separate module, just --enable-nonfree to unlock it.
+  # --enable-gpl is required for libx264; --enable-nonfree for libfdk-aac
+  # and nvenc. --disable-programs skips the ffmpeg/ffplay/ffprobe CLI
+  # tools -- only the libraries matter for the Rust bindings.
+  - name: ffmpeg
+    buildsystem: simple
+    build-commands:
+      - >-
+        ./configure --prefix=/app
+        --enable-shared --disable-static --enable-pic
+        --disable-programs --disable-doc
+        --enable-gpl --enable-nonfree
+        --enable-libx264 --enable-libfdk-aac --enable-libmp3lame
+        --enable-libvorbis --enable-libopus
+      - make -j$(nproc)
+      - make install
+    sources:
+      - type: archive
+        url: https://ffmpeg.org/releases/ffmpeg-9.0.1.tar.xz
+        sha256: cf38e0e28c7e5605942c4a77755349b0145804a397af37eb1fb4c77cb237f635
+
+  # M6 modules 3: poppler + poppler-glib.
+  #
+  # Correction to TODO.md's plan (written when poppler-glib still shipped as
+  # a separate tarball): current poppler releases are a single unified
+  # CMake project where ENABLE_GLIB=ON builds the glib wrapper as a
+  # subdirectory of the same build, not a second source tree. So this is one
+  # flatpak module, not two -- it still lands both libpoppler.so and
+  # libpoppler-glib.so in /app, which is what mattered.
+  #
+  # Its usual awkward transitive deps (fontconfig, freetype, cairo,
+  # harfbuzz, libjpeg, libtiff, libopenjp2, lcms2, nss, gpgme, libcurl) are
+  # all confirmed present in org.gnome.Sdk//50 via pkg-config -- verified
+  # per-lib rather than assumed. boost is genuinely absent, but it's only
+  # used for Splash backend performance (ENABLE_BOOST), not a hard
+  # requirement -- disabled rather than adding a module for it. Qt5/Qt6
+  # wrappers are disabled: this manifest targets the GTK frontend only, and
+  # there's no qmake in this Sdk anyway (confirmed).
+  - name: poppler
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_SHARED_LIBS=ON
+      - -DENABLE_GLIB=ON
+      - -DENABLE_GOBJECT_INTROSPECTION=ON
+      - -DENABLE_CPP=OFF
+      - -DENABLE_QT5=OFF
+      - -DENABLE_QT6=OFF
+      - -DENABLE_UTILS=OFF
+      - -DENABLE_BOOST=OFF
+      - -DENABLE_GTK_DOC=OFF
+      - -DBUILD_GTK_TESTS=OFF
+      - -DBUILD_QT5_TESTS=OFF
+      - -DBUILD_QT6_TESTS=OFF
+      - -DBUILD_CPP_TESTS=OFF
+      - -DBUILD_MANUAL_TESTS=OFF
+      - -DINSTALL_GLIB_DEMO=OFF
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-26.09.0.tar.xz
+        sha256: 8059eadb6805340768f138c465b57f8164c92b4a0773c37ef031ea6c0d987b2e
+
+  # M6 module 4: VTE, built with only the GTK4 widget (-Dgtk3=false
+  # -Dgtk4=true) -- there's no GTK3 in org.gnome.Platform//50 to pair it
+  # with anyway. meson.build's dependency list goes well beyond what
+  # TODO.md's plan anticipated for a "small, unremarkable" module: besides
+  # the expected cairo/pango/pcre2/fribidi/gnutls/icu (all present in
+  # org.gnome.Sdk//50, verified via pkg-config), it also needs liblz4 and
+  # fmt (present too) plus simdutf and fast_float (genuinely absent as
+  # system libs) -- but both of those ship as full vendored sources under
+  # vte's own subprojects/, not just download-stub .wrap files, so meson
+  # builds them from the same tarball with no extra module and no network.
+  # -D_systemd=false (sandboxed build, no systemd socket activation needed),
+  # -Dapp=false/-Dglade=false/-Ddocs=false trim the standalone terminal app,
+  # glade catalog and docs -- nothing here uses them.
+  - name: vte
+    buildsystem: meson
+    config-opts:
+      - -Dgtk3=false
+      - -Dgtk4=true
+      - -D_systemd=false
+      - -Dapp=false
+      - -Ddocs=false
+      - -Dglade=false
+      - -Dvapi=false
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/vte/0.84/vte-0.84.1.tar.xz
+        sha256: aca1caa8478aebcdbb1d67897fb3511eb7601debae6810e16a15b6fa25f31ac8
+
+  # M6 module 5: OpenBLAS, a prerequisite for opencv below, not one of the
+  # six libraries TODO.md's "verified absent" list named -- but the plan
+  # explicitly calls for linking OpenBLAS directly (rather than the
+  # Dockerfile's FlexiBLAS workaround), and pkg-config confirmed
+  # org.gnome.Sdk//50 has no openblas/cblas/lapack at all. Same "add the
+  # smallest missing module" allowance as poppler's/ffmpeg's transitive
+  # deps. gfortran (needed for OpenBLAS's bundled reference LAPACK) is
+  # confirmed present in the Sdk.
+  - name: openblas
+    buildsystem: simple
+    build-commands:
+      - make -j$(nproc) NO_STATIC=1 NO_LAPACKE=0 DYNAMIC_ARCH=0
+      - make PREFIX=/app NO_STATIC=1 install
+    sources:
+      - type: archive
+        url: https://github.com/OpenMathLib/OpenBLAS/releases/download/v0.3.34/OpenBLAS-0.3.34.tar.gz
+        sha256: cd7e129868320cc2d033afa920e31202dfe0b8066a5b66661900ccc0f197dfed
+
+  # M6 module 5: OpenCV, trimmed to what `Cargo.toml`'s opencv crate
+  # features actually need plus their transitive module deps per OpenCV's
+  # own module graph. imgcodecs is videoio's optional dep (image-sequence
+  # capture). core is implicit in every module. No python/java/highgui/
+  # apps/tests/docs -- none of those are used, and skipping them avoids
+  # needing GTK/Qt-in-OpenCV or a Python toolchain. WITH_FFMPEG picks up the
+  # ffmpeg module built above (found via its .pc files in
+  # /app/lib/pkgconfig, ahead of anything from the runtime). LAPACK_IMPL=
+  # OpenBLAS points at the OpenBLAS module above directly -- this is what
+  # makes the Dockerfile's FlexiBLAS workaround unnecessary, per TODO.md's
+  # explicit instruction.
+  #
+  # M7 corrections, both found by actually inspecting the built headers
+  # rather than guessing from the Cargo.toml feature list alone:
+  #
+  # 1. `dnn` was missing. It's not one of the Cargo.toml-requested opencv
+  #    crate features, but the `opencv` crate's own Cargo.toml declares
+  #    `video = ["dnn"]` -- Cargo therefore enables the "dnn" Rust feature
+  #    transitively, and opencv-binding-generator needs opencv_dnn's headers
+  #    present to generate the `video` Rust module (and several others
+  #    failed silently alongside it once this was missing). `WITH_PROTOBUF=ON`
+  #    (the opencv default) auto-builds opencv's own bundled protobuf
+  #    snapshot since `org.freedesktop.Sdk`//50 has no system protobuf --
+  #    needs network at cmake-configure time, already available via
+  #    --share=network.
+  #
+  # 2. `calib3d`/`features2d` are OpenCV 4.x module names -- OpenCV 5.0.0
+  #    renamed them to `calib`/`features` on disk (confirmed:
+  #    modules/{calib,features,geometry} exist, modules/calib3d and
+  #    modules/features2d do not) and additionally split camera-geometry
+  #    functions (estimateAffine2D, the RANSAC enum, etc.) out into a new
+  #    `geometry` module -- confirmed by grepping the actual built headers
+  #    (`build/files/include/opencv5/opencv2/geometry/3d.hpp` declares both).
+  #    `BUILD_LIST`'s old `calib3d,features2d` entries were silently
+  #    ignored (unrecognized module names), so neither module -- nor
+  #    `geometry`, nor the Rust bindings depending on any of them -- ever
+  #    built. Cargo.toml and `crates/stabilization/affine-l1-stabilization`
+  #    are updated to match (`geometry`/`features` Cargo features and Rust
+  #    module names, not `calib3d`/`calib`, since nothing in this workspace
+  #    actually calls OpenCV's camera-calibration API, only the
+  #    RANSAC-affine-estimation functions that moved to `geometry`).
+  - name: opencv
+    buildsystem: cmake-ninja
+    # opencv's CMakeLists.txt hard-refuses in-source builds (unlike
+    # poppler/fdk-aac above); `builddir: true` makes flatpak-builder build
+    # in a separate directory instead of the source tree.
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DBUILD_LIST=core,flann,imgproc,imgcodecs,features,geometry,video,videoio,dnn
+      - -DBUILD_opencv_apps=OFF
+      - -DBUILD_opencv_python2=OFF
+      - -DBUILD_opencv_python3=OFF
+      - -DBUILD_opencv_java=OFF
+      - -DBUILD_JAVA=OFF
+      - -DBUILD_TESTS=OFF
+      - -DBUILD_PERF_TESTS=OFF
+      - -DBUILD_EXAMPLES=OFF
+      - -DBUILD_DOCS=OFF
+      - -DWITH_GTK=OFF
+      - -DWITH_QT=OFF
+      - -DWITH_OPENGL=OFF
+      - -DWITH_V4L=OFF
+      - -DWITH_GSTREAMER=OFF
+      - -DWITH_1394=OFF
+      - -DWITH_OPENCL=OFF
+      - -DWITH_CUDA=OFF
+      - -DWITH_FFMPEG=ON
+      - -DWITH_LAPACK=ON
+      - -DLAPACK_IMPL=OpenBLAS
+      - -DLAPACK_LIBRARIES=/app/lib/libopenblas.so
+      - -DLAPACK_INCLUDE_DIR=/app/include
+      - -DLAPACK_CBLAS_H=cblas.h
+      - -DLAPACK_LAPACKE_H=lapacke.h
+      - -DOPENCV_ENABLE_NONFREE=OFF
+      - -DOPENCV_GENERATE_PKGCONFIG=ON
+      - -DENABLE_PRECOMPILED_HEADERS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/opencv/opencv/archive/refs/tags/5.0.0.tar.gz
+        sha256: b0528f5a1d379d59d4701cb28c36e22214cc51cf64594e5b56f2d3e6c0233095
+        dest-filename: opencv-5.0.0.tar.gz
+      # Fixes modules/videoio failing to compile against our vendored
+      # FFmpeg 9.x: opencv still reads AVCodec::pix_fmts and
+      # AVCodec::supported_framerates directly, both removed from the
+      # public struct in FFmpeg 8+. No newer opencv tag fixes this (checked
+      # 5.x branch HEAD) -- see TODO.md's M6 section for the full writeup.
+      - type: patch
+        path: patches/opencv-ffmpeg9-avcodec-config.patch
+
+  # M6 module 6: slang, from the external/slang git submodule. Same
+  # SLANG_ENABLE_* flags as the Makefile's slang-compiler target (the
+  # CUDA path from M4), minus -G "Ninja Multi-Config" -- flatpak-builder's
+  # cmake-ninja buildsystem already drives a single-config Ninja build,
+  # which is what we want for a one-shot Release install into /app.
+  - name: slang
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSLANG_ENABLE_SLANGC=OFF
+      - -DSLANG_ENABLE_SLANG_RHI=OFF
+      - -DSLANG_ENABLE_GFX=OFF
+      - -DSLANG_ENABLE_TESTS=OFF
+      - -DSLANG_ENABLE_EXAMPLES=OFF
+      - -DSLANG_ENABLE_SLANGD=OFF
+      - -DSLANG_ENABLE_SLANGI=OFF
+      - -DSLANG_ENABLE_SLANGRT=OFF
+      - -DSLANG_ENABLE_SPLIT_DEBUG_INFO=OFF
+      - -DSLANG_ENABLE_SLANG_GLSLANG=ON
+      - -DSLANG_ENABLE_REPLAYER=OFF
+      - -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+      - -DSLANG_ENABLE_DXIL=OFF
+    # cmake-ninja's default `ninja` (then `ninja install`) isn't enough here:
+    # source/slang-glsl-module/CMakeLists.txt marks the slang-glsl-module
+    # target EXCLUDE_FROM_ALL (so plain `ninja`/`ninja all` skips building
+    # it) but still registers an unconditional install() rule for it once
+    # SLANG_ENABLE_SLANG_GLSLANG=ON, so `ninja install` then fails with
+    # "file INSTALL cannot find .../libslang-glsl-module-0.0.0.so" -- it was
+    # never built. The Makefile's own `cmake --build --target slang
+    # slang-glslang` (M4's CUDA path) never hits this because it never runs
+    # install at all (consumes the build in place via LD_LIBRARY_PATH).
+    # Building slang-glsl-module explicitly alongside slang/slang-glslang
+    # before installing is the fix, not disabling the install rule.
+    build-commands:
+      - ninja slang slang-glslang slang-glsl-module
+      - ninja install
+    # M7 correction: was `type: dir` pointing at the local ../../external/slang
+    # checkout. flatpak-builder can't compute a stable cache key for a `dir`
+    # source (no commit/checksum), so this module -- and everything after it
+    # -- was a guaranteed cache miss on every single build, forcing a full
+    # rebuild even when nothing here changed.
+    #
+    # Tried enumerating all 18 nested submodules as individual pinned `git`
+    # sources first (matching TODO.md's M8 wording literally) -- that broke:
+    # flatpak-builder's `git` source recursively clones submodules on its own
+    # by default (`disable-submodules` defaults to false), using the exact
+    # commits recorded in the parent commit's gitlinks. Declaring them AGAIN
+    # as separate sources collided with that automatic checkout ("cp: cannot
+    # overwrite non-directory '.../external/glslang/.git' with directory").
+    # A single pinned commit on the top-level repo is sufficient: it
+    # transitively pins every submodule commit already, and gives this
+    # module the same kind of real, stable cache key the M6 dependency
+    # modules have.
+    sources:
+      - type: git
+        url: https://github.com/shader-slang/slang.git
+        commit: 961e4e59ee0181ad645825c5db3a677d5a829a9f
+
+  # M7: the actual app. `make install DESTDIR=/ PREFIX=/app` (Makefile:442)
+  # already installs the desktop file (sed-rewriting Exec=/TryExec= to the
+  # real install path, then `install -Dm644`) and the icon (via its
+  # `desktop-icon` prerequisite, `install -Dm644` into ICONDIR, plus
+  # `cp -a assets/icons/.` into ICONS_RESOURCE_DIR for in-app icon lookups) --
+  # confirmed by reading the `install:`/`desktop-icon:` recipes directly, not
+  # assumed. Only the metainfo.xml install survives from the old 3-file
+  # `simple` module below; installing the desktop file and icon a second time
+  # via explicit `install -Dm644` commands would just be redundant with what
+  # `make install` already does to the exact same destinations.
+  #
+  # `make install`'s `release` prerequisite (native-deps + cuda-artifacts,
+  # then a real `cargo build --release` of the GTK bins) needs several
+  # sandbox-specific overrides, all passed as `make` command-line variable
+  # assignments (which win over the Makefile's own `?=`/`:=` defaults, same
+  # trick M5's `flatpak-rust-check CARGO=cargo` already uses):
+  #
+  # - CARGO=cargo: the Makefile normally drives cargo via
+  #   `$(RUSTUP) run $(RUST_TOOLCHAIN) cargo`, but the sandbox has no rustup,
+  #   only the raw rust-nightly Sdk extension's `cargo` (already on PATH via
+  #   this manifest's `build-options.append-path`) -- exactly the problem
+  #   M5's `flatpak-rust-check` target already solved, same fix reused here.
+  #
+  # - the slang-compiler stamp files are pre-touched so `make`'s dependency
+  #   check treats `cuda-artifacts`'s `slang-compiler` prerequisite as already
+  #   satisfied, and a real `libslang.so` (copied from what the `slang`
+  #   module above just installed into /app) is staged at the exact path
+  #   `crates/slang-build/build.rs` and `crates/render-cuda/build.rs` expect
+  #   (`external/slang/build/Release/lib/`) via `SLANG_BUILD_DIR`'s default.
+  #   Without this, `slang-compiler`'s recipe would `cmake`+`ninja` build all
+  #   of external/slang a second time from scratch -- the exact "genuinely
+  #   slow/redundant" case TODO.md flagged as worth checking empirically; it
+  #   is, so this skips it the same way M4 skips nvcc when a cubin already
+  #   exists. `shrimply-slang-build`'s `Compiler` still needs the actual
+  #   library loadable at process start (it's a hard ELF NEEDED, not lazy),
+  #   so this stages the real installed .so, not an empty stub.
+  #
+  # - a small NVIDIA `cuda_cudart` redistributable (~1.4MB: just
+  #   `include/cuda.h` and `lib/stubs/libcuda.so`, not the ~4GB toolkit --
+  #   see TODO.md's Established Facts on CUDA build surface) is unpacked to
+  #   `cuda-stub/` and used as `CUDA_HOME`/`CUDA_TOOLKIT_PATH` so
+  #   `crates/cuda/bridge/build.rs` finds `cuda.h` to compile `bridge.c`
+  #   against, with a `libcuda.so.1` symlink added next to the stub (same
+  #   thing the Dockerfile does at `/usr/local/cuda/lib64/stubs`) and
+  #   `LIBRARY_PATH` pointed at it so the final link resolves `-lcuda`. This
+  #   stub is build-only and never installed into /app: the real
+  #   `libcuda.so.1` is supplied at runtime by
+  #   `org.freedesktop.Platform.GL.nvidia-*`, and shipping a fake one would
+  #   shadow it.
+  #
+  # cuda-artifacts itself needs no nvcc/CUDA_HOST_CXX handling beyond this:
+  # all 9 `.cubin` modules are vendored under
+  # `crates/render-cuda/prebuilt/sm_86/` (M4), so `render-cuda`'s build.rs
+  # copies them instead of invoking nvcc at all -- confirmed by the build log
+  # rather than assumed.
+  - name: shrimply
+    buildsystem: simple
+    # M7: scoped to this module only (not the top-level build-options) so
+    # iterating on these doesn't invalidate every earlier module's cache --
+    # see the note on the top-level build-options above.
+    build-options:
+      append-path: /usr/lib/sdk/llvm22/bin
+      env:
+        LIBCLANG_PATH: /usr/lib/sdk/llvm22/lib
+        BINDGEN_EXTRA_CLANG_ARGS: -resource-dir=/usr/lib/sdk/llvm22/lib/clang/22
+      # CI caching (GitHub Actions runners): this module's own source is
+      # always a fresh `dir` checkout (see below), so unlike the M6
+      # dependency modules it can never get a flatpak-builder cache hit --
+      # every build re-runs the full Rust workspace compile. `~` expands to
+      # the invoking user's home dir (flatpak's own convention, works the
+      # same in build-args as in finish-args) -- mounting a fixed path there
+      # means a CI workflow just needs to restore/save
+      # ~/.cache/shrimply-flatpak-cargo-cache between runs (e.g. actions/
+      # cache) to get cargo's downloaded crates AND compiled target/ dir
+      # back, without this manifest needing to know it's running in CI.
+      # Harmless locally too: bwrap creates it empty on first use if it
+      # doesn't exist (":create"), and an empty cache just means a cold
+      # first build, same as today.
+      build-args:
+        - --filesystem=~/.cache/shrimply-flatpak-cargo-cache:create
+    build-commands:
+      - install -Dm644 dev.shrimply.Shrimply.metainfo.xml /app/share/metainfo/dev.shrimply.Shrimply.metainfo.xml
+      - mkdir -p cuda-stub/lib/stubs
+      - ln -sf libcuda.so cuda-stub/lib/stubs/libcuda.so.1
+      - mkdir -p external/slang/build/Release/lib
+      # `libslang.so` is a symlink to `libslang-compiler.so.0.0.0.0` -- the
+      # narrower `libslang.so*` glob copied only the symlink, not its target
+      # (different filename, doesn't match), leaving it dangling. Broken
+      # symlink -> `Path::is_file()` in crates/slang-build/build.rs returns
+      # false -> it silently rebuilt all of slang via cmake from scratch
+      # every time, ignoring this module's real, already-built libslang.so
+      # entirely. `libslang*` covers the real target file too.
+      - cp -a /app/lib/libslang* external/slang/build/Release/lib/
+      - touch external/slang/build/.shrimply-configure external/slang/build/.shrimply-compiler
+      # A symlink, not a CARGO_TARGET_DIR env var: the Makefile's `install`
+      # target hardcodes relative paths like `target/release/shrimply` --
+      # pointing CARGO_TARGET_DIR at the cache dir directly made cargo build
+      # everything there while `make install` kept looking in `./target`,
+      # failing with "cannot stat 'target/release/shrimply'". Symlinking
+      # `target` itself to the cache dir keeps `make install`'s hardcoded
+      # paths working transparently while still caching every compiled
+      # artifact across runs.
+      - mkdir -p "$HOME/.cache/shrimply-flatpak-cargo-cache/target"
+      - ln -sfn "$HOME/.cache/shrimply-flatpak-cargo-cache/target" target
+      - >-
+        LIBRARY_PATH="$PWD/cuda-stub/lib/stubs:$LIBRARY_PATH"
+        CARGO_HOME="$HOME/.cache/shrimply-flatpak-cargo-cache/cargo-home"
+        make install DESTDIR=/ PREFIX=/app
+        CARGO=cargo
+        CUDA_HOME="$PWD/cuda-stub" CUDA_TOOLKIT_PATH="$PWD/cuda-stub"
+    sources:
+      - type: file
+        path: ../../assets/dev.shrimply.Shrimply.metainfo.xml
+      - type: archive
+        url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/linux-x86_64/cuda_cudart-linux-x86_64-13.0.48-archive.tar.xz
+        sha256: 30ffafae23833dafc965cf4e4d034f8553805586959328c64e2c47b3ef3bcd55
+        dest: cuda-stub
+        strip-components: 1
+      - type: dir
+        path: ../../
+        skip:
+          - .git
+          - target
+          - build
+          - .flatpak-builder
+          - external/manim

--- a/packaging/flatpak/dev.shrimply.Shrimply.yaml
+++ b/packaging/flatpak/dev.shrimply.Shrimply.yaml
@@ -290,6 +290,9 @@ modules:
         - --filesystem=~/.cache/shrimply-flatpak-cargo-cache:create
     build-commands:
       - install -Dm644 dev.shrimply.Shrimply.metainfo.xml /app/share/metainfo/dev.shrimply.Shrimply.metainfo.xml
+      # `make install` installs the app's LICENSE; this adds the bundled-deps
+      # attribution + corresponding-source pointer for the Flatpak.
+      - install -Dm644 packaging/flatpak/NOTICE /app/share/licenses/shrimply/NOTICE
       - mkdir -p cuda-stub/lib/stubs
       - ln -sf libcuda.so cuda-stub/lib/stubs/libcuda.so.1
       - mkdir -p external/slang/build/Release/lib

--- a/packaging/flatpak/dev.shrimply.Shrimply.yaml
+++ b/packaging/flatpak/dev.shrimply.Shrimply.yaml
@@ -82,9 +82,19 @@ modules:
   # what's intentionally out of scope. fft/resampler stay at "auto", which
   # resolves to the builtin implementation (no external FFT/resampler lib
   # needed) -- confirmed by the module actually linking below.
+  # -Dlibdir=lib / -DCMAKE_INSTALL_LIBDIR=lib on every meson/cmake module
+  # below: org.gnome.Sdk//50 has a real /usr/lib64, so meson's and CMake's
+  # libdir heuristics resolve to `lib64` and the module installs
+  # libfoo.so + foo.pc under /app/lib64{,/pkgconfig}. Nothing searches there
+  # -- flatpak's default PKG_CONFIG_PATH and runtime linker path are /app/lib
+  # only (and the shrimply module's `cp /app/lib/libslang*` assumes it too) --
+  # so ffmpeg's ./configure failed with "libfdk_aac not found" despite fdk-aac
+  # having built fine. Forcing /app/lib keeps build-time pkg-config, build-time
+  # linking and runtime loading all working with no PKG_CONFIG_PATH hacks.
   - name: rubberband
     buildsystem: meson
     config-opts:
+      - -Dlibdir=lib
       - -Dfft=auto
       - -Dresampler=auto
       - -Djni=disabled
@@ -118,6 +128,7 @@ modules:
   - name: fdk-aac
     buildsystem: cmake-ninja
     config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib  # see rubberband
       - -DBUILD_SHARED_LIBS=ON
     sources:
       - type: archive
@@ -194,6 +205,7 @@ modules:
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib  # see rubberband
       - -DBUILD_SHARED_LIBS=ON
       - -DENABLE_GLIB=ON
       - -DENABLE_GOBJECT_INTROSPECTION=ON
@@ -230,6 +242,7 @@ modules:
   - name: vte
     buildsystem: meson
     config-opts:
+      - -Dlibdir=lib  # see rubberband
       - -Dgtk3=false
       - -Dgtk4=true
       - -D_systemd=false
@@ -308,6 +321,7 @@ modules:
     # in a separate directory instead of the source tree.
     builddir: true
     config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib  # see rubberband
       - -DCMAKE_BUILD_TYPE=Release
       - -DBUILD_SHARED_LIBS=ON
       - -DBUILD_LIST=core,flann,imgproc,imgcodecs,features,geometry,video,videoio,dnn
@@ -360,6 +374,7 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib  # see rubberband; the shrimply module's `cp /app/lib/libslang*` needs it here
       - -DCMAKE_BUILD_TYPE=Release
       - -DSLANG_ENABLE_SLANGC=OFF
       - -DSLANG_ENABLE_SLANG_RHI=OFF

--- a/packaging/flatpak/dev.shrimply.Shrimply.yaml
+++ b/packaging/flatpak/dev.shrimply.Shrimply.yaml
@@ -82,15 +82,11 @@ modules:
   # what's intentionally out of scope. fft/resampler stay at "auto", which
   # resolves to the builtin implementation (no external FFT/resampler lib
   # needed) -- confirmed by the module actually linking below.
-  # -Dlibdir=lib / -DCMAKE_INSTALL_LIBDIR=lib on every meson/cmake module
-  # below: org.gnome.Sdk//50 has a real /usr/lib64, so meson's and CMake's
-  # libdir heuristics resolve to `lib64` and the module installs
-  # libfoo.so + foo.pc under /app/lib64{,/pkgconfig}. Nothing searches there
-  # -- flatpak's default PKG_CONFIG_PATH and runtime linker path are /app/lib
-  # only (and the shrimply module's `cp /app/lib/libslang*` assumes it too) --
-  # so ffmpeg's ./configure failed with "libfdk_aac not found" despite fdk-aac
-  # having built fine. Forcing /app/lib keeps build-time pkg-config, build-time
-  # linking and runtime loading all working with no PKG_CONFIG_PATH hacks.
+  # -Dlibdir=lib / -DCMAKE_INSTALL_LIBDIR=lib on every meson/cmake module below:
+  # org.gnome.Sdk//50 has a real /usr/lib64, so meson and CMake install
+  # libfoo.so + foo.pc under /app/lib64, which nothing searches -- flatpak's
+  # PKG_CONFIG_PATH and runtime linker path are /app/lib only. Without this,
+  # ffmpeg's ./configure fails with "libfdk_aac not found".
   - name: rubberband
     buildsystem: meson
     config-opts:

--- a/packaging/flatpak/dev.shrimply.Shrimply.yaml
+++ b/packaging/flatpak/dev.shrimply.Shrimply.yaml
@@ -81,16 +81,6 @@ modules:
         # pinned commit on the "stable" branch (no tagged releases upstream)
         commit: b35605ace3ddf7c1a5d67a2eb553f034aef41d55
 
-  - name: fdk-aac
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_INSTALL_LIBDIR=lib  # see rubberband
-      - -DBUILD_SHARED_LIBS=ON
-    sources:
-      - type: archive
-        url: https://github.com/mstorsjo/fdk-aac/archive/refs/tags/v2.0.3.tar.gz
-        sha256: e25671cd96b10bad896aa42ab91a695a9e573395262baed4e4a2ff178d6a3a78
-
   - name: lame
     buildsystem: autotools
     config-opts:
@@ -105,9 +95,11 @@ modules:
         dest-filename: lame-3.100.tar.gz
 
   # FFmpeg 9.x: the runtime ships 7.1, too old for ffmpeg-sys-next 9.0.0. Lands
-  # in /app/lib, found ahead of the runtime copy. Codecs enabled = exactly what
-  # the Rust crates request by name (x264/fdk-aac/mp3lame/vorbis/opus, plus
-  # nvenc via --enable-nonfree; ffnvcodec headers are already in the Sdk).
+  # in /app/lib, found ahead of the runtime copy. Codecs enabled = what the
+  # Rust crates request by name (x264/mp3lame/vorbis/opus + the builtin aac);
+  # nvenc comes from the Sdk's ffnvcodec headers and needs no extra flag. No
+  # --enable-nonfree: it would make the build non-redistributable and is only
+  # needed for libfdk_aac, which is GPL-incompatible anyway (the app is GPLv3).
   - name: ffmpeg
     buildsystem: simple
     build-commands:
@@ -115,8 +107,8 @@ modules:
         ./configure --prefix=/app
         --enable-shared --disable-static --enable-pic
         --disable-programs --disable-doc
-        --enable-gpl --enable-nonfree
-        --enable-libx264 --enable-libfdk-aac --enable-libmp3lame
+        --enable-gpl
+        --enable-libx264 --enable-libmp3lame
         --enable-libvorbis --enable-libopus
       - make -j$(nproc)
       - make install

--- a/packaging/flatpak/patches/opencv-ffmpeg9-avcodec-config.patch
+++ b/packaging/flatpak/patches/opencv-ffmpeg9-avcodec-config.patch
@@ -1,0 +1,88 @@
+From: shrimply flatpak packaging
+Subject: opencv videoio: use avcodec_get_supported_config() on FFmpeg 8+
+
+FFmpeg deprecated AVCodec::pix_fmts and AVCodec::supported_framerates in
+7.1 and removed both fields from the public struct entirely starting with
+FFmpeg 8 (libavcodec major version 62; our vendored FFmpeg 9.x reports 63,
+confirmed against the built libavcodec/version_major.h). Upstream OpenCV
+(including the current 5.x branch HEAD) still reads these fields directly
+in cap_ffmpeg_hw.hpp and cap_ffmpeg_impl.hpp, so modules/videoio fails to
+compile against FFmpeg 8+.
+
+The replacement API, present since well before FFmpeg 8.0 (so it exists
+in our vendored 9.x too):
+
+  int avcodec_get_supported_config(const AVCodecContext *avctx,
+                                    const AVCodec *codec,
+                                    enum AVCodecConfig config,
+                                    unsigned flags,
+                                    const void **out_configs,
+                                    int *out_num_configs);
+
+This patch guards both call sites on LIBAVCODEC_VERSION_MAJOR, keeping the
+old direct-struct-access code path for older FFmpeg (<62) and using
+avcodec_get_supported_config() on 62+.
+
+--- a/modules/videoio/src/cap_ffmpeg_hw.hpp	2026-09-07 14:21:24.444202960 +0200
++++ b/modules/videoio/src/cap_ffmpeg_hw.hpp	2026-09-07 14:21:33.653530777 +0200
+@@ -757,6 +757,22 @@
+ #endif
+             if (hw_type == AV_HWDEVICE_TYPE_CUDA) // CUDA encoders don't support avcodec_get_hw_config()
+                 hw_native_fmt = AV_PIX_FMT_CUDA;
++#if LIBAVCODEC_VERSION_MAJOR >= 62
++            if (av_codec_is_encoder(c) && hw_native_fmt != AV_PIX_FMT_NONE) {
++                const AVPixelFormat *pix_fmts = NULL;
++                int nb_pix_fmts = 0;
++                if (avcodec_get_supported_config(NULL, c, AV_CODEC_CONFIG_PIX_FORMAT, 0,
++                                                  (const void**)&pix_fmts, &nb_pix_fmts) >= 0 && pix_fmts) {
++                    for (int i = 0; pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
++                        if (pix_fmts[i] == hw_native_fmt) {
++                            *hw_pix_fmt = hw_native_fmt;
++                            if (hw_check_codec(c, hw_type, disabled_codecs))
++                                return c;
++                        }
++                    }
++                }
++            }
++#else
+             if (av_codec_is_encoder(c) && hw_native_fmt != AV_PIX_FMT_NONE && c->pix_fmts) {
+                 for (int i = 0; c->pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
+                     if (c->pix_fmts[i] == hw_native_fmt) {
+@@ -766,6 +782,7 @@
+                     }
+                 }
+             }
++#endif
+             for (int i = 0;; i++) {
+                 const AVCodecHWConfig *hw_config = avcodec_get_hw_config(c, i);
+                 if (!hw_config)
+--- a/modules/videoio/src/cap_ffmpeg_impl.hpp	2026-09-07 14:21:24.444733752 +0200
++++ b/modules/videoio/src/cap_ffmpeg_impl.hpp	2026-09-07 14:21:46.521542178 +0200
+@@ -2629,12 +2629,27 @@
+     c->time_base.den = frame_rate;
+     c->time_base.num = frame_rate_base;
+     /* adjust time base for supported framerates */
++#if LIBAVCODEC_VERSION_MAJOR >= 62
++    const AVRational *codec_framerates = NULL;
++    int nb_codec_framerates = 0;
++    if (codec) {
++        avcodec_get_supported_config(NULL, codec, AV_CODEC_CONFIG_FRAME_RATE, 0,
++                                      (const void**)&codec_framerates, &nb_codec_framerates);
++    }
++    if (codec && codec_framerates){
++        const AVRational *p = codec_framerates;
++#else
+     if(codec && codec->supported_framerates){
+         const AVRational *p= codec->supported_framerates;
++#endif
+         AVRational req = {frame_rate, frame_rate_base};
+         const AVRational *best=NULL;
+         AVRational best_error= {INT_MAX, 1};
++#if LIBAVCODEC_VERSION_MAJOR >= 62
++        for(; !(p->num==0 && p->den==0); p++){
++#else
+         for(; p->den!=0; p++){
++#endif
+             AVRational error= av_sub_q(req, *p);
+             if(error.num <0) error.num *= -1;
+             if(av_cmp_q(error, best_error) < 0){

--- a/vendor/pocketsphinx/build.rs
+++ b/vendor/pocketsphinx/build.rs
@@ -74,10 +74,22 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=SHRIMPLY_POCKETSPHINX_CACHE");
     let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
+    // Locate the profile directory (target/<profile>) by name rather than by
+    // a fixed ancestor count: OUT_DIR's standard layout is
+    // target/<profile>/build/<pkg>-<hash>/out, but that's 3 levels up from
+    // `out` only when every component is present as assumed -- a fixed
+    // `.nth(3)` silently lands one level off (target/<profile>/build) if the
+    // actual layout differs, which happened building this crate for real for
+    // the first time (staged the model there instead of
+    // target/<profile>/res/lip-sync). PROFILE is a Cargo-guaranteed env var
+    // naming the profile directory itself, so search for that component
+    // instead of guessing its depth.
+    let profile_name = env::var("PROFILE").expect("PROFILE is set by Cargo");
     let profile = out
         .ancestors()
-        .nth(3)
-        .expect("standard Cargo OUT_DIR layout");
+        .find(|path| path.file_name().is_some_and(|name| name == profile_name.as_str()))
+        .expect("OUT_DIR contains a Cargo profile directory component")
+        .to_path_buf();
     let target = profile
         .parent()
         .expect("Cargo profile directory has a parent");

--- a/vendor/pocketsphinx/build.rs
+++ b/vendor/pocketsphinx/build.rs
@@ -74,16 +74,9 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=SHRIMPLY_POCKETSPHINX_CACHE");
     let out = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by Cargo"));
-    // Locate the profile directory (target/<profile>) by name rather than by
-    // a fixed ancestor count: OUT_DIR's standard layout is
-    // target/<profile>/build/<pkg>-<hash>/out, but that's 3 levels up from
-    // `out` only when every component is present as assumed -- a fixed
-    // `.nth(3)` silently lands one level off (target/<profile>/build) if the
-    // actual layout differs, which happened building this crate for real for
-    // the first time (staged the model there instead of
-    // target/<profile>/res/lip-sync). PROFILE is a Cargo-guaranteed env var
-    // naming the profile directory itself, so search for that component
-    // instead of guessing its depth.
+    // Find the target/<profile> directory by name rather than a fixed ancestor
+    // count -- OUT_DIR's depth isn't guaranteed and a fixed `.nth(3)` can land
+    // one level off. PROFILE names the profile directory.
     let profile_name = env::var("PROFILE").expect("PROFILE is set by Cargo");
     let profile = out
         .ancestors()


### PR DESCRIPTION
This MR introduces a minimal flatpak build for Linux.

Notes:
- fdk-aac has been disabled due to incompatibility with GPLv3; AAC encoding should still work with the other codecs.
- Blender and other integrations do not work at the moment - TBD
- CUDA blobs are shipped as part of flatpak distribution
- OpenCV needed a small patch to work with a modern FFmpeg version.

build is passing: https://github.com/aurabirb/shrimply/actions/runs/34160824538