### PR TITLE
Take the denominator's sign into account in fraction_new

### DIFF
--- a/crates/math/core/src/lib.rs
+++ b/crates/math/core/src/lib.rs
@@ -185,7 +185,7 @@ pub fn fraction_new(numerator: i64, denominator: i64) -> Fraction {
     if denominator == 0 {
         return FRACTION_ZERO;
     }
-    if numerator < 0 {
+    if numerator != 0 && (numerator < 0) != (denominator < 0) {
         GenericFraction::Rational(
             Sign::Minus,
             fraction::Ratio::new(numerator.unsigned_abs(), denominator.unsigned_abs()),
@@ -193,7 +193,7 @@ pub fn fraction_new(numerator: i64, denominator: i64) -> Fraction {
     } else {
         GenericFraction::Rational(
             Sign::Plus,
-            fraction::Ratio::new(numerator as u64, denominator.unsigned_abs()),
+            fraction::Ratio::new(numerator.unsigned_abs(), denominator.unsigned_abs()),
         )
     }
 }
@@ -683,5 +683,35 @@ mod tests {
             60,
         );
         assert_eq!(frame_rate_from_duration(Duration::ZERO), None);
+    }
+
+    #[test]
+    fn a_negative_denominator_makes_the_fraction_negative() {
+        assert_eq!(fraction_new(1, -2), fraction_new(-1, 2));
+        assert_eq!(fraction_as_f64(fraction_new(1, -2)), -0.5);
+    }
+
+    #[test]
+    fn two_negatives_make_the_fraction_positive() {
+        assert_eq!(fraction_new(-1, -2), fraction_new(1, 2));
+        assert_eq!(fraction_as_f64(fraction_new(-1, -2)), 0.5);
+    }
+
+    #[test]
+    fn positive_denominators_are_unchanged() {
+        assert_eq!(fraction_as_f64(fraction_new(1, 2)), 0.5);
+        assert_eq!(fraction_as_f64(fraction_new(-1, 2)), -0.5);
+        assert_eq!(fraction_as_f64(fraction_new(3, 1)), 3.0);
+        assert_eq!(fraction_new(2, 4), fraction_new(1, 2));
+    }
+
+    #[test]
+    fn a_zero_stays_a_plain_zero() {
+        assert_eq!(fraction_new(0, -1), FRACTION_ZERO);
+        assert_eq!(fraction_new(0, 5), FRACTION_ZERO);
+        assert_eq!(fraction_new(1, 0), FRACTION_ZERO);
+        assert_eq!(fraction_new(-1, 0), FRACTION_ZERO);
+        assert!(fraction_new(0, -1) <= FRACTION_ZERO);
+        assert!(fraction_new(0, -1) >= FRACTION_ZERO);
     }
 }


### PR DESCRIPTION
## The defect

`fraction_new` picks the sign from the numerator only:

```rust
pub fn fraction_new(numerator: i64, denominator: i64) -> Fraction {
    if denominator == 0 {
        return FRACTION_ZERO;
    }
    if numerator < 0 {
        GenericFraction::Rational(Sign::Minus, ...unsigned_abs()...)
    } else {
        GenericFraction::Rational(Sign::Plus, ...unsigned_abs()...)
    }
}
```

Both operands then go through `unsigned_abs()`, so the denominator's sign is
discarded rather than folded into the result. That is wrong in both directions:

| call | returns | value of `numerator / denominator` |
| --- | --- | --- |
| `fraction_new(1, -2)` | `Rational(Plus, 1/2)` = **+0.5** | -0.5 |
| `fraction_new(-1, -2)` | `Rational(Minus, 1/2)` = **-0.5** | +0.5 |

There is no error and no `None` — the caller gets a well-formed fraction with
the sign flipped.

## Why this is reachable

`crates/binaries/editor-gtk/src/mcp.rs:773` converts a Manim fraction parameter
straight off an MCP request, and its guard rejects only a *zero* denominator:

```rust
(ManimParameterControl::Fraction, ProtocolManimParameterValue::Fraction(value))
    if value.denominator != 0 =>
{
    let value = fraction_new(value.numerator, value.denominator);
    Ok(ManimParameterValue::Fraction {
        numerator: fraction_numerator(value),
        denominator: fraction_denominator(value),
    })
}
```

A client sending `{ numerator: 1, denominator: -2 }` means -1/2 and gets +1/2,
which is then written back out as `numerator: 1, denominator: 2` — the sign is
lost from the stored parameter, not just from one computation.

The neighbouring conversions guard the sign themselves rather than trusting the
constructor, which is what made me look at this one:

- `crates/binaries/editor-gtk/src/mcp.rs:1802` — `if value.denominator <= 0 { return Err(...) }`
- `crates/integrations/mcp/src/edit.rs:868` — `positive_fraction` rejects `<= 0`
- `crates/math/core/src/lib.rs:163` — `deserialize_fraction` rejects `<= 0` with
  "fraction denominator must be positive"

So three call sites defend against a negative denominator and one deliberately
allows it. Since `fraction_new` already guards `denominator == 0` rather than
letting it through, handling the sign here seemed more in keeping than adding a
fourth guard at the call site. `Time::from_fraction` is a thin wrapper over
`fraction_new` and inherits the same behaviour.

## Reproduction

### Before

```
$ cargo test -p shrimply-math-core

running 5 tests
test tests::a_zero_stays_a_plain_zero ... ok
test tests::frame_rate_is_the_reciprocal_of_the_latest_render_cost ... ok
test tests::a_negative_denominator_makes_the_fraction_negative ... FAILED
test tests::positive_denominators_are_unchanged ... ok
test tests::two_negatives_make_the_fraction_positive ... FAILED

---- tests::a_negative_denominator_makes_the_fraction_negative stdout ----
assertion `left == right` failed
  left: Rational(Plus, Ratio { numer: 1, denom: 2 })
 right: Rational(Minus, Ratio { numer: 1, denom: 2 })

---- tests::two_negatives_make_the_fraction_positive stdout ----
assertion `left == right` failed
  left: Rational(Minus, Ratio { numer: 1, denom: 2 })
 right: Rational(Plus, Ratio { numer: 1, denom: 2 })

test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

### After

```
$ cargo test -p shrimply-math-core

running 5 tests
test tests::a_negative_denominator_makes_the_fraction_negative ... ok
test tests::two_negatives_make_the_fraction_positive ... ok
test tests::frame_rate_is_the_reciprocal_of_the_latest_render_cost ... ok
test tests::a_zero_stays_a_plain_zero ... ok
test tests::positive_denominators_are_unchanged ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`positive_denominators_are_unchanged`, `a_zero_stays_a_plain_zero` and the
existing `frame_rate_is_the_reciprocal_of_the_latest_render_cost` all pass both
before and after — every call with a positive denominator, which is every call
in the tree today, is untouched.

## The zero case

`fraction_new(0, -1)` deliberately still returns a `Sign::Plus` zero. Signing it
`Minus` would produce a negative zero that no longer compares equal to
`FRACTION_ZERO`, and `fraction_rem_euclid` and `fit_nonnegative_fraction_pair`
both branch on exactly that comparison. `a_zero_stays_a_plain_zero` pins it,
including `<=` and `>=` against `FRACTION_ZERO`.

## How I tested

Windows 11. `cargo test -p shrimply-math-core` as above,
`cargo fmt -p shrimply-math-core -- --check` and
`cargo clippy -p shrimply-math-core --all-targets` clean.

A note on the toolchain: I built with the pinned `nightly-2026-04-03` from
`rust-toolchain.toml`. `math/core` compiles standalone, so this did not need the
Slang toolchain the wider workspace wants — `shrimply-slang-build` does not
configure on this machine, so I could not compile the `editor-gtk` call site I
quote above and read it rather than ran it.
