### PR TITLE
fix(editor-appkit): add standard text editing actions to Edit menu

### DIFF
--- a/crates/binaries/editor-appkit/src/macos/menus.rs
+++ b/crates/binaries/editor-appkit/src/macos/menus.rs
@@ -118,6 +118,11 @@ pub fn install(editor: &Editor) {
         undo.setTarget(Some(editor));
         redo.setTarget(Some(editor));
     }
+    edit.addItem(&NSMenuItem::separatorItem(mtm));
+    item(&edit, "Cut", "x", Some(sel!(cut:)), mtm);
+    item(&edit, "Copy", "c", Some(sel!(copy:)), mtm);
+    item(&edit, "Paste", "v", Some(sel!(paste:)), mtm);
+    item(&edit, "Select All", "a", Some(sel!(selectAll:)), mtm);
 
     let view = submenu(&main, "View", mtm);
     let mut view_items = Vec::new();


### PR DESCRIPTION
#### Description

  Adds standard macOS text-editing actions (Cut, Copy, Paste, and Select All) to the AppKit application's
  Edit menu.

  #### Problem

  On macOS, NSTextView and NSTextField rely on the Main Menu's key equivalents and the responder chain to
  handle ⌘A, ⌘C, ⌘V, and ⌘X. Because the Edit menu only contained Undo and Redo, standard text-editing
  shortcuts were not recognized in any text inputs across the macOS editor.

  #### Solution

  • Added Cut (sel!(cut:), ⌘X), Copy (sel!(copy:), ⌘C), Paste (sel!(paste:), ⌘V), and Select All
  (sel!(selectAll:), ⌘A) to the Edit menu.
  • Kept targets unset (nil) so AppKit automatically dispatches actions to whichever text control currently
  has focus.