### PR TITLE
Fix AppKit color picker editing

### DIFF
--- a/crates/ui/components/components-appkit/src/controls.rs
+++ b/crates/ui/components/components-appkit/src/controls.rs
@@ -17,7 +17,7 @@ use objc2_foundation::{
     NSString, NSTimer,
 };
 use shrimply_math_color::Color;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::ffi::c_void;
 use std::rc::Rc;
 
@@ -917,18 +917,93 @@ impl ActionButton {
     }
 }
 
+thread_local! {
+    static ACTIVE_COLOR_WELLS: Cell<usize> = const { Cell::new(0) };
+}
+
+pub fn has_active_color_well() -> bool {
+    ACTIVE_COLOR_WELLS.with(|cell| cell.get() > 0)
+}
+
+struct ColorWellIvars {
+    active: Cell<bool>,
+    has_changed: Cell<bool>,
+    on_commit: RefCell<Option<Box<dyn FnMut()>>>,
+}
+
+define_class!(
+    #[unsafe(super(NSColorWell))]
+    #[thread_kind = MainThreadOnly]
+    #[ivars = ColorWellIvars]
+    struct ColorWell;
+
+    unsafe impl NSObjectProtocol for ColorWell {}
+
+    impl ColorWell {
+        #[unsafe(method(activate:))]
+        fn activate(&self, exclusive: bool) {
+            unsafe {
+                let _: () = msg_send![super(self), activate: exclusive];
+            }
+            if !self.ivars().active.replace(true) {
+                ACTIVE_COLOR_WELLS.with(|cell| cell.set(cell.get() + 1));
+            }
+        }
+
+        #[unsafe(method(deactivate))]
+        fn deactivate(&self) {
+            unsafe {
+                let _: () = msg_send![super(self), deactivate];
+            }
+            if self.ivars().active.replace(false) {
+                ACTIVE_COLOR_WELLS.with(|cell| cell.set(cell.get().saturating_sub(1)));
+            }
+            if self.ivars().has_changed.replace(false)
+                && let Some(callback) = self.ivars().on_commit.borrow_mut().as_mut()
+            {
+                callback();
+            }
+        }
+
+        #[unsafe(method(viewWillMoveToWindow:))]
+        fn view_will_move_to_window(&self, window: Option<&objc2_app_kit::NSWindow>) {
+            if window.is_none() {
+                if self.ivars().active.replace(false) {
+                    ACTIVE_COLOR_WELLS.with(|cell| cell.set(cell.get().saturating_sub(1)));
+                }
+                if self.ivars().has_changed.replace(false)
+                    && let Some(callback) = self.ivars().on_commit.borrow_mut().as_mut()
+                {
+                    callback();
+                }
+            }
+            unsafe {
+                let _: () = msg_send![super(self), viewWillMoveToWindow: window];
+            }
+        }
+    }
+);
+
 pub struct ColorPicker {
-    view: Retained<NSColorWell>,
+    view: Retained<ColorWell>,
 }
 
 impl ColorPicker {
     pub fn new(
         color: Color<u8>,
         on_change: impl Fn(Color<u8>) + 'static,
+        on_commit: impl FnMut() + 'static,
         mtm: MainThreadMarker,
     ) -> Self {
-        let well = NSColorWell::initWithFrame(NSColorWell::alloc(mtm), NSRect::ZERO);
+        let well = ColorWell::alloc(mtm).set_ivars(ColorWellIvars {
+            active: Cell::new(false),
+            has_changed: Cell::new(false),
+            on_commit: RefCell::new(Some(Box::new(on_commit))),
+        });
+        let well: Retained<ColorWell> =
+            unsafe { msg_send![super(well), initWithFrame: NSRect::ZERO] };
         well.setColor(&native_color(color));
+        let weak_well = Weak::new(&*well);
         action::attach(
             &well,
             move |control| {
@@ -944,6 +1019,13 @@ impl ColorPicker {
                     channel(color.blueComponent()),
                     channel(color.alphaComponent()),
                 ));
+                if let Some(well) = weak_well.load() {
+                    if well.isActive() {
+                        well.ivars().has_changed.set(true);
+                    } else if let Some(callback) = well.ivars().on_commit.borrow_mut().as_mut() {
+                        callback();
+                    }
+                }
             },
             mtm,
         );
@@ -951,7 +1033,7 @@ impl ColorPicker {
     }
 
     pub fn view(&self) -> &NSColorWell {
-        &self.view
+        self.view.as_super()
     }
 }
 

--- a/crates/ui/components/components-appkit/src/lib.rs
+++ b/crates/ui/components/components-appkit/src/lib.rs
@@ -15,9 +15,9 @@ mod text_input;
 pub use controls::{
     ActionButton, ColorPicker, ProgressButton, ProgressButtonState, ReadOnlyField, SearchChoices,
     StringChoice, StringSelector, Switch, Tab, Tabs, choice_menu, column_append,
-    column_append_intrinsic, column_stack, control_row, control_row_with_suffix, inset,
-    live_performance, modifier_menu, playback_shortcuts, row_stack, show_searchable_popover_at,
-    split_button, switch_row,
+    column_append_intrinsic, column_stack, control_row, control_row_with_suffix,
+    has_active_color_well, inset, live_performance, modifier_menu, playback_shortcuts, row_stack,
+    show_searchable_popover_at, split_button, switch_row,
 };
 pub use font_picker::{FontPicker, FontPickerBuilder, FontPickerItem};
 pub use frame_graph::{FrameGraph, SharedFrameGraphState};

--- a/crates/ui/components/components-demo-appkit/src/macos.rs
+++ b/crates/ui/components/components-demo-appkit/src/macos.rs
@@ -396,6 +396,10 @@ fn general_page(log: Rc<dyn Fn(String)>, mtm: MainThreadMarker) -> Retained<NSVi
                 ))
             }
         },
+        {
+            let log = log.clone();
+            move || log("color committed".to_string())
+        },
         mtm,
     );
     column_append(&general, &control_row("Color", color.view(), mtm));

--- a/crates/ui/inspector/inspector-appkit/src/control.rs
+++ b/crates/ui/inspector/inspector-appkit/src/control.rs
@@ -526,9 +526,10 @@ fn color(control: &InspectorControl, context: &Context, mtm: MainThreadMarker) -
     let picker = ColorPicker::new(
         Color::new(components[0], components[1], components[2], components[3]),
         move |color| {
-            if editing_context.set_components(&editing, &color.to_array().map(f64::from)) {
-                committing.commit(&committed_control);
-            }
+            editing_context.set_components(&editing, &color.to_array().map(f64::from));
+        },
+        move || {
+            committing.commit(&committed_control);
         },
         mtm,
     );

--- a/crates/ui/inspector/inspector-appkit/src/lib.rs
+++ b/crates/ui/inspector/inspector-appkit/src/lib.rs
@@ -211,6 +211,7 @@ impl Inspector {
         // final position is applied on the first poll after release.
         if self.state.dirty.get()
             && (player_state::snapshot(&self.state.player).scrubbing
+                || shrimply_components_appkit::has_active_color_well()
                 || unsafe {
                     objc2_foundation::NSRunLoop::currentRunLoop()
                         .currentMode()

--- a/crates/ui/inspector/inspector-core/src/document/mod.rs
+++ b/crates/ui/inspector/inspector-core/src/document/mod.rs
@@ -599,7 +599,10 @@ fn control_commit(control: &InspectorControl) -> InspectorCommit<'_> {
         InspectorCommit::Immediate(&control.commit_name)
     } else if matches!(
         control.kind,
-        ControlKind::LayeredNumber | ControlKind::LayeredVector2 | ControlKind::LayeredVector3
+        ControlKind::LayeredNumber
+            | ControlKind::LayeredVector2
+            | ControlKind::LayeredVector3
+            | ControlKind::LayeredColor
     ) {
         // Match GTK: changes only update the live preview; the picker commits once.
         InspectorCommit::Deferred


### PR DESCRIPTION
## Summary

Fixes AppKit color pickers only applying the first color, brightness, or opacity change while the picker remains open.

The issue was caused by committing on every color change, which rebuilt the inspector and destroyed the active `NSColorWell`.

## Fix

* Keep color changes live while the picker is open
* Commit once when color editing finishes
* Preserve the active `NSColorWell` during editing
* Use deferred history for `LayeredColor`

This also fixes the extra no-op Undo entry, so one `Cmd+Z` now reverts the whole color-editing session.

No GTK or Qt changes.
No tests added.