### PR TITLE
Give each rotation component its own axis under every rotation order

### DIFF
--- a/crates/media/visual/3d/transform-3d/src/lib.rs
+++ b/crates/media/visual/3d/transform-3d/src/lib.rs
@@ -255,21 +255,40 @@ impl ResolvedTransform3D {
 }
 
 pub fn rotation(degrees: Vec3, order: RotationOrder) -> Quat {
+    let [first, second, third] = axes(order);
     Quat::from_euler(
         euler(order),
-        degrees.x.to_radians(),
-        degrees.y.to_radians(),
-        degrees.z.to_radians(),
+        degrees[first].to_radians(),
+        degrees[second].to_radians(),
+        degrees[third].to_radians(),
     )
 }
 
 pub fn rotation_degrees(rotation: Quat, order: RotationOrder) -> Vec3 {
-    let (x, y, z) = rotation.to_euler(euler(order));
-    Vec3::new(x.to_degrees(), y.to_degrees(), z.to_degrees())
+    let (first_angle, second_angle, third_angle) = rotation.to_euler(euler(order));
+    let [first, second, third] = axes(order);
+    let mut degrees = Vec3::ZERO;
+    degrees[first] = first_angle.to_degrees();
+    degrees[second] = second_angle.to_degrees();
+    degrees[third] = third_angle.to_degrees();
+    degrees
 }
 
 pub fn camera_world(position: Vec3, rotation_degrees: Vec3) -> Mat4 {
     Mat4::from_rotation_translation(rotation(rotation_degrees, RotationOrder::Xyz), position)
+}
+
+/// The `degrees` components that the euler sequence takes its angles from, in
+/// sequence order, so that each component always turns about its own axis.
+fn axes(order: RotationOrder) -> [usize; 3] {
+    match order {
+        RotationOrder::Xyz => [0, 1, 2],
+        RotationOrder::Xzy => [0, 2, 1],
+        RotationOrder::Yxz => [1, 0, 2],
+        RotationOrder::Yzx => [1, 2, 0],
+        RotationOrder::Zxy => [2, 0, 1],
+        RotationOrder::Zyx => [2, 1, 0],
+    }
 }
 
 fn euler(order: RotationOrder) -> EulerRot {
@@ -280,5 +299,61 @@ fn euler(order: RotationOrder) -> EulerRot {
         RotationOrder::Yzx => EulerRot::YZX,
         RotationOrder::Zxy => EulerRot::ZXY,
         RotationOrder::Zyx => EulerRot::ZYX,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ORDERS: [RotationOrder; 6] = [
+        RotationOrder::Xyz,
+        RotationOrder::Xzy,
+        RotationOrder::Yxz,
+        RotationOrder::Yzx,
+        RotationOrder::Zxy,
+        RotationOrder::Zyx,
+    ];
+
+    const PROBE: Vec3 = Vec3::new(1.0, 2.0, 3.0);
+
+    fn close(left: Vec3, right: Vec3) -> bool {
+        (left - right).abs().max_element() <= 1e-4
+    }
+
+    #[test]
+    fn one_nonzero_angle_turns_about_its_own_axis_whatever_the_order() {
+        let quarter = 90f32.to_radians();
+        for (degrees, expected) in [
+            (Vec3::new(90.0, 0.0, 0.0), Quat::from_rotation_x(quarter)),
+            (Vec3::new(0.0, 90.0, 0.0), Quat::from_rotation_y(quarter)),
+            (Vec3::new(0.0, 0.0, 90.0), Quat::from_rotation_z(quarter)),
+        ] {
+            let expected = expected * PROBE;
+            for order in ORDERS {
+                let actual = rotation(degrees, order) * PROBE;
+                assert!(
+                    close(actual, expected),
+                    "{degrees:?} {order:?}: {actual:?} {expected:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn degrees_round_trip_through_every_order() {
+        let degrees = Vec3::new(10.0, 20.0, 30.0);
+        for order in ORDERS {
+            let actual = rotation_degrees(rotation(degrees, order), order);
+            assert!(close(actual, degrees), "{order:?}: {actual:?}");
+        }
+    }
+
+    #[test]
+    fn the_order_still_changes_a_three_axis_rotation() {
+        let degrees = Vec3::new(10.0, 20.0, 30.0);
+        let first = rotation(degrees, RotationOrder::Xyz) * PROBE;
+        let second = rotation(degrees, RotationOrder::Zyx) * PROBE;
+        assert!(!close(first, second), "{first:?} {second:?}");
     }
 }


### PR DESCRIPTION
## The defect

`rotation` fed the three components of the rotation vector to `Quat::from_euler`
positionally:

```rust
pub fn rotation(degrees: Vec3, order: RotationOrder) -> Quat {
    Quat::from_euler(
        euler(order),
        degrees.x.to_radians(),
        degrees.y.to_radians(),
        degrees.z.to_radians(),
    )
}
```

glam does not read those three arguments as x, y and z. It reads them as the
angles for the **first, second and third axis of the sequence** it was handed.
For `EulerRot::ZYX` the first argument is the rotation about Z:

```
from_euler(XYZ, 90deg, 0, 0) rotates (1, 2, 3) to (1, -3, 2)   == from_rotation_x
from_euler(ZYX, 90deg, 0, 0) rotates (1, 2, 3) to (-2, 1, 3)   == from_rotation_z
```

So the rotation order control does not only change the order the three
rotations compose in — it changes **which field drives which axis**. Setting
Rotation X to 90 degrees and then switching the order from `Xyz` to `Zyx` spins
the object about Z instead, with the X field still reading 90.

Measured across all six orders, with `(90, 0, 0)` applied to the point
`(1, 2, 3)`:

| order | result | turns about |
| --- | --- | --- |
| `Xyz` | `(1, -3, 2)` | X (correct) |
| `Xzy` | `(1, -3, 2)` | X (correct) |
| `Yxz` | `(3, 2, -1)` | **Y** |
| `Yzx` | `(3, 2, -1)` | **Y** |
| `Zxy` | `(-2, 1, 3)` | **Z** |
| `Zyx` | `(-2, 1, 3)` | **Z** |

`Quat::from_rotation_x(90deg)` gives `(1, -3, 2)`, so only the two X-first
orders were right.

`rotation_degrees` had the matching mistake in reverse:

```rust
let (x, y, z) = rotation.to_euler(euler(order));
Vec3::new(x.to_degrees(), y.to_degrees(), z.to_degrees())
```

`to_euler(ZYX)` returns the Z, Y and X angles in that order, and they were
packed straight into `Vec3::new` as if they were x, y, z. Because both
directions were mislabelled the same way, `rotation_degrees(rotation(d, order), order)`
still round-tripped, which is why nothing downstream noticed.

The rotation order is a user-facing setting — a "Rotation order" step selector
sits directly under the "Rotation" vector control in
`crates/ui/inspector/inspector-core/src/gaussian_3d.rs:63-80` — and `rotation`
feeds the 3D model, camera and shadow matrices via
`crates/media/visual/3d/render-3d-core/src/math.rs` and
`crates/project/project-document/src/project/preview/scene_3d.rs`.

## The fix

A small table maps each position in the euler sequence back to the component it
should read, and `rotation_degrees` writes the angles back through the same
table.

## Reproduction

### Before

```
$ cargo test -p shrimply-transform-3d

running 3 tests
test tests::the_order_still_changes_a_three_axis_rotation ... ok
test tests::degrees_round_trip_through_every_order ... ok
test tests::one_nonzero_angle_turns_about_its_own_axis_whatever_the_order ... FAILED

---- tests::one_nonzero_angle_turns_about_its_own_axis_whatever_the_order stdout ----
thread '...' panicked at crates\media\visual\3d\transform-3d\src\lib.rs:316:17:
Vec3(90.0, 0.0, 0.0) Yxz: Vec3(2.9999998, 1.9999999, -0.99999994) Vec3(0.99999994, -2.9999998, 1.9999999)

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

### After

```
$ cargo test -p shrimply-transform-3d

running 3 tests
test tests::degrees_round_trip_through_every_order ... ok
test tests::one_nonzero_angle_turns_about_its_own_axis_whatever_the_order ... ok
test tests::the_order_still_changes_a_three_axis_rotation ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The other two tests pass both before and after, and are the guard rails:

- `degrees_round_trip_through_every_order` — `rotation_degrees(rotation(d, order), order)`
  still returns `d` for all six orders, so the inverse stays an inverse.
- `the_order_still_changes_a_three_axis_rotation` — `Xyz` and `Zyx` still differ
  for a rotation with three nonzero angles, so the order control is not quietly
  turned into a no-op.

`Xyz` is the default and is unaffected either way, so existing projects that
never touched the order render identically.

## How I tested

Windows 11. `cargo test -p shrimply-transform-3d` as above,
`cargo fmt -p shrimply-transform-3d -- --check` and
`cargo clippy -p shrimply-transform-3d --all-targets` clean. The measurements in
the table above come from a scratch test in this crate that printed
`rotation(Vec3::new(90.0, 0.0, 0.0), order) * Vec3::new(1.0, 2.0, 3.0)` for each
order next to `Quat::from_rotation_x/y/z`; it is not part of the diff.

A note on the toolchain: I built with the pinned `nightly-2026-04-03` from
`rust-toolchain.toml`. `transform-3d` compiles standalone, so this did not need
the Slang toolchain the wider workspace wants — `shrimply-slang-build` does not
configure on this machine, so the render and preview call sites I mention are
read rather than run.
