### PR TITLE
Fix adding fonts after removing the last font

### DIFF
--- a/crates/ui/inspector/inspector-core/src/font_selector.rs
+++ b/crates/ui/inspector/inspector-core/src/font_selector.rs
@@ -425,12 +425,7 @@ impl crate::InspectorController {
         edit: FamilyEdit,
     ) -> Result<(), String> {
         let (value, _) = self.control_graph_source(target)?;
-        let families = value
-            .pointer(&control.path)
-            .cloned()
-            .ok_or("font list is unavailable")?;
-        let families: Vec<ProjectFontFamily> = serde_json::from_value(families)
-            .map_err(|error| format!("invalid font list: {error}"))?;
+        let families = read_control_font_families(&value, control)?;
         let next = match edit {
             FamilyEdit::Append(family) => append_family(&families, family),
             FamilyEdit::Remove(index) => remove_family(&families, index),
@@ -444,5 +439,336 @@ impl crate::InspectorController {
             )?;
         }
         Ok(())
+    }
+}
+
+fn read_control_font_families(
+    value: &serde_json::Value,
+    control: &crate::InspectorControl,
+) -> Result<Vec<ProjectFontFamily>, String> {
+    if control.kind != crate::ControlKind::FontFamilies {
+        return Err("font list is unavailable".to_string());
+    }
+    if let Some(families) = value.pointer(&control.path) {
+        return serde_json::from_value(families.clone())
+            .map_err(|error| format!("invalid font list: {error}"));
+    }
+    let Some(parent_path) = control.path.strip_suffix("/font_families") else {
+        return Err("font list is unavailable".to_string());
+    };
+    if matches!(
+        value.pointer(parent_path),
+        Some(serde_json::Value::Object(_))
+    ) {
+        Ok(Vec::new())
+    } else {
+        Err("font list is unavailable".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ControlKind, InspectorControl, InspectorController, InspectorTarget};
+    use shrimply_math_core::Fraction;
+    use shrimply_project_document::project::{
+        CanvasSize, ItemAddress, ItemRef, Project, Time, VideoItem, VideoItemContent, VisualTrack,
+    };
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn test_controller_with_fonts(
+        font_families: Vec<shrimply_property_model::FontFamily>,
+    ) -> (
+        InspectorController,
+        Rc<RefCell<Project>>,
+        InspectorTarget,
+        InspectorControl,
+    ) {
+        let canvas_size = CanvasSize {
+            width: 1920,
+            height: 1080,
+        };
+        let mut text_item = VideoItem::text_item(canvas_size, Time::ZERO, Time::from_seconds(5));
+        let item_id = text_item.id;
+        if let VideoItemContent::Text(text) = &mut text_item.content {
+            text.font_families = font_families;
+        } else {
+            unreachable!();
+        }
+
+        let track_id = uuid::Uuid::new_v4();
+        let mut track = VisualTrack::default();
+        track.id = track_id;
+        track.items.push(text_item);
+
+        let project = Project {
+            format_version: shrimply_project_document::project::PROJECT_FORMAT_VERSION,
+            name: "Test Project".to_string(),
+            fps: Fraction::from(30),
+            canvas_size,
+            caption_tracks: Vec::new(),
+            video_tracks: vec![track],
+            audio_tracks: Vec::new(),
+            folded_sequences: Vec::new(),
+            expanded_sequence_paths: Vec::new(),
+            cursor_position: None,
+            timeline_zoom: None,
+            preview_guides: Default::default(),
+        };
+
+        let project_cell = Rc::new(RefCell::new(project));
+        let player =
+            shrimply_editor_state::player_state::new(Time::from_seconds(5), Fraction::from(30));
+        let selection = shrimply_timeline_edit::selection_state::new();
+        let controller = InspectorController::new(project_cell.clone(), player, selection);
+        let target = InspectorTarget::Item(ItemAddress::Video {
+            sequence_path: Vec::new(),
+            track_id,
+            item_id,
+        });
+        let control = InspectorControl::new(
+            ControlKind::FontFamilies,
+            crate::generated::text::FONT_FAMILIES_PATH,
+            "Fonts",
+        )
+        .immediate_commit(crate::generated::text::FONT_EDIT_COMMIT);
+        (controller, project_cell, target, control)
+    }
+
+    fn current_font_names(
+        project_cell: &Rc<RefCell<Project>>,
+        target: &InspectorTarget,
+    ) -> Vec<String> {
+        let project = project_cell.borrow();
+        let InspectorTarget::Item(address) = target else {
+            panic!("expected item target");
+        };
+        let ItemRef::Video(video_item) = project.item(address).expect("video item") else {
+            panic!("expected video item");
+        };
+        let VideoItemContent::Text(text) = &video_item.content else {
+            panic!("expected text item");
+        };
+        text.font_families
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn case_1_existing_font_and_append() {
+        let (controller, project, target, control) =
+            test_controller_with_fonts(vec![ProjectFontFamily::GoogleFonts {
+                name: "Inter".to_string(),
+            }]);
+        assert_eq!(current_font_names(&project, &target), vec!["Inter"]);
+
+        controller
+            .edit_control_font_family(
+                &target,
+                &control,
+                FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                    name: "Roboto".to_string(),
+                }),
+            )
+            .expect("append should succeed");
+
+        assert_eq!(
+            current_font_names(&project, &target),
+            vec!["Inter", "Roboto"]
+        );
+    }
+
+    #[test]
+    fn case_2_remove_last_font_then_append() {
+        let (controller, project, target, control) =
+            test_controller_with_fonts(vec![ProjectFontFamily::GoogleFonts {
+                name: "Inter".to_string(),
+            }]);
+        assert_eq!(current_font_names(&project, &target), vec!["Inter"]);
+
+        // Remove the default font
+        controller
+            .edit_control_font_family(&target, &control, FamilyEdit::Remove(0))
+            .expect("remove should succeed");
+        assert!(current_font_names(&project, &target).is_empty());
+
+        // Verify that the serialized model omitted the font_families key due to skip_serializing_if
+        let (serialized, _) = controller
+            .control_graph_source(&target)
+            .expect("target must serialize");
+        assert!(
+            serialized.pointer("/content/font_families").is_none(),
+            "empty font_families must be omitted in serialized JSON"
+        );
+        assert!(
+            serialized.pointer("/content").is_some(),
+            "parent content object must exist"
+        );
+
+        // Append a new font now that font_families is empty
+        controller
+            .edit_control_font_family(
+                &target,
+                &control,
+                FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                    name: "Roboto".to_string(),
+                }),
+            )
+            .expect("append after removing last font must succeed");
+
+        assert_eq!(current_font_names(&project, &target), vec!["Roboto"]);
+    }
+
+    #[test]
+    fn case_3_empty_list_directly() {
+        let (controller, project, target, control) = test_controller_with_fonts(Vec::new());
+        assert!(current_font_names(&project, &target).is_empty());
+
+        let (serialized, _) = controller
+            .control_graph_source(&target)
+            .expect("target must serialize");
+        assert!(serialized.pointer("/content/font_families").is_none());
+
+        controller
+            .edit_control_font_family(
+                &target,
+                &control,
+                FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                    name: "Open Sans".to_string(),
+                }),
+            )
+            .expect("append to empty list directly must succeed");
+
+        assert_eq!(current_font_names(&project, &target), vec!["Open Sans"]);
+    }
+
+    #[test]
+    fn case_4_invalid_inspector_paths_return_errors() {
+        let (controller, _project, target, _control) = test_controller_with_fonts(Vec::new());
+
+        // Missing parent path
+        let invalid_path_control = InspectorControl::new(
+            ControlKind::FontFamilies,
+            "/nonexistent/parent/font_families",
+            "Fonts",
+        );
+        let result = controller.edit_control_font_family(
+            &target,
+            &invalid_path_control,
+            FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                name: "Roboto".to_string(),
+            }),
+        );
+        assert!(result.is_err(), "missing parent path must return an error");
+
+        // Wrong field name (not ending in /font_families)
+        let wrong_field_control = InspectorControl::new(
+            ControlKind::FontFamilies,
+            "/content/nonexistent_field",
+            "Fonts",
+        );
+        let result = controller.edit_control_font_family(
+            &target,
+            &wrong_field_control,
+            FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                name: "Roboto".to_string(),
+            }),
+        );
+        assert!(result.is_err(), "wrong field name must return an error");
+
+        // Wrong control kind
+        let wrong_kind_control = InspectorControl::new(
+            ControlKind::Text,
+            crate::generated::text::FONT_FAMILIES_PATH,
+            "Fonts",
+        );
+        let result = controller.edit_control_font_family(
+            &target,
+            &wrong_kind_control,
+            FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                name: "Roboto".to_string(),
+            }),
+        );
+        assert!(result.is_err(), "wrong control kind must return an error");
+    }
+
+    #[test]
+    fn case_5_duplicate_protection() {
+        let (controller, project, target, control) =
+            test_controller_with_fonts(vec![ProjectFontFamily::GoogleFonts {
+                name: "Inter".to_string(),
+            }]);
+
+        controller
+            .edit_control_font_family(
+                &target,
+                &control,
+                FamilyEdit::Append(ProjectFontFamily::GoogleFonts {
+                    name: "Inter".to_string(),
+                }),
+            )
+            .expect("duplicate append should not error");
+
+        assert_eq!(
+            current_font_names(&project, &target),
+            vec!["Inter"],
+            "duplicate font must not be added"
+        );
+    }
+
+    #[test]
+    fn case_6_move_and_remove_on_empty_list() {
+        let (controller, project, target, control) = test_controller_with_fonts(Vec::new());
+
+        let remove_result =
+            controller.edit_control_font_family(&target, &control, FamilyEdit::Remove(0));
+        assert!(remove_result.is_ok());
+        assert!(current_font_names(&project, &target).is_empty());
+
+        let move_result = controller.edit_control_font_family(
+            &target,
+            &control,
+            FamilyEdit::Move {
+                index: 0,
+                offset: 1,
+            },
+        );
+        assert!(move_result.is_ok());
+        assert!(current_font_names(&project, &target).is_empty());
+    }
+
+    #[test]
+    fn case_7_modifier_nested_empty_font_families_and_stale_path() {
+        let control = InspectorControl::new(
+            ControlKind::FontFamilies,
+            "/modifiers/0/effect/effect/config/font_families",
+            "Fonts",
+        );
+
+        // When parent config object exists, but font_families is omitted:
+        let value = serde_json::json!({
+            "modifiers": [
+                {
+                    "effect": {
+                        "effect": {
+                            "config": {
+                                "text": "Hello 3D"
+                            }
+                        }
+                    }
+                }
+            ]
+        });
+        let result = read_control_font_families(&value, &control);
+        assert_eq!(result.unwrap(), Vec::<ProjectFontFamily>::new());
+
+        // When parent config object does not exist (stale/invalid modifier index):
+        let stale_value = serde_json::json!({
+            "modifiers": []
+        });
+        let stale_result = read_control_font_families(&stale_value, &control);
+        assert!(stale_result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Fixes an issue where a new font could not be added to a Text item after removing its last/default font.

When `font_families` becomes empty, it is omitted from the serialized model because the field uses `skip_serializing_if = "Vec::is_empty"`. The AppKit font editor then attempted to resolve `/content/font_families` through a JSON pointer, which failed because the key no longer existed.

This caused font addition to abort with `font list is unavailable`.

## Fix

Handle the omitted `font_families` field as an empty font list when editing the font-family control, allowing a new font to be appended after the last one has been removed.

Invalid inspector paths continue to be treated as errors rather than being silently interpreted as empty font lists.

## Before

```text
[Inter]
→ Remove Inter
→ []
→ Add another font
→ []
```

## After

```text
[Inter]
→ Remove Inter
→ []
→ Add another font
→ [NewFont]
```

This preserves the existing behavior for non-empty font lists and duplicate font handling.

AI-assisted contribution: developed with a coding agent; I reviewed and tested the changes.