### PR TITLE
Apply shear before scale in ResolvedTransform2D::matrix

### DIFF
--- a/crates/math/geometry/src/transform.rs
+++ b/crates/math/geometry/src/transform.rs
@@ -191,21 +191,21 @@ impl ResolvedTransform2D {
     /// Composition is `translation(position) * rotation * shear * scale *
     /// translation(-anchor)`, so rotation and scale occur around the anchor.
     pub fn matrix(self) -> Mat3 {
-        Mat3::from_scale_angle_translation(
-            self.scale,
-            self.rotation_degrees.to_radians(),
-            self.position,
-        ) * Mat3::from_cols_array(&[
-            1.0,
-            self.shear.y,
-            0.0,
-            self.shear.x,
-            1.0,
-            0.0,
-            0.0,
-            0.0,
-            1.0,
-        ]) * Mat3::from_translation(-self.anchor)
+        Mat3::from_translation(self.position)
+            * Mat3::from_angle(self.rotation_degrees.to_radians())
+            * Mat3::from_cols_array(&[
+                1.0,
+                self.shear.y,
+                0.0,
+                self.shear.x,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+            ])
+            * Mat3::from_scale(self.scale)
+            * Mat3::from_translation(-self.anchor)
     }
 
     pub fn composed(self) -> ComposedTransform2D {
@@ -276,4 +276,83 @@ pub fn relative_motion_transforms(
             .map(|sample| sample.compose(inverse))
             .collect(),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(left: Vec2, right: Vec2) -> bool {
+        (left - right).abs().max_element() <= 1e-5
+    }
+
+    #[test]
+    fn shear_is_applied_after_scale() {
+        // scale (2, 4) then an x-shear of 0.5 maps (1, 1) to (1, 1) * scale = (2, 4),
+        // then (2 + 0.5 * 4, 4) = (4, 4). Composing the other way round shears the
+        // unscaled point first and reaches (3, 4) instead.
+        let transform = ResolvedTransform2D {
+            scale: Vec2::new(2.0, 4.0),
+            shear: Vec2::new(0.5, 0.0),
+            ..ResolvedTransform2D::IDENTITY
+        };
+        let point = transform.matrix().transform_point2(Vec2::ONE);
+        assert!(approx(point, Vec2::new(4.0, 4.0)), "{point:?}");
+    }
+
+    #[test]
+    fn the_matrix_is_the_documented_composition() {
+        let transform = ResolvedTransform2D {
+            position: Vec2::new(30.0, -10.0),
+            anchor: Vec2::new(4.0, 7.0),
+            scale: Vec2::new(3.0, 0.5),
+            shear: Vec2::new(0.25, -0.75),
+            rotation_degrees: 35.0,
+        };
+        let shear = Mat3::from_cols_array(&[
+            1.0,
+            transform.shear.y,
+            0.0,
+            transform.shear.x,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ]);
+        let documented = Mat3::from_translation(transform.position)
+            * Mat3::from_angle(transform.rotation_degrees.to_radians())
+            * shear
+            * Mat3::from_scale(transform.scale)
+            * Mat3::from_translation(-transform.anchor);
+        for point in [Vec2::ZERO, Vec2::X, Vec2::Y, Vec2::new(-6.0, 11.0)] {
+            let actual = transform.matrix().transform_point2(point);
+            let expected = documented.transform_point2(point);
+            assert!(
+                approx(actual, expected),
+                "{point:?}: {actual:?} {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_transform_without_shear_is_unchanged() {
+        let transform = ResolvedTransform2D {
+            position: Vec2::new(120.0, 80.0),
+            anchor: Vec2::new(16.0, 9.0),
+            scale: Vec2::new(2.0, 3.0),
+            shear: Vec2::ZERO,
+            rotation_degrees: 90.0,
+        };
+        // Rotating a quarter turn about the anchor, then translating to the position.
+        let anchor = transform.matrix().transform_point2(transform.anchor);
+        assert!(approx(anchor, transform.position), "{anchor:?}");
+        let corner = transform
+            .matrix()
+            .transform_point2(transform.anchor + Vec2::X);
+        assert!(
+            approx(corner, transform.position + Vec2::Y * 2.0),
+            "{corner:?}"
+        );
+    }
 }


### PR DESCRIPTION
## The defect

`ResolvedTransform2D::matrix()` carries this docstring:

```
/// Composition is `translation(position) * rotation * shear * scale *
/// translation(-anchor)`, so rotation and scale occur around the anchor.
```

The code did something else:

```rust
Mat3::from_scale_angle_translation(self.scale, angle, self.position)
    * shear
    * Mat3::from_translation(-self.anchor)
```

`Mat3::from_scale_angle_translation(scale, angle, translation)` is already
`translation * rotation * scale`, so the shear ends up to the *right* of the
scale. The composition actually built was

```
translation(position) * rotation * scale * shear * translation(-anchor)
```

Scale and shear commute only when the scale is uniform. With scale `(sx, sy)`
and shear `(hx, hy)` the two orderings are

```
shear * scale = [ sx        hx * sy ]      scale * shear = [ sx        sx * hx ]
                [ hy * sx   sy      ]                      [ sy * hy   sy      ]
```

so any layer with shear and a non-uniform scale rendered through a different
matrix than the one the docstring promises.

## Why the docstring is the side that is right

Two call sites already compose the linear part in the documented order and
must agree with `matrix()` to be correct.

`crates/project/project-document/src/project/preview/visual_item.rs:837-847`
(`ResolvedTransform` there is a re-export of this very type,
`crates/project/project-document/src/project/mod.rs:11`):

```rust
fn unscaled_transform(transform: ResolvedTransform) -> Mat3 {
    Mat3::from_angle(transform.rotation_degrees.to_radians()) * shear_transform(transform.shear)
}

fn linear_transform(transform: ResolvedTransform) -> Mat3 {
    unscaled_transform(transform) * Mat3::from_scale(transform.scale)
}
```

That is `rotation * shear * scale`. It is used to keep a handle pinned while
resizing (`visual_item.rs:876`):

```rust
transform.position = fixed_canvas
    - linear_transform(*transform).transform_vector2(fixed_local - transform.anchor);
```

Since `matrix()` maps `p` to `position + L * (p - anchor)`, `linear_transform`
*is* `L` by construction — so the two must be the same matrix, and they were not.

`crates/media/visual/visual-modifiers/src/modifiers/transform.rs:419` makes the same
assumption from the other direction, recovering the rotation-and-shear factor
by zeroing the scale and then dividing it out of a parent-space delta:

```rust
let rotation_shear = ResolvedTransform2D { scale: glam::Vec2::ONE, ..start }.matrix();
let local_delta = rotation_shear.inverse().transform_vector2(parent - base_parent);
...
scale.x = (local_delta.x / denominator.x).max(0.001);
```

Dividing out that factor recovers the scale only if the scale sits to the right
of the shear in `matrix()`. So the docstring, the preview resize maths and the
drag solver all say `rotation * shear * scale`; only `matrix()` said otherwise.
This changes the code rather than the comment.

## Reproduction

Scale `(2, 4)` with an x-shear of `0.5`, applied to `(1, 1)`:

- documented order — scale first: `(2, 4)`; then shear: `(2 + 0.5 * 4, 4)` = **`(4, 4)`**
- shipped order — shear first: `(1 + 0.5 * 1, 1)` = `(1.5, 1)`; then scale: **`(3, 4)`**

### Before

```
$ cargo test -p shrimply-math-geometry

running 3 tests
test transform::tests::a_transform_without_shear_is_unchanged ... ok
test transform::tests::shear_is_applied_after_scale ... FAILED
test transform::tests::the_matrix_is_the_documented_composition ... FAILED

---- transform::tests::shear_is_applied_after_scale stdout ----
thread 'transform::tests::shear_is_applied_after_scale' panicked at crates\math\geometry\src\transform.rs:300:9:
Vec2(3.0, 4.0)

---- transform::tests::the_matrix_is_the_documented_composition stdout ----
thread 'transform::tests::the_matrix_is_the_documented_composition' panicked at crates\math\geometry\src\transform.rs:331:13:
Vec2(0.0, 0.0): Vec2(17.01678, -21.532497) Vec2(16.298748, -12.87946)

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

The second failure is worth reading: with shear and a non-uniform scale the
anchor itself no longer landed on the position, because the anchor translation
is now being scaled through a different matrix.

### After

```
$ cargo test -p shrimply-math-geometry

running 3 tests
test transform::tests::a_transform_without_shear_is_unchanged ... ok
test transform::tests::shear_is_applied_after_scale ... ok
test transform::tests::the_matrix_is_the_documented_composition ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`a_transform_without_shear_is_unchanged` is the guard in the other direction: it
pins a rotate-scale-about-the-anchor transform with zero shear and passes both
before and after, since the two orderings coincide there. Every project without
shear renders identically.

## Scope

Projects that do use shear together with a non-uniform scale will render
differently after this — that is the point of the change, and it is the only way
to make the renderer agree with the editor. If you would rather keep the shipped
matrix and correct the comment instead, say so and I will invert the patch;
in that case `linear_transform` and the drag solver both need the same
correction, which is why I did not choose that direction.

## How I tested

Windows 11. `cargo test -p shrimply-math-geometry` as above,
`cargo fmt -p shrimply-math-geometry -- --check` and
`cargo clippy -p shrimply-math-geometry --all-targets` clean.

A note on the toolchain: `rust-toolchain.toml` pins `nightly-2026-04-03` with
`rustc-dev` and `llvm-tools`; that is what I built with. `math/geometry` compiles
standalone, so I did not need the Slang toolchain that the wider workspace
requires (`shrimply-slang-build` does not configure here). The two crates I quote
as corroborating evidence are downstream of Slang and I could not compile them,
so please sanity-check that side.
